### PR TITLE
Use RPC URLs from env in JS tests

### DIFF
--- a/op-e2e/celo/shared.sh
+++ b/op-e2e/celo/shared.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #shellcheck disable=SC2034  # unused vars make sense in a shared file
 
-export ETH_RPC_URL=http://127.0.0.1:9545
-export ETH_RPC_URL_L1=http://127.0.0.1:8545
+export ETH_RPC_URL=http://localhost:9545
+export ETH_RPC_URL_L1=http://localhost:8545
 
 export ACC_PRIVKEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ACC_ADDR=$(cast wallet address $ACC_PRIVKEY)

--- a/op-e2e/celo/src/chain.js
+++ b/op-e2e/celo/src/chain.js
@@ -2,6 +2,7 @@ import { chainConfig } from 'viem/op-stack'
 import { defineChain } from 'viem'
 
 export function makeChainConfigs(l1ChainID, l2ChainID, contractAddresses) {
+  console.log(process.env)
   return {
     l2: defineChain({
       formatters: {
@@ -19,7 +20,7 @@ export function makeChainConfigs(l1ChainID, l2ChainID, contractAddresses) {
       },
       rpcUrls: {
         default: {
-          http: ['http://localhost:9545'],
+          http: [process.env.ETH_RPC_URL],
         },
       },
       contracts: {
@@ -52,7 +53,7 @@ export function makeChainConfigs(l1ChainID, l2ChainID, contractAddresses) {
       },
       rpcUrls: {
         default: {
-          http: ['http://localhost:8545'],
+          http: [process.env.ETH_RPC_URL_L1],
         },
       },
       contracts: {

--- a/op-e2e/celo/test_npm.sh
+++ b/op-e2e/celo/test_npm.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#shellcheck disable=SC1091
 set -eo pipefail
 
+source shared.sh
 npm test


### PR DESCRIPTION
This makes sure we use the same configuration across all tests.