### PR TITLE
Set ownership of proxy contracts on deployment

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -73,6 +73,8 @@ export FUNDS_DEV_ACCOUNTS=false
 export USE_ALTDA=false
 # Set to false if migrating state from a Celo L1. True for new testnets
 export DEPLOY_CELO_CONTRACTS=false
+# Assign ownership of SystemConfig and ProtocolVersions to safe instead of deployment account
+export SAFE_AS_OWNER=true
 
 export USE_CUSTOM_GAS_TOKEN=true
 # Set to "0x0000000000000000000000000000000000000000" when the contract

--- a/.envrc.example
+++ b/.envrc.example
@@ -74,7 +74,7 @@ export USE_ALTDA=false
 # Set to false if migrating state from a Celo L1. True for new testnets
 export DEPLOY_CELO_CONTRACTS=false
 # Assign ownership of SystemConfig and ProtocolVersions to safe instead of deployment account
-export SAFE_AS_OWNER=true
+export SAFE_AS_OWNER=false
 
 export USE_CUSTOM_GAS_TOKEN=true
 # Set to "0x0000000000000000000000000000000000000000" when the contract

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -828,6 +828,9 @@ type DeployConfig struct {
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
+
+	// SafeAsOwner indicates whether specific proxy contracts should be owned by the Safe contract.
+	SafeAsOwner bool `json:"safeAsOwner"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -93,5 +93,6 @@
   "daChallengeWindow": 0,
   "daResolveWindow": 0,
   "daResolverRefundPercentage": 0,
-  "deployCeloContracts": false
+  "deployCeloContracts": false,
+  "safeAsOwner": false
 }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -72,7 +72,6 @@ library ChainAssertions {
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
         if (_isProxy) {
-            require(config.owner() == _cfg.finalSystemOwner());
             require(config.basefeeScalar() == _cfg.basefeeScalar());
             require(config.blobbasefeeScalar() == _cfg.blobbasefeeScalar());
             require(config.batcherHash() == bytes32(uint256(uint160(_cfg.batchSenderAddress()))));
@@ -404,7 +403,6 @@ library ChainAssertions {
         assertSlotValueIsOne({ _contractAddress: address(versions), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
-            require(versions.owner() == _cfg.finalSystemOwner());
             require(ProtocolVersion.unwrap(versions.required()) == _cfg.requiredProtocolVersion());
             require(ProtocolVersion.unwrap(versions.recommended()) == _cfg.recommendedProtocolVersion());
         } else {

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1354,7 +1354,7 @@ contract Deploy is Deployer {
 
         address protocolVersionsOwner = cfg.finalSystemOwner();
         if (cfg.safeAsOwner()) {
-            systemConfigOwner = mustGetAddress("SystemOwnerSafe");
+            protocolVersionsOwner = mustGetAddress("SystemOwnerSafe");
         }
         uint256 requiredProtocolVersion = cfg.requiredProtocolVersion();
         uint256 recommendedProtocolVersion = cfg.recommendedProtocolVersion();

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1358,11 +1358,7 @@ contract Deploy is Deployer {
             _implementation: protocolVersions,
             _innerCallData: abi.encodeCall(
                 ProtocolVersions.initialize,
-                (
-                    safe,
-                    ProtocolVersion.wrap(requiredProtocolVersion),
-                    ProtocolVersion.wrap(recommendedProtocolVersion)
-                )
+                (safe, ProtocolVersion.wrap(requiredProtocolVersion), ProtocolVersion.wrap(recommendedProtocolVersion))
             )
         });
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -60,7 +60,6 @@ import { Process } from "scripts/libraries/Process.sol";
 
 import { CeloTokenL1 } from "src/celo/CeloTokenL1.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Multicall3 } from "@multicall/Multicall3.sol";
 
 /// @title Deploy

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -373,6 +373,8 @@ contract Deploy is Deployer {
 
         address safe = mustGetAddress("SystemOwnerSafe");
         if (owner != safe) {
+            console.log("Contract owner: %s", address(owner));
+            console.log("Caller : %s", msg.sender);
             ccontract.transferOwnership(safe);
             console.log("%s ownership transferred to Safe at: %s ", _contract, safe);
         }

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1059,13 +1059,16 @@ contract Deploy is Deployer {
         console.log("Upgrading and initializing SystemConfig proxy");
         address systemConfigProxy = mustGetAddress("SystemConfigProxy");
         address systemConfig = mustGetAddress("SystemConfig");
-        address safe = mustGetAddress("SystemOwnerSafe");
 
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
         address customGasTokenAddress = Constants.ETHER;
         if (cfg.useCustomGasToken()) {
             customGasTokenAddress = cfg.customGasTokenAddress();
+        }
+        address systemConfigOwner = cfg.finalSystemOwner();
+        if (cfg.safeAsOwner()) {
+            systemConfigOwner = mustGetAddress("SystemOwnerSafe");
         }
 
         _upgradeAndCallViaSafe({
@@ -1074,7 +1077,7 @@ contract Deploy is Deployer {
             _innerCallData: abi.encodeCall(
                 SystemConfig.initialize,
                 (
-                    safe,
+                    systemConfigOwner,
                     cfg.basefeeScalar(),
                     cfg.blobbasefeeScalar(),
                     batcherHash,
@@ -1349,7 +1352,10 @@ contract Deploy is Deployer {
         address protocolVersionsProxy = mustGetAddress("ProtocolVersionsProxy");
         address protocolVersions = mustGetAddress("ProtocolVersions");
 
-        address safe = mustGetAddress("SystemOwnerSafe");
+        address protocolVersionsOwner = cfg.finalSystemOwner();
+        if (cfg.safeAsOwner()) {
+            systemConfigOwner = mustGetAddress("SystemOwnerSafe");
+        }
         uint256 requiredProtocolVersion = cfg.requiredProtocolVersion();
         uint256 recommendedProtocolVersion = cfg.recommendedProtocolVersion();
 
@@ -1358,7 +1364,11 @@ contract Deploy is Deployer {
             _implementation: protocolVersions,
             _innerCallData: abi.encodeCall(
                 ProtocolVersions.initialize,
-                (safe, ProtocolVersion.wrap(requiredProtocolVersion), ProtocolVersion.wrap(recommendedProtocolVersion))
+                (
+                    protocolVersionsOwner,
+                    ProtocolVersion.wrap(requiredProtocolVersion),
+                    ProtocolVersion.wrap(recommendedProtocolVersion)
+                )
             )
         });
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -374,7 +374,7 @@ contract Deploy is Deployer {
         address safe = mustGetAddress("SystemOwnerSafe");
         if (owner != safe) {
             ccontract.transferOwnership(safe);
-            console.log("%s ownership transferred to Safe at: %s", _contract, safe);
+            console.log("%s ownership transferred to Safe at: %s ", _contract, safe);
         }
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -308,7 +308,6 @@ contract Deploy is Deployer {
             }
         }
         setupOpChain();
-
         console.log("set up op chain!");
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -361,23 +361,6 @@ contract Deploy is Deployer {
 
         transferDisputeGameFactoryOwnership();
         transferDelayedWETHOwnership();
-
-        setOwnershipToSystemOwner("SystemConfigProxy");
-        setOwnershipToSystemOwner("ProtocolVersionsProxy");
-    }
-
-    /// @notice Transfer ownership of proxy contracts to system owner
-    function setOwnershipToSystemOwner(string memory _contract) public broadcast {
-        OwnableUpgradeable ccontract = OwnableUpgradeable(mustGetAddress(_contract));
-        address owner = ccontract.owner();
-
-        address safe = mustGetAddress("SystemOwnerSafe");
-        if (owner != safe) {
-            console.log("Contract owner: %s", address(owner));
-            console.log("Caller : %s", msg.sender);
-            ccontract.transferOwnership(safe);
-            console.log("%s ownership transferred to Safe at: %s ", _contract, safe);
-        }
     }
 
     /// @notice Deploy all of the proxies
@@ -1076,6 +1059,7 @@ contract Deploy is Deployer {
         console.log("Upgrading and initializing SystemConfig proxy");
         address systemConfigProxy = mustGetAddress("SystemConfigProxy");
         address systemConfig = mustGetAddress("SystemConfig");
+        address safe = mustGetAddress("SystemOwnerSafe");
 
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
@@ -1090,7 +1074,7 @@ contract Deploy is Deployer {
             _innerCallData: abi.encodeCall(
                 SystemConfig.initialize,
                 (
-                    cfg.finalSystemOwner(),
+                    safe,
                     cfg.basefeeScalar(),
                     cfg.blobbasefeeScalar(),
                     batcherHash,
@@ -1365,7 +1349,7 @@ contract Deploy is Deployer {
         address protocolVersionsProxy = mustGetAddress("ProtocolVersionsProxy");
         address protocolVersions = mustGetAddress("ProtocolVersions");
 
-        address finalSystemOwner = cfg.finalSystemOwner();
+        address safe = mustGetAddress("SystemOwnerSafe");
         uint256 requiredProtocolVersion = cfg.requiredProtocolVersion();
         uint256 recommendedProtocolVersion = cfg.recommendedProtocolVersion();
 
@@ -1375,7 +1359,7 @@ contract Deploy is Deployer {
             _innerCallData: abi.encodeCall(
                 ProtocolVersions.initialize,
                 (
-                    finalSystemOwner,
+                    safe,
                     ProtocolVersion.wrap(requiredProtocolVersion),
                     ProtocolVersion.wrap(recommendedProtocolVersion)
                 )

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -93,6 +93,7 @@ contract DeployConfig is Script {
     bool public useInterop;
 
     bool public deployCeloContracts;
+    bool public safeAsOwner;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -181,6 +182,7 @@ contract DeployConfig is Script {
 
         // Celo specific config
         deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
+        safeAsOwner = _readOr(_json, "$.safeAsOwner", false);
     }
 
     function fork() public view returns (Fork fork_) {

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -97,6 +97,7 @@ cat << EOL > tmp_config.json
   "gasPriceOracleScalar": 1000000,
 
   "deployCeloContracts": $DEPLOY_CELO_CONTRACTS,
+  "safeAsOwner": $SAFE_AS_OWNER,
 
   "enableGovernance": $ENABLE_GOVERNANCE,
   "governanceTokenSymbol": "OP",

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -43,6 +43,7 @@ reqenv "USE_ALTDA"
 reqenv "DEPLOY_CELO_CONTRACTS"
 reqenv "USE_CUSTOM_GAS_TOKEN"
 reqenv "CUSTOM_GAS_TOKEN_ADDRESS"
+reqenv "SAFE_AS_OWNER"
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")
@@ -165,7 +166,8 @@ cat << EOL >> tmp_config.json
   "daResolveWindow": 1,
 
   "useCustomGasToken": $USE_CUSTOM_GAS_TOKEN,
-  "customGasTokenAddress": "$CUSTOM_GAS_TOKEN_ADDRESS"
+  "customGasTokenAddress": "$CUSTOM_GAS_TOKEN_ADDRESS",
+  "safeAsOwner": $SAFE_AS_OWNER
 }
 EOL
 


### PR DESCRIPTION
Sets the ownership of two proxy contracts (SystemConfigProxy and ProtocolVersionsProxy) to the SystemOwnerSafe contract during deployment if the correct config var is set. This removes the deployment account from directly owning L1 contracts, and instead indirectly owns them through multisig membership.

closes https://github.com/celo-org/celo-blockchain-planning/issues/518