### PR TITLE
Add forkdiff comparison to optimism

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Build and publish forkdiff github-pages
+permissions:
+  contents: write
+on:
+  push:
+    branches:
+      - eelanagaraj/add-forkdiff # TODO remove
+      - develop
+jobs:
+  deploy:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000  # make sure to fetch the old commit we diff against
+
+      - name: Build forkdiff
+        uses: "docker://protolambda/forkdiff:latest"
+        with:
+          args: -repo=/github/workspace -fork=/github/workspace/fork.yaml -out=/github/workspace/index.html
+
+      - name: Build pages
+        run: |
+          mkdir -p tmp/pages
+          mv index.html tmp/pages/index.html
+          touch tmp/pages/.nojekyll
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: tmp/pages
+          clean: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ permissions:
 on:
   push:
     branches:
-      - develop
+      - celo[0-9]+
 jobs:
   deploy:
     concurrency: ci-${{ github.ref }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,6 @@ permissions:
 on:
   push:
     branches:
-      - eelanagaraj/add-forkdiff # TODO remove
       - develop
 jobs:
   deploy:

--- a/fork.yaml
+++ b/fork.yaml
@@ -6,7 +6,7 @@ footer: |
 base:
   name: OP
   url: https://github.com/ethereum-optimism/optimism
-  hash: a4aaafcd8491e8cc87146c8314f659135627ac92 # tracks the last rebased commit
+  hash: c0f0f2d5fc6f1aaa6bf05e102ec0b8bdf74356db # tracks the last rebased commit
 fork:
   name: CELO
   url: https://github.com/celo-org/optimism

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,0 +1,146 @@
+title: "CELO <> OP optimism forkdiff"
+footer: |
+  Fork-diff overview of changes made in [Celo's `optimism`](https://github.com/celo-org/optimism),
+  a fork of [Optimism's `optimism`](https://github.com/ethereum-optimism/optimism).
+
+base:
+  name: OP
+  url: https://github.com/ethereum-optimism/optimism
+  # TODO EN: update, used older commit for testing
+  hash: af163a33dc122a6a1ddb0103341075ab0c35ebe8 # tracks the last rebased commit
+fork:
+  name: CELO
+  url: https://github.com/celo-org/optimism
+  ref: HEAD
+def:
+  title: "Celo's optimism"
+  description: |
+    This is an overview of the changes in [Celo's `optimism` implementation](https://github.com/celo-org/optimism),
+    a fork of [Optimism's `optimism`](https://github.com/ethereum-optimism/optimism).
+
+    Changes are currently separated by sub-package or component. Check out the [README](https://github.com/celo-org/optimism/blob/develop/README.md)
+    for more details about each of these components and packages.
+
+  sub:
+    - title: "packages/*"
+      description: ""
+      sub:
+      - title: "common-ts"
+        description: ""
+        globs:
+          - "packages/common-ts/*"
+      - title: "contracts-bedrock"
+        description: ""
+        globs:
+          - "packages/contracts-bedrock/*"
+          - "packages/contracts-bedrock/*/*"
+          - "packages/contracts-bedrock/*/*/*"
+      - title: "core-utils"
+        description: ""
+        globs:
+          - "packages/core-utils/*"
+      - title: "chain-mon"
+        description: ""
+        globs:
+          - "packages/chain-mon/*"
+      - title: "sdk"
+        description: ""
+        globs:
+          - "packages/sdk/*"
+    - title: "op-bindings"
+      description: ""
+      globs:
+        - "op-bindings/*"
+        - "op-bindings/*/*"
+    - title: "op-batcher"
+      description: ""
+      globs:
+        - "op-batcher/*"
+    - title: "op-bootnode"
+      description: ""
+      globs:
+        - "op-bootnode/*"
+    - title: "op-chain-ops"
+      description: ""
+      globs:
+        - "op-chain-ops/*"
+        - "op-chain-ops/*/*"
+        - "op-chain-ops/*/*/*"
+    - title: "op-challenger"
+      description: ""
+      globs:
+        - "op-challenger/*"
+        - "op-challenger/*/*"
+        - "op-challenger/*/*/*"
+    - title: "op-e2e"
+      description: ""
+      globs:
+        - "op-e2e/*"
+        - "op-e2e/*/*"
+        - "op-e2e/*/*/*"
+        - "op-e2e/*/*/*/*"
+
+    - title: "op-exporter"
+      description: ""
+      globs:
+        - "op-exporter/*"
+    - title: "op-heartbeat"
+      description: ""
+      globs:
+        - "op-heartbeat/*"
+    - title: "op-node"
+      description: ""
+      globs:
+        - "op-node/*"
+        - "op-node/*/*"
+        - "op-node/*/*/*"
+    - title: "op-program"
+      description: ""
+      globs:
+        - "op-program/*"
+    - title: "op-proposer"
+      description: ""
+      globs:
+        - "op-proposer/*"
+    - title: "op-service"
+      description: ""
+      globs:
+        - "op-service/*"
+    - title: "op-signer"
+      description: ""
+      globs:
+        - "op-signer/*"
+    - title: "op-wheel"
+      description: ""
+      globs:
+        - "op-wheel/*"
+    - title: "ops-bedrock"
+      description: ""
+      globs:
+        - "ops-bedrock/*"
+    - title: "proxyd"
+      description: ""
+      globs:
+        - "proxyd/*"
+    - title: "specs"
+      description: ""
+      globs:
+        - "specs/*"
+    - title: "indexer"
+      description: ""
+      globs:
+        - "indexer/*"
+        - "indexer/*/*"
+        - "indexer/*/*/*"
+
+# ignored globally, does not count towards line count
+ignore:
+  - ".circleci/*"
+  - "*.sum"
+  - "go.mod"
+  - "fork.yaml"
+  - ".github/workflows/*"
+  - ".changeset/*"
+  - ".github/*"
+  - "CONTRIBUTING.md"
+  - "pnpm-lock.yaml"

--- a/fork.yaml
+++ b/fork.yaml
@@ -6,8 +6,7 @@ footer: |
 base:
   name: OP
   url: https://github.com/ethereum-optimism/optimism
-  # TODO EN: update, used older commit for testing
-  hash: af163a33dc122a6a1ddb0103341075ab0c35ebe8 # tracks the last rebased commit
+  hash: a4aaafcd8491e8cc87146c8314f659135627ac92 # tracks the last rebased commit
 fork:
   name: CELO
   url: https://github.com/celo-org/optimism


### PR DESCRIPTION
# Description
Add forkdiff comparison between celo's & OP's `optimism` repos. For now, this just separates things by component and major package (as described in the README - for instance, this leaves out `packages/web3js-plugin`)

Take a look at the deployed version: https://celo-org.github.io/optimism/

Note: this currently points to a slightly older OP commit than we have merged in order to sanity check the diffs, but this will be updated.

Other than the code changes, as part of this PR, the GH pages build (from `gh-pages` branch) has been activated

# TODOs (after review, any structure changes)
- [x] update hash to point to the latest OP commit hash in our history
- [x] remove trigger for pushes to `eelanagaraj/add-forkdiff`

# Related issues
closes #31 