### PR TITLE
Piersy/migrate script full alfajores snap sync

### DIFF
--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -29,6 +29,7 @@ jobs:
     if: |
       contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/cmd/celo-migrate') ||
       contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/Dockerfile') ||
+      contains(needs.detect-files-changed.outputs.files-changed, '.github/workflows/docker-build-scan.yaml') ||
       github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
@@ -64,6 +65,7 @@ jobs:
       contains(needs.detect-files-changed.outputs.files-changed, 'op-batcher/') ||
       contains(needs.detect-files-changed.outputs.files-changed, 'op-proposer/') ||
       contains(needs.detect-files-changed.outputs.files-changed, 'op-service/') ||
+      contains(needs.detect-files-changed.outputs.files-changed, '.github/workflows/docker-build-scan.yaml') ||
       github.event_name == 'workflow_dispatch'
     permissions:
       contents: read

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -76,7 +76,7 @@ jobs:
     env:
       GIT_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       GIT_DATE: ${{ github.event.head_commit.timestamp }}
-      IMAGE_TAGS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/celo')) && 'latest,' || '') }}${{ github.sha }}
+      IMAGE_TAGS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/celo')) && 'latest,' || '') }}${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       REGISTRY: us-west1-docker.pkg.dev
       REPOSITORY: blockchaintestsglobaltestnet/dev-images
     steps:

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -76,7 +76,7 @@ jobs:
     env:
       GIT_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       GIT_DATE: ${{ github.event.head_commit.timestamp }}
-      IMAGE_TAGS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/celo')) && 'latest,' || '') }}${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      IMAGE_TAGS: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/celo')) && 'latest,' || '') }}${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       REGISTRY: us-west1-docker.pkg.dev
       REPOSITORY: blockchaintestsglobaltestnet/dev-images
     steps:

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - 'master'
       - 'celo*'
+  push:
+    branches:
+      - 'master'
+      - 'celo*'
   workflow_dispatch:
 
 jobs:
@@ -24,7 +28,8 @@ jobs:
     needs: detect-files-changed
     if: |
       contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/cmd/celo-migrate') ||
-      contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/Dockerfile')
+      contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/Dockerfile') ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       id-token: write
@@ -58,7 +63,8 @@ jobs:
       contains(needs.detect-files-changed.outputs.files-changed, 'op-node/') ||
       contains(needs.detect-files-changed.outputs.files-changed, 'op-batcher/') ||
       contains(needs.detect-files-changed.outputs.files-changed, 'op-proposer/') ||
-      contains(needs.detect-files-changed.outputs.files-changed, 'op-service/')
+      contains(needs.detect-files-changed.outputs.files-changed, 'op-service/') ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -25,6 +25,8 @@ jobs:
 
   build-cel2-migration-tool:
     runs-on: ubuntu-latest
+    env:
+      GIT_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     needs: detect-files-changed
     if: |
       contains(needs.detect-files-changed.outputs.files-changed, 'op-chain-ops/cmd/celo-migrate') ||
@@ -48,7 +50,7 @@ jobs:
         with:
           platforms: linux/amd64
           registry: us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool
-          tags: ${{ github.sha }}
+          tags: ${{ env.GIT_COMMIT }}
           context: ./
           dockerfile: ./op-chain-ops/Dockerfile
           push: true
@@ -72,9 +74,9 @@ jobs:
       id-token: write
       security-events: write
     env:
-      GIT_COMMIT: ${{ github.sha }}
+      GIT_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       GIT_DATE: ${{ github.event.head_commit.timestamp }}
-      IMAGE_TAGS: ${{ github.sha }},latest
+      IMAGE_TAGS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/celo')) && 'latest,' || '') }}${{ github.sha }}
       REGISTRY: us-west1-docker.pkg.dev
       REPOSITORY: blockchaintestsglobaltestnet/dev-images
     steps:

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -49,6 +49,10 @@ var (
 		Usage:    "Path to write the rollup config JSON file, to be provided to op-node with the 'rollup.config' flag",
 		Required: true,
 	}
+	migrationBlockTimeFlag = &cli.Uint64Flag{
+		Name:  "migration-block-time",
+		Usage: "Specifies a unix timestamp to use for the migration block. If not provided, the current time will be used.",
+	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",
 		Usage:    "Path to the old Celo chaindata dir, can be found at '<datadir>/celo/chaindata'",
@@ -104,6 +108,7 @@ var (
 		l1RPCFlag,
 		l2AllocsFlag,
 		outfileRollupConfigFlag,
+		migrationBlockTimeFlag,
 	}
 	// Ignore onlyAncients flag and duplicate newDBPathFlag for full migration
 	fullMigrationFlags = append(blockMigrationFlags[1:], stateMigrationFlags[1:]...)
@@ -127,6 +132,7 @@ type stateMigrationOptions struct {
 	l2AllocsPath        string
 	outfileRollupConfig string
 	newDBPath           string
+	migrationBlockTime  uint64
 }
 
 func parseBlockMigrationOptions(ctx *cli.Context) blockMigrationOptions {
@@ -150,6 +156,7 @@ func parseStateMigrationOptions(ctx *cli.Context) stateMigrationOptions {
 		l1RPC:               ctx.String(l1RPCFlag.Name),
 		l2AllocsPath:        ctx.Path(l2AllocsFlag.Name),
 		outfileRollupConfig: ctx.Path(outfileRollupConfigFlag.Name),
+		migrationBlockTime:  ctx.Uint64(migrationBlockTimeFlag.Name),
 	}
 }
 
@@ -337,7 +344,7 @@ func runStateMigration(opts stateMigrationOptions) error {
 	}
 
 	// Write changes to state to actual state database
-	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, opts.newDBPath)
+	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, opts.newDBPath, opts.migrationBlockTime)
 	if err != nil {
 		return err
 	}

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -50,7 +51,7 @@ var (
 	}
 )
 
