### PR TITLE
Migrate alfajores contracts to mainnet addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v0.0.0-20240612131021-96a2a76ceaaa
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v0.0.0-20240618124816-43f1bdd6e286
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v0.0.0-20240612131021-96a2a76ceaaa h1:a9OVs0F3EjWwePKDuDUPr0QWe/CWi7uwElH9JzUxq/8=
-github.com/celo-org/op-geth v0.0.0-20240612131021-96a2a76ceaaa/go.mod h1:vObZmT4rKd8hjSblIktsJHtLX8SXbCoaIXEd42HMDB0=
+github.com/celo-org/op-geth v0.0.0-20240618124816-43f1bdd6e286 h1:6c7LYSHfuLT16rMXUn2fPLfsy7ooZ9lF9UENi3R7sCM=
+github.com/celo-org/op-geth v0.0.0-20240618124816-43f1bdd6e286/go.mod h1:vObZmT4rKd8hjSblIktsJHtLX8SXbCoaIXEd42HMDB0=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -434,18 +433,6 @@ func addAllocsToCeloState(db *state.StateDB, genesis *core.Genesis) error {
 	}
 	log.Info("Migrated OP contracts into state DB", "copiedAccounts", accountCounter, "overwrittenAccounts", overwriteCounter)
 	return nil
-}
-
-func dbValueToHash(enc []byte) common.Hash {
-	var value common.Hash
-	if len(enc) > 0 {
-		_, content, _, err := rlp.Split(enc)
-		if err != nil {
-			panic(err)
-		}
-		value.SetBytes(content)
-	}
-	return value
 }
 
 func migrateTestnetAccounts(db *state.StateDB, config *params.ChainConfig) error {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -280,6 +281,12 @@ func ApplyMigrationChangesToDB(genesis *core.Genesis, dbPath string, commit bool
 	}
 	log.Info("Migrated OP contracts into state DB", "copiedAccounts", accountCounter, "overwrittenAccounts", overwriteCounter)
 
+	// Celo contract addresses are now fixed, so we need to take care to move proxies to the expected addresses
+	err = migrateTestnetAccounts(db, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	migrationBlock := new(big.Int).Add(header.Number, common.Big1)
 
 	// We're done messing around with the database, so we can now commit the changes to the DB.
@@ -416,4 +423,41 @@ func openCeloDb(path string) (ethdb.Database, error) {
 		return nil, err
 	}
 	return ldb, nil
+}
+
+func dbValueToHash(enc []byte) common.Hash {
+	var value common.Hash
+	if len(enc) > 0 {
+		_, content, _, err := rlp.Split(enc)
+		if err != nil {
+			panic(err)
+		}
+		value.SetBytes(content)
+	}
+	return value
+}
+
+func migrateTestnetAccounts(db *state.StateDB, config *params.ChainConfig) error {
+	if mapping, exists := contractMigrations[config.ChainID.Uint64()]; exists {
+		log.Info("Found contract migrations for chain", "chainID", config.ChainID, "mappings", len(mapping))
+		for source, target := range mapping {
+			if !db.Exist(source) {
+				log.Warn("Source account does not exist", "source", source)
+				continue
+			}
+
+			if db.Exist(target) {
+				log.Warn("Target account already exists, overwriting...", "target", target)
+			}
+
+			err := db.MoveAccount(source, target)
+			if err != nil {
+				return err
+			}
+
+			log.Info("Migrated account", "source", source, "target", target)
+		}
+		log.Info("Migrated accounts")
+	}
+	return nil
 }

--- a/op-chain-ops/cmd/celo-migrate/testnets.go
+++ b/op-chain-ops/cmd/celo-migrate/testnets.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ChainContractMigrations map[uint64]map[common.Address]common.Address
+
+var (
+	alfajoresChainID   uint64 = 44787
+	alfajoresContracts        = map[common.Address]common.Address{
+		// GoldToken
+		common.HexToAddress("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"): common.HexToAddress("0x471EcE3750Da237f93B8E339c536989b8978a438"),
+		// FeeHandler
+		common.HexToAddress("0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38"): common.HexToAddress("0xcD437749E43A154C07F3553504c68fBfD56B8778"),
+		// FeeCurrencyDirectory
+		// TODO: Add once the address is known
+	}
+
+	contractMigrations = ChainContractMigrations{
+		alfajoresChainID: alfajoresContracts,
+	}
+)


### PR DESCRIPTION
Resolves https://github.com/celo-org/optimism/issues/141

The current implementation of celo-geth assumes that core contract addresses are fixed. This assumption creates issues because the contract addresses on Alfajores differ from those on the mainnet.

This PR introduces the capability to migrate contracts using the state migration tool. Additionally, it provides initial configuration settings for Alfajores.