### PR TITLE
Change config script to pass verification on deploy

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -91,7 +91,8 @@ config=$(cat << EOL
 
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 44,
-  "faultGameMaxDuration": 1200,
+  "faultGameClockExtension": 0,
+  "faultGameMaxClockDuration": 1200,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 14,

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -96,6 +96,7 @@ config=$(cat << EOL
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 14,
+  "faultGameWithdrawalDelay": 604800,
 
   "preimageOracleMinProposalSize": 1800000,
   "preimageOracleChallengePeriod": 86400,


### PR DESCRIPTION
Config fields have been renamed and added since last deployment, and DeployConfig under `celo6` branch will fail to parse generated scripts when required fields are missing.