### PR TITLE
Fix migration script gap in migrated blocks

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -50,7 +50,7 @@ func migrateAncientsDb(oldDBPath, newDBPath string, batchSize, bufferSize uint64
 		return numAncientsNewBefore, numAncientsNewBefore, nil
 	}
 
-	log.Info("Ancient Block Migration Started", "process", "ancients", "startBlock", numAncientsNewBefore, "endBlock", numAncientsOld, "count", numAncientsOld-numAncientsNewBefore, "step", batchSize)
+	log.Info("Ancient Block Migration Started", "process", "ancients", "startBlock", numAncientsNewBefore, "endBlock", numAncientsOld-1, "count", numAncientsOld-numAncientsNewBefore, "step", batchSize)
 
 	g, ctx := errgroup.WithContext(context.Background())
 	readChan := make(chan RLPBlockRange, bufferSize)

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -89,7 +89,7 @@ func migrateNonAncientsDb(oldDbPath, newDbPath string, numAncients, batchSize ui
 		}
 	}
 
-	if numAncients > 0 {
+	if lastAncient > 0 {
 		toBeRemoved := rawdb.ReadAllHashesInRange(newDB, 1, lastAncient)
 		log.Info("Removing frozen blocks", "process", "non-ancients", "count", len(toBeRemoved))
 		batch := newDB.NewBatch()

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -51,8 +51,9 @@ func migrateNonAncientsDb(oldDbPath, newDbPath string, numAncients, batchSize ui
 	// get the last block number
 	hash := rawdb.ReadHeadHeaderHash(newDB)
 	lastBlock := *rawdb.ReadHeaderNumber(newDB, hash)
+	lastAncient := numAncients - 1
 
-	log.Info("Non-Ancient Block Migration Started", "process", "non-ancients", "startBlock", numAncients, "endBlock", lastBlock, "count", lastBlock-numAncients, "lastAncientBlock", numAncients)
+	log.Info("Non-Ancient Block Migration Started", "process", "non-ancients", "startBlock", numAncients, "endBlock", lastBlock, "count", lastBlock-lastAncient, "lastAncientBlock", lastAncient)
 
 	for i := numAncients; i <= lastBlock; i += batchSize {
 		numbersHash := rawdb.ReadAllHashesInRange(newDB, i, i+batchSize-1)
@@ -89,7 +90,7 @@ func migrateNonAncientsDb(oldDbPath, newDbPath string, numAncients, batchSize ui
 	}
 
 	if numAncients > 0 {
-		toBeRemoved := rawdb.ReadAllHashesInRange(newDB, 1, numAncients)
+		toBeRemoved := rawdb.ReadAllHashesInRange(newDB, 1, lastAncient)
 		log.Info("Removing frozen blocks", "process", "non-ancients", "count", len(toBeRemoved))
 		batch := newDB.NewBatch()
 		for _, numberHash := range toBeRemoved {


### PR DESCRIPTION
The range of ancient blocks to remove from the non ancients database was off by one and resulted in a gap between ancients and non ancients.

Also corrected some log statements that contained values that were off by one.