### PR TITLE
Port migration tool to rebased branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __pycache__
 
 # Ignore echidna artifacts
 crytic-export
+
+# vscode
+.vscode/

--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -15,6 +15,9 @@ receipt-reference-builder:
 op-upgrade:
 	go build -o ./bin/op-upgrade ./cmd/op-upgrade/main.go
 
+celo-migrate:
+	go build -o ./bin/celo-migrate ./cmd/celo-migrate/*.go
+
 test:
 	go test ./...
 

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -64,16 +64,6 @@ var (
 		Usage:    "Path to the Celo database, not including the `celo/chaindata` part",
 		Required: true,
 	}
-	dbCacheFlag = &cli.IntFlag{
-		Name:  "db-cache",
-		Usage: "LevelDB cache size in mb",
-		Value: 1024,
-	}
-	dbHandlesFlag = &cli.IntFlag{
-		Name:  "db-handles",
-		Usage: "LevelDB number of handles",
-		Value: 60,
-	}
 	dryRunFlag = &cli.BoolFlag{
 		Name:  "dry-run",
 		Usage: "Dry run the upgrade by not committing the database",
@@ -86,8 +76,6 @@ var (
 		l2AllocsFlag,
 		outfileRollupConfigFlag,
 		dbPathFlag,
-		dbCacheFlag,
-		dbHandlesFlag,
 		dryRunFlag,
 	}
 
@@ -116,8 +104,6 @@ func main() {
 			l2AllocsPath := ctx.Path("l2-allocs")
 			outfileRollupConfig := ctx.Path("outfile.rollup-config")
 			dbPath := ctx.String("db-path")
-			dbCache := ctx.Int("db-cache")
-			dbHandles := ctx.Int("db-handles")
 			dryRun := ctx.Bool("dry-run")
 
 			// Read deployment configuration
@@ -192,7 +178,7 @@ func main() {
 			}
 
 			// Write changes to state to actual state database
-			cel2Header, err := ApplyMigrationChangesToDB(l2Genesis, dbPath, dbCache, dbHandles, !dryRun)
+			cel2Header, err := ApplyMigrationChangesToDB(l2Genesis, dbPath, !dryRun)
 			if err != nil {
 				return err
 			}
@@ -221,9 +207,9 @@ func main() {
 	log.Info("Finished migration successfully!")
 }
 
-func ApplyMigrationChangesToDB(genesis *core.Genesis, dbPath string, dbCache int, dbHandles int, commit bool) (*types.Header, error) {
-	log.Info("Opening celo database", "dbCache", dbCache, "dbHandles", dbHandles, "dbPath", dbPath)
-	ldb, err := openCeloDb(dbPath, dbCache, dbHandles)
+func ApplyMigrationChangesToDB(genesis *core.Genesis, dbPath string, commit bool) (*types.Header, error) {
+	log.Info("Opening Celo database", "dbPath", dbPath)
+	ldb, err := openCeloDb(dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open DB: %w", err)
 	}
@@ -410,7 +396,7 @@ func ApplyMigrationChangesToDB(genesis *core.Genesis, dbPath string, dbCache int
 }
 
 // Opens a Celo database, stored in the `celo` subfolder
-func openCeloDb(path string, cache int, handles int) (ethdb.Database, error) {
+func openCeloDb(path string) (ethdb.Database, error) {
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
@@ -422,8 +408,8 @@ func openCeloDb(path string, cache int, handles int) (ethdb.Database, error) {
 		Directory:         chaindataPath,
 		AncientsDirectory: ancientPath,
 		Namespace:         "",
-		Cache:             cache,
-		Handles:           handles,
+		Cache:             1024,
+		Handles:           60,
 		ReadOnly:          false,
 	})
 	if err != nil {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/holiman/uint256"
+	"github.com/mattn/go-isatty"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+var (
+	deployConfigFlag = &cli.PathFlag{
+		Name:     "deploy-config",
+		Usage:    "Path to the JSON file that was used for the bedrock contracts deployment. A test example can be found here 'op-chain-ops/genesis/testdata/test-deploy-config-full.json' and documentation for the fields is at https://docs.optimism.io/builders/chain-operators/management/configuration",
+		Required: true,
+	}
+	l1DeploymentsFlag = &cli.PathFlag{
+		Name:     "l1-deployments",
+		Usage:    "Path to L1 deployments JSON file, the output of running the bedrock contracts deployment for the given 'deploy-config'",
+		Required: true,
+	}
+	l1RPCFlag = &cli.StringFlag{
+		Name:     "l1-rpc",
+		Usage:    "RPC URL for a node of the L1 defined in the 'deploy-config'",
+		Required: true,
+	}
+	l2AllocsFlag = &cli.PathFlag{
+		Name:     "l2-allocs",
+		Usage:    "Path to L2 genesis allocs file",
+		Required: true,
+	}
+	outfileRollupConfigFlag = &cli.PathFlag{
+		Name:     "outfile.rollup-config",
+		Usage:    "Path to write the rollup config JSON file, to be provided to op-node with the 'rollup.config' flag",
+		Required: true,
+	}
+	dbPathFlag = &cli.StringFlag{
+		Name:     "db-path",
+		Usage:    "Path to the Celo database, not including the `celo/chaindata` part",
+		Required: true,
+	}
+	dbCacheFlag = &cli.IntFlag{
+		Name:  "db-cache",
+		Usage: "LevelDB cache size in mb",
+		Value: 1024,
+	}
+	dbHandlesFlag = &cli.IntFlag{
+		Name:  "db-handles",
+		Usage: "LevelDB number of handles",
+		Value: 60,
+	}
+	dryRunFlag = &cli.BoolFlag{
+		Name:  "dry-run",
+		Usage: "Dry run the upgrade by not committing the database",
+	}
+
+	flags = []cli.Flag{
+		deployConfigFlag,
+		l1DeploymentsFlag,
+		l1RPCFlag,
+		l2AllocsFlag,
+		outfileRollupConfigFlag,
+		dbPathFlag,
+		dbCacheFlag,
+		dbHandlesFlag,
+		dryRunFlag,
+	}
+
+	// TODO: read those form the deploy config
+	// TODO(pl): select values
+	EIP1559Denominator       = uint64(50)
+	EIP1559DenominatorCanyon = uint64(250)
+	EIP1559Elasticity        = uint64(10)
+
+	OutFilePerm = os.FileMode(0o440)
+)
+
+func main() {
+	color := isatty.IsTerminal(os.Stderr.Fd())
+	handler := log.NewTerminalHandler(os.Stderr, color)
+	oplog.SetGlobalLogHandler(handler)
+
+	app := &cli.App{
+		Name:  "migrate",
+		Usage: "Migrate Celo state to a CeL2 DB",
+		Flags: flags,
+		Action: func(ctx *cli.Context) error {
+			deployConfig := ctx.Path("deploy-config")
+			l1Deployments := ctx.Path("l1-deployments")
+			l1RPC := ctx.String("l1-rpc")
+			l2AllocsPath := ctx.Path("l2-allocs")
+			outfileRollupConfig := ctx.Path("outfile.rollup-config")
+			dbPath := ctx.String("db-path")
+			dbCache := ctx.Int("db-cache")
+			dbHandles := ctx.Int("db-handles")
+			dryRun := ctx.Bool("dry-run")
+
+			// Read deployment configuration
+			log.Info("Deploy config", "path", deployConfig)
+			config, err := genesis.NewDeployConfig(deployConfig)
+			if err != nil {
+				return err
+			}
+
+			if config.DeployCeloContracts {
+				return errors.New("DeployCeloContracts is not supported in migration")
+			}
+			if config.FundDevAccounts {
+				return errors.New("FundDevAccounts is not supported in migration")
+			}
+
+			// Try reading the L1 deployment information
+			deployments, err := genesis.NewL1Deployments(l1Deployments)
+			if err != nil {
+				return fmt.Errorf("cannot read L1 deployments at %s: %w", l1Deployments, err)
+			}
+			config.SetDeployments(deployments)
+
+			// Get latest block information from L1
+			var l1StartBlock *types.Block
+			client, err := ethclient.Dial(l1RPC)
+			if err != nil {
+				return fmt.Errorf("cannot dial %s: %w", l1RPC, err)
+			}
+
+			if config.L1StartingBlockTag == nil {
+				l1StartBlock, err = client.BlockByNumber(context.Background(), nil)
+				if err != nil {
+					return fmt.Errorf("cannot fetch latest block: %w", err)
+				}
+				tag := rpc.BlockNumberOrHashWithHash(l1StartBlock.Hash(), true)
+				config.L1StartingBlockTag = (*genesis.MarshalableRPCBlockNumberOrHash)(&tag)
+			} else if config.L1StartingBlockTag.BlockHash != nil {
+				l1StartBlock, err = client.BlockByHash(context.Background(), *config.L1StartingBlockTag.BlockHash)
+				if err != nil {
+					return fmt.Errorf("cannot fetch block by hash: %w", err)
+				}
+			} else if config.L1StartingBlockTag.BlockNumber != nil {
+				l1StartBlock, err = client.BlockByNumber(context.Background(), big.NewInt(config.L1StartingBlockTag.BlockNumber.Int64()))
+				if err != nil {
+					return fmt.Errorf("cannot fetch block by number: %w", err)
+				}
+			}
+
+			// Ensure that there is a starting L1 block
+			if l1StartBlock == nil {
+				return fmt.Errorf("no starting L1 block")
+			}
+
+			// Sanity check the config. Do this after filling in the L1StartingBlockTag
+			// if it is not defined.
+			if err := config.Check(); err != nil {
+				return err
+			}
+
+			log.Info("Using L1 Start Block", "number", l1StartBlock.Number(), "hash", l1StartBlock.Hash().Hex())
+
+			// Build the L2 genesis block
+			l2Allocs, err := genesis.LoadForgeAllocs(l2AllocsPath)
+			if err != nil {
+				return err
+			}
+
+			l2Genesis, err := genesis.BuildL2Genesis(config, l2Allocs, l1StartBlock)
+			if err != nil {
+				return fmt.Errorf("error creating l2 genesis: %w", err)
+			}
+
+			// Write changes to state to actual state database
+			cel2Header, err := ApplyMigrationChangesToDB(l2Genesis, dbPath, dbCache, dbHandles, !dryRun)
+			if err != nil {
+				return err
+			}
+			log.Info("Updated Cel2 state")
+
+			rollupConfig, err := config.RollupConfig(l1StartBlock, cel2Header.Hash(), cel2Header.Number.Uint64())
+			if err != nil {
+				return err
+			}
+			if err := rollupConfig.Check(); err != nil {
+				return fmt.Errorf("generated rollup config does not pass validation: %w", err)
+			}
+
+			log.Info("Writing rollup config", "file", outfileRollupConfig)
+			if err := jsonutil.WriteJSON(outfileRollupConfig, rollupConfig, OutFilePerm); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Crit("error in migration", "err", err)
+	}
+	log.Info("Finished migration successfully!")
+}
+
+func ApplyMigrationChangesToDB(genesis *core.Genesis, dbPath string, dbCache int, dbHandles int, commit bool) (*types.Header, error) {
+	log.Info("Opening celo database", "dbCache", dbCache, "dbHandles", dbHandles, "dbPath", dbPath)
+	ldb, err := openCeloDb(dbPath, dbCache, dbHandles)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open DB: %w", err)
+	}
+	log.Info("Loaded Celo L1 DB", "db", ldb)
+
+	// Grab the hash of the tip of the legacy chain.
+	hash := rawdb.ReadHeadHeaderHash(ldb)
+	log.Info("Reading chain tip from database", "hash", hash)
+
+	// Grab the header number.
+	num := rawdb.ReadHeaderNumber(ldb, hash)
+	if num == nil {
+		return nil, fmt.Errorf("cannot find header number for %s", hash)
+	}
+	log.Info("Reading chain tip num from database", "number", num)
+
+	// Grab the full header.
+	header := rawdb.ReadHeader(ldb, hash, *num)
+	log.Info("Read header from database", "header", header)
+
+	// We need to update the chain config to set the correct hardforks.
+	genesisHash := rawdb.ReadCanonicalHash(ldb, 0)
+	cfg := rawdb.ReadChainConfig(ldb, genesisHash)
+	if cfg == nil {
+		log.Crit("chain config not found")
+	}
+	log.Info("Read chain config from database", "config", cfg)
+
+	// Set up the backing store.
+	// TODO(pl): Do we need the preimages setting here?
+	underlyingDB := state.NewDatabaseWithConfig(ldb, &triedb.Config{Preimages: true})
+
+	// Open up the state database.
+	db, err := state.New(header.Root, underlyingDB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open StateDB: %w", err)
+	}
+
+	// So far we applied changes in the memory VM and collected changes in the genesis struct
+	// Now we iterate through all accounts that have been written there and set them inside the statedb.
+	// This will change the state root
+	// Another property is that the total balance changes must be 0
+	accountCounter := 0
+	overwriteCounter := 0
+	for k, v := range genesis.Alloc {
+		accountCounter++
+		if db.Exist(k) {
+			equal := bytes.Equal(db.GetCode(k), v.Code)
+
+			log.Warn("Operating on existing state", "account", k, "equalCode", equal)
+			overwriteCounter++
+		}
+		// TODO(pl): decide what to do with existing accounts.
+		db.CreateAccount(k)
+
+		// CreateAccount above copied the balance, check if we change it
+		if db.GetBalance(k).Cmp(uint256.MustFromBig(v.Balance)) != 0 {
+			// TODO(pl): make this a hard error once the migration has been tested more
+			log.Warn("Moving account changed native balance", "address", k, "oldBalance", db.GetBalance(k), "newBalance", v.Balance)
+		}
+
+		db.SetNonce(k, v.Nonce)
+		db.SetBalance(k, uint256.MustFromBig(v.Balance))
+		db.SetCode(k, v.Code)
+		db.SetStorage(k, v.Storage)
+
+		log.Info("Moved account", "address", k)
+	}
+	log.Info("Migrated OP contracts into state DB", "copiedAccounts", accountCounter, "overwrittenAccounts", overwriteCounter)
+
+	migrationBlock := new(big.Int).Add(header.Number, common.Big1)
+
+	// We're done messing around with the database, so we can now commit the changes to the DB.
+	// Note that this doesn't actually write the changes to disk.
+	log.Info("Committing state DB")
+	newRoot, err := db.Commit(migrationBlock.Uint64(), true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the header for the Bedrock transition block.
+	cel2Header := &types.Header{
+		ParentHash:  header.Hash(),
+		UncleHash:   types.EmptyUncleHash,
+		Coinbase:    predeploys.SequencerFeeVaultAddr,
+		Root:        newRoot,
+		TxHash:      types.EmptyTxsHash,
+		ReceiptHash: types.EmptyReceiptsHash,
+		Bloom:       types.Bloom{},
+		Difficulty:  new(big.Int).Set(common.Big0),
+		Number:      migrationBlock,
+		GasLimit:    header.GasLimit,
+		GasUsed:     0,
+		Time:        uint64(time.Now().Unix()), // TODO(pl): Needed to avoid L1-L2 time mismatches
+		Extra:       []byte("CeL2 migration"),
+		MixDigest:   common.Hash{},
+		Nonce:       types.BlockNonce{},
+		BaseFee:     new(big.Int).Set(header.BaseFee),
+	}
+	log.Info("Build Cel2 migration header", "header", cel2Header)
+
+	// Create the Bedrock transition block from the header. Note that there are no transactions,
+	// uncle blocks, or receipts in the Bedrock transition block.
+	cel2Block := types.NewBlock(cel2Header, nil, nil, nil, trie.NewStackTrie(nil))
+
+	// We did it!
+	log.Info(
+		"Built Cel2 migration block",
+		"hash", cel2Block.Hash(),
+		"root", cel2Block.Root(),
+		"number", cel2Block.NumberU64(),
+		"gas-used", cel2Block.GasUsed(),
+		"gas-limit", cel2Block.GasLimit(),
+	)
+
+	// If we're not actually writing this to disk, then we're done.
+	if !commit {
+		log.Info("Dry run complete")
+		return nil, nil
+	}
+
+	// Otherwise we need to write the changes to disk. First we commit the state changes.
+	log.Info("Committing trie DB")
+	if err := db.Database().TrieDB().Commit(newRoot, true); err != nil {
+		return nil, err
+	}
+
+	// Next we write the Cel2 genesis block to the database.
+	rawdb.WriteTd(ldb, cel2Block.Hash(), cel2Block.NumberU64(), cel2Block.Difficulty())
+	rawdb.WriteBlock(ldb, cel2Block)
+	rawdb.WriteReceipts(ldb, cel2Block.Hash(), cel2Block.NumberU64(), nil)
+	rawdb.WriteCanonicalHash(ldb, cel2Block.Hash(), cel2Block.NumberU64())
+	rawdb.WriteHeadBlockHash(ldb, cel2Block.Hash())
+	rawdb.WriteHeadFastBlockHash(ldb, cel2Block.Hash())
+	rawdb.WriteHeadHeaderHash(ldb, cel2Block.Hash())
+
+	// Mark the first CeL2 block as finalized
+	rawdb.WriteFinalizedBlockHash(ldb, cel2Block.Hash())
+
+	// Set the standard options.
+	cfg.LondonBlock = cel2Block.Number()
+	cfg.BerlinBlock = cel2Block.Number()
+	cfg.ArrowGlacierBlock = cel2Block.Number()
+	cfg.GrayGlacierBlock = cel2Block.Number()
+	cfg.MergeNetsplitBlock = cel2Block.Number()
+	cfg.TerminalTotalDifficulty = big.NewInt(0)
+	cfg.TerminalTotalDifficultyPassed = true
+	cfg.ShanghaiTime = &cel2Header.Time
+	cfg.CancunTime = &cel2Header.Time
+
+	// Set the Optimism options.
+	cfg.BedrockBlock = cel2Block.Number()
+	// Enable Regolith from the start of Bedrock
+	cfg.RegolithTime = new(uint64) // what are those? do we need those?
+	cfg.Optimism = &params.OptimismConfig{
+		EIP1559Denominator:       EIP1559Denominator,
+		EIP1559DenominatorCanyon: EIP1559DenominatorCanyon,
+		EIP1559Elasticity:        EIP1559Elasticity,
+	}
+	cfg.CanyonTime = &cel2Header.Time
+	cfg.EcotoneTime = &cel2Header.Time
+	cfg.Cel2Time = &cel2Header.Time
+
+	// Write the chain config to disk.
+	// TODO(pl): Why do we need to write this with the genesis hash, not `cel2Block.Hash()`?`
+	rawdb.WriteChainConfig(ldb, genesisHash, cfg)
+	log.Info("Wrote updated chain config", "config", cfg)
+
+	// We're done!
+	log.Info(
+		"Wrote CeL2 migration block",
+		"height", cel2Header.Number,
+		"root", cel2Header.Root.String(),
+		"hash", cel2Header.Hash().String(),
+		"timestamp", cel2Header.Time,
+	)
+
+	// Close the database handle
+	if err := ldb.Close(); err != nil {
+		return nil, err
+	}
+
+	return cel2Header, nil
+}
+
+// Opens a Celo database, stored in the `celo` subfolder
+func openCeloDb(path string, cache int, handles int) (ethdb.Database, error) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	chaindataPath := filepath.Join(path, "celo", "chaindata")
+	ancientPath := filepath.Join(chaindataPath, "ancient")
+	ldb, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              "leveldb",
+		Directory:         chaindataPath,
+		AncientsDirectory: ancientPath,
+		Namespace:         "",
+		Cache:             cache,
+		Handles:           handles,
+		ReadOnly:          false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ldb, nil
+}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -289,6 +289,9 @@ type DeployConfig struct {
 
 	// UseInterop is a flag that indicates if the system is using interop
 	UseInterop bool `json:"useInterop,omitempty"`
+
+	// DeployCeloContracts indicates whether to deploy Celo contracts.
+	DeployCeloContracts bool `json:"deployCeloContracts"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -91,5 +91,6 @@
   "daChallengeProxy": "0x0000000000000000000000000000000000000000",
   "daChallengeWindow": 0,
   "daResolveWindow": 0,
-  "daResolverRefundPercentage": 0
+  "daResolverRefundPercentage": 0,
+  "deployCeloContracts": false
 }

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -79,6 +79,8 @@ contract DeployConfig is Script {
 
     bool public useInterop;
 
+    bool public deployCeloContracts;
+
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
         try vm.readFile(_path) returns (string memory data) {
@@ -155,6 +157,9 @@ contract DeployConfig is Script {
         customGasTokenAddress = _readOr(_json, "$.customGasTokenAddress", address(0));
 
         useInterop = _readOr(_json, "$.useInterop", false);
+
+        // Celo specific config
+        deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
     }
 
     function l1StartingBlockTag() public returns (bytes32) {
@@ -203,6 +208,11 @@ contract DeployConfig is Script {
     /// @notice Allow the `fundDevAccounts` config to be overridden.
     function setFundDevAccounts(bool _fundDevAccounts) public {
         fundDevAccounts = _fundDevAccounts;
+    }
+
+    /// @notice Allow the `deployCeloContracts` config to be overridden.
+    function setDeployCeloContracts(bool _deployCeloContracts) public {
+        deployCeloContracts = _deployCeloContracts;
     }
 
     /// @notice Allow the `useCustomGasToken` config to be overridden in testing environments

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -150,11 +150,15 @@ contract L2Genesis is Deployer {
         vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
 
-        dealEthToPrecompiles();
+        if (cfg.deployCeloContracts()) {
+            dealEthToPrecompiles();
+        }
         setPredeployProxies();
         setPredeployImplementations(_l1Dependencies);
         setPreinstalls();
-        setCeloPredeploys();
+        if (cfg.deployCeloContracts()) {
+            setCeloPredeploys();
+        }
         if (cfg.fundDevAccounts()) {
             fundDevAccounts();
         }

--- a/packages/contracts-bedrock/test/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2Genesis.t.sol
@@ -180,6 +180,7 @@ contract L2GenesisTest is Test {
     /// @notice Tests the number of accounts in the genesis setup
     function _test_allocs_size(string memory _path) internal {
         genesis.cfg().setFundDevAccounts(false);
+        genesis.cfg().setDeployCeloContracts(true);
         genesis.runWithOptions(OutputMode.LOCAL_LATEST, _dummyL1Deps());
         genesis.writeGenesisAllocs(_path);
 


### PR DESCRIPTION
Ports https://github.com/celo-org/optimism/pull/110 on `celo5` branch, which reworked the whole (l2) genesis creation logic.

The allocations containing the OP contracts are now generated using the `L2Genesis.s.sol` foundry script, stored and passed into the migration tool via the `--l2-allocs` flag. This also helps to shorten migration time and splits generation/application nicely.
Also adds an option to not deploy celo contracts during l2 genesis creation, which will be used when creating the allocs for the migration.

Resolves https://github.com/celo-org/optimism/issues/134
Resolves #142 
Resolves #143 