### PR TITLE
Migration script fixes

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -14,9 +14,8 @@ import (
 
 // Constants for the database
 const (
-	DBCache                        = 1024 // size of the cache in MB
-	DBHandles                      = 60   // number of handles
-	LastMigratedNonAncientBlockKey = "celoLastMigratedNonAncientBlock"
+	DBCache   = 1024 // size of the cache in MB
+	DBHandles = 60   // number of handles
 )
 
 var (
@@ -33,28 +32,6 @@ func encodeBlockNumber(number uint64) []byte {
 // headerKey = headerPrefix + num (uint64 big endian) + hash
 func headerKey(number uint64, hash common.Hash) []byte {
 	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
-}
-
-// readLastMigratedNonAncientBlock returns the last migration number. If it doesn't exist, it returns 0.
-func readLastMigratedNonAncientBlock(db ethdb.KeyValueReader) uint64 {
-	data, err := db.Get([]byte(LastMigratedNonAncientBlockKey))
-	if err != nil {
-		return 0
-	}
-	number := binary.BigEndian.Uint64(data)
-	return number
-}
-
-// writeLastMigratedNonAncientBlock stores the last migration number.
-func writeLastMigratedNonAncientBlock(db ethdb.KeyValueWriter, number uint64) error {
-	enc := make([]byte, 8)
-	binary.BigEndian.PutUint64(enc, number)
-	return db.Put([]byte(LastMigratedNonAncientBlockKey), enc)
-}
-
-// deleteLastMigratedNonAncientBlock removes the last migration number.
-func deleteLastMigratedNonAncientBlock(db ethdb.KeyValueWriter) error {
-	return db.Delete([]byte(LastMigratedNonAncientBlockKey))
 }
 
 // openDB opens the chaindata database at the given path. Note this path is below the datadir

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -82,10 +82,6 @@ var (
 		Name:  "clear-all",
 		Usage: "Use this to start with a fresh new db, deleting all data including ancients. CAUTION: Re-migrating ancients takes time.",
 	}
-	keepNonAncientsFlag = &cli.BoolFlag{
-		Name:  "keep-non-ancients",
-		Usage: "CAUTION: Not recommended for production. Use to keep all data in the new db as is, including any partially migrated non-ancient blocks and state data. If non-ancient blocks are partially migrated, the script will attempt to resume the migration.",
-	}
 	onlyAncientsFlag = &cli.BoolFlag{
 		Name:  "only-ancients",
 		Usage: "Use to only migrate ancient blocks. Ignored when running full migration",
@@ -99,7 +95,6 @@ var (
 		bufferSizeFlag,
 		memoryLimitFlag,
 		clearAllFlag,
-		keepNonAncientsFlag,
 	}
 	stateMigrationFlags = []cli.Flag{
 		newDBPathFlag,
@@ -115,14 +110,13 @@ var (
 )
 
 type blockMigrationOptions struct {
-	oldDBPath       string
-	newDBPath       string
-	batchSize       uint64
-	bufferSize      uint64
-	memoryLimit     int64
-	clearAll        bool
-	keepNonAncients bool
-	onlyAncients    bool
+	oldDBPath    string
+	newDBPath    string
+	batchSize    uint64
+	bufferSize   uint64
+	memoryLimit  int64
+	clearAll     bool
+	onlyAncients bool
 }
 
 type stateMigrationOptions struct {
@@ -137,14 +131,13 @@ type stateMigrationOptions struct {
 
 func parseBlockMigrationOptions(ctx *cli.Context) blockMigrationOptions {
 	return blockMigrationOptions{
-		oldDBPath:       ctx.String(oldDBPathFlag.Name),
-		newDBPath:       ctx.String(newDBPathFlag.Name),
-		batchSize:       ctx.Uint64(batchSizeFlag.Name),
-		bufferSize:      ctx.Uint64(bufferSizeFlag.Name),
-		memoryLimit:     ctx.Int64(memoryLimitFlag.Name),
-		clearAll:        ctx.Bool(clearAllFlag.Name),
-		keepNonAncients: ctx.Bool(keepNonAncientsFlag.Name),
-		onlyAncients:    ctx.Bool(onlyAncientsFlag.Name),
+		oldDBPath:    ctx.String(oldDBPathFlag.Name),
+		newDBPath:    ctx.String(newDBPathFlag.Name),
+		batchSize:    ctx.Uint64(batchSizeFlag.Name),
+		bufferSize:   ctx.Uint64(bufferSizeFlag.Name),
+		memoryLimit:  ctx.Int64(memoryLimitFlag.Name),
+		clearAll:     ctx.Bool(clearAllFlag.Name),
+		onlyAncients: ctx.Bool(onlyAncientsFlag.Name),
 	}
 }
 
@@ -232,7 +225,7 @@ func runBlockMigration(opts blockMigrationOptions) error {
 
 	debug.SetMemoryLimit(opts.memoryLimit * 1 << 20) // Set memory limit, converting from MiB to bytes
 
-	log.Info("Block Migration Started", "oldDBPath", opts.oldDBPath, "newDBPath", opts.newDBPath, "batchSize", opts.batchSize, "memoryLimit", opts.memoryLimit, "clearAll", opts.clearAll, "keepNonAncients", opts.keepNonAncients, "onlyAncients", opts.onlyAncients)
+	log.Info("Block Migration Started", "oldDBPath", opts.oldDBPath, "newDBPath", opts.newDBPath, "batchSize", opts.batchSize, "memoryLimit", opts.memoryLimit, "clearAll", opts.clearAll, "onlyAncients", opts.onlyAncients)
 
 	var err error
 
@@ -244,7 +237,7 @@ func runBlockMigration(opts blockMigrationOptions) error {
 		if err = os.RemoveAll(opts.newDBPath); err != nil {
 			return fmt.Errorf("failed to remove new database: %w", err)
 		}
-	} else if !opts.keepNonAncients {
+	} else {
 		if err = cleanupNonAncientDb(opts.newDBPath); err != nil {
 			return fmt.Errorf("failed to reset non-ancient database: %w", err)
 		}
@@ -258,7 +251,7 @@ func runBlockMigration(opts blockMigrationOptions) error {
 
 	var numNonAncients uint64
 	if !opts.onlyAncients {
-		if numNonAncients, err = migrateNonAncientsDb(opts.oldDBPath, opts.newDBPath, numAncientsNewAfter-1, opts.batchSize); err != nil {
+		if numNonAncients, err = migrateNonAncientsDb(opts.oldDBPath, opts.newDBPath, numAncientsNewAfter, opts.batchSize); err != nil {
 			return fmt.Errorf("failed to migrate non-ancients database: %w", err)
 		}
 	} else {

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -125,6 +125,9 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 	}
 
 	// If gas limit was zero at the transition point use a default of 30M.
+	// Note that in op-geth we use gasLimit==0 to indicate a pre-gingerbread
+	// block and adjust encoding appropriately, so we must make sure that
+	// gasLimit is non-zero, bacause L2 blocks are all post gingerbread.
 	gasLimit := header.GasLimit
 	if gasLimit == 0 {
 		gasLimit = 30e6

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -124,6 +124,11 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		migrationBlockTime = uint64(time.Now().Unix())
 	}
 
+	// If gas limit was zero at the transition point use a default of 30M.
+	gasLimit := header.GasLimit
+	if gasLimit == 0 {
+		gasLimit = 30e6
+	}
 	// Create the header for the Cel2 transition block.
 	cel2Header := &types.Header{
 		ParentHash:       header.Hash(),
@@ -135,7 +140,7 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		Bloom:            types.Bloom{},
 		Difficulty:       new(big.Int).Set(common.Big0),
 		Number:           migrationBlock,
-		GasLimit:         header.GasLimit,
+		GasLimit:         gasLimit,
 		GasUsed:          0,
 		Time:             migrationBlockTime,
 		Extra:            []byte("CeL2 migration"),


### PR DESCRIPTION
These fixes ensure that the migration script works when there are no
ancients and also when the final celo L1 block is a pre-gingerbread block.

The migration script was assuming that ancients would be present and was
considering the numAncients-1 to be first non ancient block to migrate but when
numAncients is zero that's a problem.

Also removed logic for picking up where db migration left of for the
level db since it was complicating the logic for correctly calculating the
non ancient block to start migrating from.

Finally these changes ensure that the migration block has a non zero gas limit,
even if the parent block had a zero gas limit