### PR TITLE
Update op-geth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.1 => github.com/celo-org/op-geth v0.0.0-20231117111846-c362c07d6b56
+replace github.com/ethereum/go-ethereum v1.13.1 => github.com/celo-org/op-geth v0.0.0-20240206143241-8845c5e0bc65
 
 //replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain
 //replace github.com/ethereum/go-ethereum v1.13.1 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v0.0.0-20231117111846-c362c07d6b56 h1:vLgwFvIVIthyc5vsN0tM6X0ztMJT7QqhinAl/hD8uT0=
-github.com/celo-org/op-geth v0.0.0-20231117111846-c362c07d6b56/go.mod h1:12W+vBetjYbDj5D2+V8hizke5yWuLrUDf7UmVkXTnCQ=
+github.com/celo-org/op-geth v0.0.0-20240206143241-8845c5e0bc65 h1:qDDAo2HXxniKC9Hw2IvUTzUMdEX5JiHaZQgLa5D3mwA=
+github.com/celo-org/op-geth v0.0.0-20240206143241-8845c5e0bc65/go.mod h1:12W+vBetjYbDj5D2+V8hizke5yWuLrUDf7UmVkXTnCQ=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -340,7 +340,7 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txData], receiptsCh chan txmgr.TxReceipt[txData]) {
 	// Do the gas estimation offline. A value of 0 will cause the [txmgr] to estimate the gas limit.
 	data := txdata.Bytes()
-	intrinsicGas, err := core.IntrinsicGas(data, nil, false, true, true, false)
+	intrinsicGas, err := core.IntrinsicGas(data, nil, false, true, true, false, nil)
 	if err != nil {
 		l.Log.Error("Failed to calculate intrinsic gas", "error", err)
 		return

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -222,7 +222,7 @@ func (s *L2Batcher) ActL2BatchSubmit(t Testing, txOpts ...func(tx *types.Dynamic
 	for _, opt := range txOpts {
 		opt(rawTx)
 	}
-	gas, err := core.IntrinsicGas(rawTx.Data, nil, false, true, true, false)
+	gas, err := core.IntrinsicGas(rawTx.Data, nil, false, true, true, false, nil)
 	require.NoError(t, err, "need to compute intrinsic gas")
 	rawTx.Gas = gas
 
@@ -305,7 +305,7 @@ func (s *L2Batcher) ActL2BatchSubmitGarbage(t Testing, kind GarbageKind) {
 		GasFeeCap: gasFeeCap,
 		Data:      outputFrame,
 	}
-	gas, err := core.IntrinsicGas(rawTx.Data, nil, false, true, true, false)
+	gas, err := core.IntrinsicGas(rawTx.Data, nil, false, true, true, false, nil)
 	require.NoError(t, err, "need to compute intrinsic gas")
 	rawTx.Gas = gas
 

--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -485,7 +485,7 @@ func BigL2Txs(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 			data := make([]byte, 120_000) // very large L2 txs, as large as the tx-pool will accept
 			_, err := rand.Read(data[:])  // fill with random bytes, to make compression ineffective
 			require.NoError(t, err)
-			gas, err := core.IntrinsicGas(data, nil, false, true, true, false)
+			gas, err := core.IntrinsicGas(data, nil, false, true, true, false, nil)
 			require.NoError(t, err)
 			if gas > engine.engineApi.RemainingBlockGas() {
 				break

--- a/op-e2e/actions/span_batch_test.go
+++ b/op-e2e/actions/span_batch_test.go
@@ -319,7 +319,7 @@ func TestSpanBatchLowThroughputChain(gt *testing.T) {
 				data := make([]byte, rand.Intn(100))
 				_, err := crand.Read(data[:]) // fill with random bytes
 				require.NoError(t, err)
-				gas, err := core.IntrinsicGas(data, nil, false, true, true, false)
+				gas, err := core.IntrinsicGas(data, nil, false, true, true, false, nil)
 				require.NoError(t, err)
 				baseFee := seqEngine.l2Chain.CurrentBlock().BaseFee
 				nonce, err := cl.PendingNonceAt(t.Ctx(), addrs[userIdx])

--- a/op-e2e/actions/sync_test.go
+++ b/op-e2e/actions/sync_test.go
@@ -287,7 +287,7 @@ func TestInvalidPayloadInSpanBatch(gt *testing.T) {
 			aliceNonce, err := seqEng.EthClient().PendingNonceAt(t.Ctx(), dp.Addresses.Alice)
 			require.NoError(t, err)
 			data := make([]byte, rand.Intn(100))
-			gas, err := core.IntrinsicGas(data, nil, false, true, true, false)
+			gas, err := core.IntrinsicGas(data, nil, false, true, true, false, nil)
 			require.NoError(t, err)
 			baseFee := seqEng.l2Chain.CurrentBlock().BaseFee
 			tx := types.MustSignNewTx(dp.Secrets.Alice, signer, &types.DynamicFeeTx{

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1165,7 +1165,7 @@ func TestFees(t *testing.T) {
 	require.Equal(t, scalar.Uint64(), cfg.DeployConfig.GasPriceOracleScalar, "wrong gpo scalar")
 
 	// BaseFee Recipient
-	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(context.Background(), predeploys.FeeHandlerAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
+	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(context.Background(), predeploys.BaseFeeVaultAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
 	require.Nil(t, err)
 
 	// L1Fee Recipient
@@ -1208,7 +1208,7 @@ func TestFees(t *testing.T) {
 	endBalance, err := l2Seq.BalanceAt(context.Background(), fromAddr, header.Number)
 	require.Nil(t, err)
 
-	baseFeeRecipientEndBalance, err := l2Seq.BalanceAt(context.Background(), predeploys.FeeHandlerAddr, header.Number)
+	baseFeeRecipientEndBalance, err := l2Seq.BalanceAt(context.Background(), predeploys.BaseFeeVaultAddr, header.Number)
 	require.Nil(t, err)
 
 	l1Header, err := l1.HeaderByNumber(context.Background(), nil)


### PR DESCRIPTION
We haven't updated our op-geth dependency in a longer while. The update required two changes:
* Add the feeCurrency parameter to `IntrinsicGas`. Hard-coding `nil` (native token) seems to be ok in all cases.
* Due to the `IsCel2` flag, we need to either explicitly enable Cel2 or use the old behaviour. I chose the latter approach to keep the diff (after the next rebase) minimal.