### PR TITLE
Add CallProxies for mainnet addresses on alfajores

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -29,6 +29,7 @@ import { Process } from "scripts/libraries/Process.sol";
 import { GoldToken } from "src/celo/GoldToken.sol";
 
 import { CeloPredeploys } from "src/celo/CeloPredeploys.sol";
+import { CallProxy } from "src/celo/CallProxy.sol";
 import { CeloRegistry } from "src/celo/CeloRegistry.sol";
 import { FeeHandler } from "src/celo/FeeHandler.sol";
 import { FeeCurrencyWhitelist } from "src/celo/FeeCurrencyWhitelist.sol";
@@ -159,6 +160,7 @@ contract L2Genesis is Deployer {
         if (cfg.fundDevAccounts()) {
             fundDevAccounts();
         }
+        setCeloTestnetProxies();
         vm.stopPrank();
 
         if (writeForkGenesisAllocs(_fork, Fork.DELTA, _mode)) {
@@ -608,6 +610,20 @@ contract L2Genesis is Deployer {
         uint256[] memory initialBalances = new uint256[](1);
         initialBalances[0] = 100_000 ether;
         //deploycUSD(initialBalanceAddresses, initialBalances, 2);
+    }
+
+    function setCeloTestnetProxies() internal {
+        console.log("Setting up Celo testnet proxies");
+
+        setupCallProxy(CeloPredeploys.GOLD_TOKEN, CeloPredeploys.ALFAJORES_GOLD_TOKEN);
+        setupCallProxy(CeloPredeploys.FEE_HANDLER, CeloPredeploys.ALFAJORES_FEE_HANDLER);
+    }
+
+    function setupCallProxy(address addr, address impl) internal {
+        bytes memory code = vm.getDeployedCode("CallProxy.sol:CallProxy");
+
+        vm.etch(addr, code);
+        vm.store(addr, bytes32(uint256(0)), bytes32(impl));
     }
 
     /// @notice Sets up a proxy for the given impl address

--- a/packages/contracts-bedrock/src/celo/CallProxy.sol
+++ b/packages/contracts-bedrock/src/celo/CallProxy.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.15;
+
+contract CallProxy {
+    address public implementation;
+
+    constructor(address _implementation) {
+        implementation = _implementation;
+    }
+
+    function _delegate(address _implementation) internal virtual {
+        uint256 val = msg.value;
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := call(gas(), _implementation, val, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    function _fallback() internal virtual {
+        _delegate(implementation);
+    }
+
+    fallback() external payable virtual {
+        _fallback();
+    }
+}

--- a/packages/contracts-bedrock/src/celo/CeloPredeploys.sol
+++ b/packages/contracts-bedrock/src/celo/CeloPredeploys.sol
@@ -19,6 +19,11 @@ library CeloPredeploys {
     address internal constant FEE_CURRENCY_DIRECTORY = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
     address internal constant cUSD = 0x765DE816845861e75A25fCA122bb6898B8B1282a;
 
+    // Alfajores addresses that need an additional proxy to be reachable under mainnet address
+    address internal constant ALFAJORES_GOLD_TOKEN = 0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9;
+    // TODO: find out real address
+    address internal constant ALFAJORES_FEE_HANDLER = 0x7d21685C17607338b313a7174bAb6620baD0aaB7;
+
     /// @notice Returns the name of the predeploy at the given address.
     function getName(address _addr) internal pure returns (string memory out_) {
         // require(isPredeployNamespace(_addr), "Predeploys: address must be a predeploy");


### PR DESCRIPTION
Ref https://github.com/celo-org/optimism/issues/141

Moving state accounts including storage turned out to be not supported. As we currently only need this for testnets, this offers an alternative solution instead.

This PR creates a new proxy which used `call` to forward calls to the implementation contract. It should only be used for proxying mainnet addresses to the respective (normal) proxy on alfajores.

@pahor167 Please give me some early feedback on this approach 🙏 