### PR TITLE
feat: Adding some extra config to `config.sh` script

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -71,3 +71,5 @@ export PRIVATE_KEY=
 export ENABLE_GOVERNANCE=false
 export FUNDS_DEV_ACCOUNTS=false
 export USE_PLASMA=false
+# Set to false if migrating state from a Celo L1. True for new testnets
+export DEPLOY_CELO_CONTRACTS=false

--- a/.envrc.example
+++ b/.envrc.example
@@ -66,3 +66,8 @@ export ETHERSCAN_API_KEY=
 # Private key to use for contract deployments, you don't need to worry about
 # this for the Getting Started guide.
 export PRIVATE_KEY=
+
+# CELO additional configuration
+export ENABLE_GOVERNANCE=false
+export FUNDS_DEV_ACCOUNTS=false
+export USE_PLASMA=false

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ build-ts: submodules
 		. $$NVM_DIR/nvm.sh && nvm use; \
 	fi
 	pnpm install:ci
-	pnpm prepare
 	pnpm build
 .PHONY: build-ts
 

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -90,6 +90,7 @@ config=$(cat << EOL
   "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 6,
 
+  "l2GenesisFjordTimeOffset": "0x0",
   "l2GenesisEcotoneTimeOffset": "0x0",
   "l2GenesisDeltaTimeOffset": "0x0",
   "l2GenesisCanyonTimeOffset": "0x0",

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -25,6 +25,7 @@ reqenv "L1_BLOCK_TIME"
 reqenv "L2_BLOCK_TIME"
 reqenv "FUNDS_DEV_ACCOUNTS"
 reqenv "USE_PLASMA"
+reqenv "DEPLOY_CELO_CONTRACTS"
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")
@@ -77,7 +78,7 @@ config=$(cat << EOL
   "gasPriceOracleOverhead": 0,
   "gasPriceOracleScalar": 1000000,
 
-  "deployCeloContracts": true,
+  "deployCeloContracts": $DEPLOY_CELO_CONTRACTS,
 
   "enableGovernance": $ENABLE_GOVERNANCE,
   "governanceTokenSymbol": "OP",

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -77,6 +77,8 @@ config=$(cat << EOL
   "gasPriceOracleOverhead": 0,
   "gasPriceOracleScalar": 1000000,
 
+  "deployCeloContracts": true,
+
   "enableGovernance": $ENABLE_GOVERNANCE,
   "governanceTokenSymbol": "OP",
   "governanceTokenName": "Optimism",


### PR DESCRIPTION
Adding some additional exposure to `config.sh` script to expose on `.envrc` configurations that may be interesting to consider when deploying a new testnet.
Also included a small fix on Makefile caused by a dead npm script: https://github.com/ethereum-optimism/optimism/pull/10821