-func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string) (*types.Header, error) {
+func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string, migrationBlockTime uint64) (*types.Header, error) {
 	log.Info("Opening Celo database", "dbPath", dbPath)
 
 	ldb, err := openDB(dbPath)
@@ -119,6 +120,10 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		baseFee = header.BaseFee
 	}
 
+	if migrationBlockTime == 0 {
+		migrationBlockTime = uint64(time.Now().Unix())
+	}
+
 	// Create the header for the Cel2 transition block.
 	cel2Header := &types.Header{
 		ParentHash:       header.Hash(),
@@ -132,7 +137,7 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 		Number:           migrationBlock,
 		GasLimit:         header.GasLimit,
 		GasUsed:          0,
-		Time:             header.Time + 5,
+		Time:             migrationBlockTime,
 		Extra:            []byte("CeL2 migration"),
 		MixDigest:        common.Hash{},
 		Nonce:            types.BlockNonce{},

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -133,3 +133,4 @@ EOL
 
 # Write the config file
 echo "$config" > deploy-config/$DEPLOYMENT_CONTEXT.json
+echo "Created file deploy-config/$DEPLOYMENT_CONTEXT.json successfully."

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -122,9 +122,9 @@ config=$(cat << EOL
   "respectedGameType": 0,
 
   "usePlasma": $USE_PLASMA,
-  "daCommitmentType": "KeccakCommitment",
-  "daChallengeWindow": 160,
-  "daResolveWindow": 160,
+  "daCommitmentType": "GenericCommitment",
+  "daChallengeWindow": 3600,
+  "daResolveWindow": 3600,
   "daBondSize": 1000000,
   "daResolverRefundPercentage": 0
 }


### PR DESCRIPTION
Fixes when L1 migration block is too old, and the migration block generated timestamp was also generated as a too old block and latter sequencer rejected to generate more blocks.