### PR TITLE
cel2-testnet: Fix paths in docker-compose.yml

### DIFF
--- a/cel2-testnet/docker/docker-compose.yml
+++ b/cel2-testnet/docker/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   l2:
     image: celo-testnet-ops-l2
     build:
-      context: .
-      dockerfile: ${HOME}/optimism/ops-bedrock/Dockerfile.l2
+      context: ${PWD}/../../ops-bedrock/
+      dockerfile: ${PWD}/../../ops-bedrock/Dockerfile.l2
     ports:
       - "9545:8545"
       - "8060:6060"
@@ -33,8 +33,8 @@ services:
       - l2
     image: celo-testnet-ops-op-node
     build:
-      context: ${HOME}/optimism
-      dockerfile: ${HOME}/optimism/op-node/Dockerfile
+      context: ${PWD}/../..
+      dockerfile: ${PWD}/../../op-node/Dockerfile
     command: >
       op-node
       --l1=${L1_RPC}
@@ -77,8 +77,8 @@ services:
       - op-node
     image: celo-testnet-ops-op-proposer
     build:
-      context: ${HOME}/optimism
-      dockerfile: ${HOME}/optimism/op-proposer/Dockerfile
+      context: ${PWD}/../..
+      dockerfile: ${PWD}/../../op-proposer/Dockerfile
     ports:
       - "6062:6060"
       - "7302:7300"
@@ -99,8 +99,8 @@ services:
       - op-node
     image: celo-testnet-ops-op-batcher
     build:
-      context: ${HOME}/optimism
-      dockerfile: ${HOME}/optimism/op-batcher/Dockerfile
+      context: ${PWD}/../..
+      dockerfile: ${PWD}/../../op-batcher/Dockerfile
     ports:
       - "6061:6060"
       - "7301:7300"
@@ -131,8 +131,8 @@ services:
 
   # stateviz:
   #   build:
-  #     context: ${HOME}/optimism
-  #     dockerfile: ${HOME}/optimism/ops-bedrock/Dockerfile.stateviz
+  #     context: ${PWD}/../..
+  #     dockerfile: ${PWD}/../../ops-bedrock/Dockerfile.stateviz
   #   command:
   #     - stateviz
   #     - -addr=0.0.0.0:8080


### PR DESCRIPTION
* The context for building the `l2` container was not correct. I used to have the entrypoints copied into the `cel2-testnet/docker` directory, but notices that it is pure duplication. So now I reference the `ops-bedrock` directory as context.
* Using local paths makes the container build work for developers that don't have the optimism repo checked out at `~/optimism`.