### PR TITLE
Fix l2 block older than l1 origin error

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -50,7 +50,7 @@ var (
 	}
 	migrationBlockTimeFlag = &cli.Uint64Flag{
 		Name:  "migration-block-time",
-		Usage: "Specifies a timestamp to use for the migration block. If not provided, the current time will be used.",
+		Usage: "Specifies a unix timestamp to use for the migration block. If not provided, the current time will be used.",
 	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -48,6 +48,10 @@ var (
 		Usage:    "Path to write the rollup config JSON file, to be provided to op-node with the 'rollup.config' flag",
 		Required: true,
 	}
+	migrationBlockTimeFlag = &cli.Uint64Flag{
+		Name:  "migration-block-time",
+		Usage: "Specifies a timestamp to use for the migration block. If not provided, the current time will be used.",
+	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",
 		Usage:    "Path to the old Celo chaindata dir, can be found at '<datadir>/celo/chaindata'",
@@ -103,6 +107,7 @@ var (
 		l1RPCFlag,
 		l2AllocsFlag,
 		outfileRollupConfigFlag,
+		migrationBlockTimeFlag,
 	}
 	// Ignore onlyAncients flag and duplicate newDBPathFlag for full migration
 	fullMigrationFlags = append(blockMigrationFlags[1:], stateMigrationFlags[1:]...)
@@ -126,6 +131,7 @@ type stateMigrationOptions struct {
 	l2AllocsPath        string
 	outfileRollupConfig string
 	newDBPath           string
+	migrationBlockTime  uint64
 }
 
 func parseBlockMigrationOptions(ctx *cli.Context) blockMigrationOptions {
@@ -149,6 +155,7 @@ func parseStateMigrationOptions(ctx *cli.Context) stateMigrationOptions {
 		l1RPC:               ctx.String(l1RPCFlag.Name),
 		l2AllocsPath:        ctx.Path(l2AllocsFlag.Name),
 		outfileRollupConfig: ctx.Path(outfileRollupConfigFlag.Name),
+		migrationBlockTime:  ctx.Uint64(migrationBlockTimeFlag.Name),
 	}
 }
 
@@ -336,7 +343,7 @@ func runStateMigration(opts stateMigrationOptions) error {
 	}
 
 	// Write changes to state to actual state database
-	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, opts.newDBPath)
+	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, opts.newDBPath, opts.migrationBlockTime)
 	if err != nil {
 		return err
 	}

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -54,7 +54,7 @@ var (
 	}
 )
 
-func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string) (*types.Header, error) {
+func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string, migrationBlockTime uint64) (*types.Header, error) {
 	log.Info("Opening Celo database", "dbPath", dbPath)
 
 	ldb, err := openDB(dbPath)
@@ -123,6 +123,10 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		baseFee = header.BaseFee
 	}
 
+	if migrationBlockTime == 0 {
+		migrationBlockTime = uint64(time.Now().Unix())
+	}
+
 	// Create the header for the Cel2 transition block.
 	cel2Header := &types.Header{
 		ParentHash:       header.Hash(),
@@ -136,7 +140,7 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		Number:           migrationBlock,
 		GasLimit:         header.GasLimit,
 		GasUsed:          0,
-		Time:             uint64(time.Now().Unix()),
+		Time:             migrationBlockTime,
 		Extra:            []byte("CeL2 migration"),
 		MixDigest:        common.Hash{},
 		Nonce:            types.BlockNonce{},

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/celo-migrate/bindings"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -135,7 +136,7 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		Number:           migrationBlock,
 		GasLimit:         header.GasLimit,
 		GasUsed:          0,
-		Time:             header.Time + 5,
+		Time:             uint64(time.Now().Unix()),
 		Extra:            []byte("CeL2 migration"),
 		MixDigest:        common.Hash{},
 		Nonce:            types.BlockNonce{},


### PR DESCRIPTION
We were encountering the following error when running op-node with a migrated datadir:

```
ERROR[06-25|16:53:24.779] Derivation pipeline not ready, failed to reset engine err="reset: cannot reset block derivation to start at L2 block 0xdf1dfd6566270260a33f4a33406358e93b8402d4bb6829bb35d685259cc1c3c2:23912612 with time 1714956104 older than its L1 origin 0xbbed3612407993e67f8ca7a423b181837ae164a531941e78f5ee48e766d39cad:1729797 with time 1718312256, time invariant is broken"
```
This pr fixes that by using time.Now for the time of the l2 transition block.
We really do need a deterministic time for the migration block so that
all parties that run the migration arrive at the same migration block
but the problem is that op-geth requires that the L2 migration block
(aka l2 origin) occurs after the l1 origin (I guess the point where you
deploy the bridge contracts to the l1). When we migrate a partially
synced datadir the block before the transition block will be very old,
up to 4 years old! So of course it occurs before the l1 origin. So a fix
just to get things working is to use time.Now(), but probably we should
make this a configurable parameter.