### PR TITLE
migration: Set fields correctly for migration block

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -383,7 +383,7 @@ func runStateMigration(newDBPath string, opts stateMigrationOptions) error {
 	}
 
 	// Write changes to state to actual state database
-	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, newDBPath, opts.migrationBlockTime)
+	cel2Header, err := applyStateMigrationChanges(config, l2Genesis, newDBPath, opts.migrationBlockTime, l1StartBlock)
 	if err != nil {
 		return err
 	}

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -81,7 +81,7 @@ var (
 	}
 )
 
-func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string, migrationBlockTime uint64) (*types.Header, error) {
+func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Genesis, dbPath string, migrationBlockTime uint64, l1StartBlock *types.Block) (*types.Header, error) {
 	log.Info("Opening Celo database", "dbPath", dbPath)
 
 	ldb, err := openDBWithoutFreezer(dbPath, false)
@@ -166,26 +166,31 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 	}
 	// Create the header for the Cel2 transition block.
 	cel2Header := &types.Header{
-		ParentHash:       header.Hash(),
-		UncleHash:        types.EmptyUncleHash,
-		Coinbase:         predeploys.SequencerFeeVaultAddr,
-		Root:             newRoot,
-		TxHash:           types.EmptyTxsHash,
-		ReceiptHash:      types.EmptyReceiptsHash,
-		Bloom:            types.Bloom{},
-		Difficulty:       new(big.Int).Set(common.Big0),
-		Number:           migrationBlock,
-		GasLimit:         gasLimit,
-		GasUsed:          0,
-		Time:             migrationBlockTime,
-		Extra:            []byte("CeL2 migration"),
-		MixDigest:        common.Hash{},
-		Nonce:            types.BlockNonce{},
-		BaseFee:          baseFee,
-		WithdrawalsHash:  &types.EmptyWithdrawalsHash,
-		BlobGasUsed:      new(uint64),
-		ExcessBlobGas:    new(uint64),
-		ParentBeaconRoot: &common.Hash{},
+		ParentHash:  header.Hash(),
+		UncleHash:   types.EmptyUncleHash,
+		Coinbase:    predeploys.SequencerFeeVaultAddr,
+		Root:        newRoot,
+		TxHash:      types.EmptyTxsHash,
+		ReceiptHash: types.EmptyReceiptsHash,
+		Bloom:       types.Bloom{},
+		Difficulty:  new(big.Int).Set(common.Big0),
+		Number:      migrationBlock,
+		GasLimit:    gasLimit,
+		GasUsed:     0,
+		Time:        migrationBlockTime,
+		Extra:       []byte("Celo L2 migration"),
+		MixDigest:   common.Hash{},
+		Nonce:       types.BlockNonce{},
+		BaseFee:     baseFee,
+		// Added during Shanghai hardfork
+		// As there're no withdrawals in L2, we set it to the empty hash
+		WithdrawalsHash: &types.EmptyWithdrawalsHash,
+		// Blobs are disabled in L2
+		BlobGasUsed:   new(uint64),
+		ExcessBlobGas: new(uint64),
+		// This is set to the ParentBeaconRoot of the L1 origin (see `PreparePayloadAttributes`)
+		// Use the L1 start block's ParentBeaconRoot
+		ParentBeaconRoot: l1StartBlock.Header().ParentBeaconRoot,
 	}
 	log.Info("Build Cel2 migration header", "header", cel2Header)
 
@@ -230,14 +235,14 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 	cfg.CancunTime = &cel2Header.Time
 
 	// Set the Optimism options.
-	cfg.BedrockBlock = cel2Block.Number()
-	// Enable Regolith from the start of Bedrock
-	cfg.RegolithTime = new(uint64) // what are those? do we need those?
 	cfg.Optimism = &params.OptimismConfig{
 		EIP1559Denominator:       config.EIP1559Denominator,
 		EIP1559DenominatorCanyon: &config.EIP1559DenominatorCanyon,
 		EIP1559Elasticity:        config.EIP1559Elasticity,
 	}
+	// Set Optimism hardforks
+	cfg.BedrockBlock = cel2Block.Number()
+	cfg.RegolithTime = &cel2Header.Time
 	cfg.CanyonTime = &cel2Header.Time
 	cfg.EcotoneTime = &cel2Header.Time
 	cfg.FjordTime = &cel2Header.Time
@@ -245,11 +250,11 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, genesis *core.Gene
 
 	// Write the chain config to disk.
 	rawdb.WriteChainConfig(ldb, genesisHash, cfg)
-	marhslledConfig, err := json.Marshal(cfg)
+	marshalledConfig, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal chain config to JSON: %w", err)
 	}
-	log.Info("Wrote updated chain config", "config", string(marhslledConfig))
+	log.Info("Wrote updated chain config", "config", string(marshalledConfig))
 
 	// We're done!
 	log.Info(


### PR DESCRIPTION
The Shanghai and Cancun forks added new header fields.

Until now we were setting them with bogus data during the migration, this PR sets the `ParentBeaconRoot` to the correct value.

This doesn't write the `ParentBeaconRoot` to the EIP4788 contract. I started implementing this, but it turned out quite complicated. As the value, which would be written during the migration, would be overwritten in 4.5 hours (8191*2/60/60) for 2s blocks, I think it's not required for the migration.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/350