### PR TITLE
dependabot: no PRs for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/ops-bedrock"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - M-dependabot
 
@@ -12,7 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - M-dependabot
 
@@ -22,7 +22,7 @@ updates:
       interval: daily
       time: "16:30"
       timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: auto
     labels:
       - M-dependabot
@@ -31,6 +31,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - M-dependabot


### PR DESCRIPTION
Setting `open-pull-requests-limit: 0` prevents version updates but should keep the security scans and updates according to
https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file

> If you only require security updates and want to exclude version
> updates, you can set open-pull-requests-limit to 0 in order to prevent
> version updates for a given package-ecosystem.

We want to rely on upstream to handle the dependency updates.