### PR TITLE
Update op-geth (both go.mod and devnet container)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v0.0.0-20240624092059-26b8a1d8617d
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v0.0.0-20240626110223-99afa464d86e
 
 //replace github.com/ethereum/go-ethereum v1.13.9 => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v0.0.0-20240624092059-26b8a1d8617d h1:Qs1Sy1TVhOGWLEMj3i+5Tg30gPEtgrCkNcIg8vvfBz4=
-github.com/celo-org/op-geth v0.0.0-20240624092059-26b8a1d8617d/go.mod h1:vObZmT4rKd8hjSblIktsJHtLX8SXbCoaIXEd42HMDB0=
+github.com/celo-org/op-geth v0.0.0-20240626110223-99afa464d86e h1:s2kq9PdLiAPY3W2okIbHol2qZRZHYBQnEFwmJ1yuwQ8=
+github.com/celo-org/op-geth v0.0.0-20240626110223-99afa464d86e/go.mod h1:vObZmT4rKd8hjSblIktsJHtLX8SXbCoaIXEd42HMDB0=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/ops-bedrock/Dockerfile.l2
+++ b/ops-bedrock/Dockerfile.l2
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth@sha256:0f7500f796362a9b9102c28cec6d94a590e219777b8344eef3784f629b720bb9
+FROM --platform=linux/amd64 us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth@sha256:fab76a990c21271419a40dfe5d28e30905869183b18ee9e6f711fe562365bc8e
 
 RUN apk add --no-cache jq
 

--- a/packages/contracts-bedrock/src/celo/CeloPredeploys.sol
+++ b/packages/contracts-bedrock/src/celo/CeloPredeploys.sol
@@ -16,7 +16,7 @@ library CeloPredeploys {
     address internal constant ADDRESS_SORTED_LINKED_LIST_WITH_MEDIAN = 0xED477A99035d0c1e11369F1D7A4e587893cc002B;
     address internal constant FEE_CURRENCY = 0x4200000000000000000000000000000000001022;
     address internal constant BRIDGED_ETH = 0x4200000000000000000000000000000000001023;
-    address internal constant FEE_CURRENCY_DIRECTORY = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
+    address internal constant FEE_CURRENCY_DIRECTORY = 0x71FFbD48E34bdD5a87c3c683E866dc63b8B2a685;
     address internal constant cUSD = 0x765DE816845861e75A25fCA122bb6898B8B1282a;
 
     /// @notice Returns the name of the predeploy at the given address.


### PR DESCRIPTION
The new version uses a different FeeCurrencyDirectory address, so we also need to update that.