### PR TITLE
l1-origin: Use finalized block as upper limit for l1 origin

### DIFF
--- a/op-node/rollup/driver/origin_selector_celo_test.go
+++ b/op-node/rollup/driver/origin_selector_celo_test.go
@@ -1,0 +1,87 @@
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOriginSelectorSameFinalized ensures that the origin selector
+// advances only to the finalized block when Cel2 is enabled.
+func TestOriginSelectorSameFinalized(t *testing.T) {
+	log := testlog.Logger(t, log.LevelCrit)
+	cfg := &rollup.Config{
+		MaxSequencerDrift: 500,
+		BlockTime:         2,
+		Cel2Time:          new(uint64),
+	}
+	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
+	a := eth.L1BlockRef{
+		Hash:   common.Hash{'a'},
+		Number: 10,
+		Time:   20,
+	}
+	l2Head := eth.L2BlockRef{
+		L1Origin: a.ID(),
+		Time:     24,
+	}
+
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByLabel(eth.Finalized, a, nil)
+
+	s := NewL1OriginSelector(log, cfg, l1)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
+	require.Nil(t, err)
+	require.Equal(t, a, next)
+}
+
+// TestOriginSelectorNewFinalized ensures that the origin selector
+// advances by only one block when a new finalized block is available.
+func TestOriginSelectorNewFinalized(t *testing.T) {
+	log := testlog.Logger(t, log.LevelCrit)
+	cfg := &rollup.Config{
+		MaxSequencerDrift: 500,
+		BlockTime:         2,
+		Cel2Time:          new(uint64),
+	}
+	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
+	a := eth.L1BlockRef{
+		Hash:   common.Hash{'a'},
+		Number: 10,
+		Time:   20,
+	}
+	b := eth.L1BlockRef{
+		Hash:       common.Hash{'b'},
+		Number:     11,
+		Time:       25,
+		ParentHash: a.Hash,
+	}
+	c := eth.L1BlockRef{
+		Hash:       common.Hash{'c'},
+		Number:     12,
+		Time:       30,
+		ParentHash: b.Hash,
+	}
+	l2Head := eth.L2BlockRef{
+		L1Origin: a.ID(),
+		Time:     24,
+	}
+
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+	l1.ExpectL1BlockRefByLabel(eth.Finalized, c, nil)
+
+	s := NewL1OriginSelector(log, cfg, l1)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
+	require.Nil(t, err)
+	require.Equal(t, b, next)
+}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -522,6 +522,10 @@ func (c *Config) PlasmaEnabled() bool {
 	return c.PlasmaConfig != nil
 }
 
+func (c *Config) IsCelo() bool {
+	return c.Cel2Time != nil
+}
+
 // SyncLookback computes the number of blocks to walk back in order to find the correct L1 origin.
 // In alt-da mode longest possible window is challenge + resolve windows.
 func (c *Config) SyncLookback() uint64 {


### PR DESCRIPTION
Resolves https://github.com/celo-org/optimism/issues/200

Implements usage of the finalized L1 block when on Celo (this is determined by checking the `Cel2` timestamp in the config).

When enabled the code requests the latest finalized block. This requires a small change to the `L1Blocks` interface.
If the finalized block is not higher than the current origin, return the current origin.

ℹ️ We could also implement a new struct like `L1OriginSelector`, but the changes are so small that I don't think that makes a lot of sense right now.