### PR TITLE
op-node: Stall block creation when block finalization lags behind

### DIFF
--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -24,4 +24,6 @@ type Config struct {
 	// SequencerUseFinalized is true when the sequencer should use only finalized L1 blocks as origin.
 	// If this is set to true, the value of `SequencerConfDepth` is ignored.
 	SequencerUseFinalized bool `json:"sequencer_use_finalized"`
+
+	SequencerMaxFinalizedLag uint64 `json:"sequencer_max_finalized_lag"`
 }

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,8 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// SequencerUseFinalized is true when the sequencer should use only finalized L1 blocks as origin.
+	// If this is set to true, the value of `SequencerConfDepth` is ignored.
+	SequencerUseFinalized bool `json:"sequencer_use_finalized"`
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -176,8 +176,13 @@ func NewDriver(
 
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
-	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
-	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
+	var l1Fetcher L1Blocks
+	if driverCfg.SequencerUseFinalized {
+		l1Fetcher = NewFinalized(l1State.L1Finalized, l1)
+	} else {
+		l1Fetcher = NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
+	}
+	findL1Origin := NewL1OriginSelector(log, cfg, l1Fetcher)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	ec := engine.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode, synchronousEvents)
 	engineResetDeriver := engine.NewEngineResetDeriver(driverCtx, log, cfg, l1, l2, syncCfg, synchronousEvents)

--- a/op-node/rollup/driver/finalized.go
+++ b/op-node/rollup/driver/finalized.go
@@ -1,0 +1,33 @@
+package driver
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type finalized struct {
+	derive.L1Fetcher
+	l1Finalized func() eth.L1BlockRef
+}
+
+func NewFinalized(l1Finalized func() eth.L1BlockRef, fetcher derive.L1Fetcher) *finalized {
+	return &finalized{L1Fetcher: fetcher, l1Finalized: l1Finalized}
+}
+
+func (f *finalized) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	// Don't apply the finalized wrapper if l1Finalized is empty (as it is during the startup case before the l1State is initialized).
+	l1Finalized := f.l1Finalized()
+	if l1Finalized == (eth.L1BlockRef{}) {
+		return f.L1Fetcher.L1BlockRefByNumber(ctx, num)
+	}
+	if num == 0 || num <= l1Finalized.Number {
+		return f.L1Fetcher.L1BlockRefByNumber(ctx, num)
+	}
+	return eth.L1BlockRef{}, ethereum.NotFound
+}
+
+var _ derive.L1Fetcher = (*finalized)(nil)

--- a/op-node/rollup/driver/finalized_test.go
+++ b/op-node/rollup/driver/finalized_test.go
@@ -1,0 +1,56 @@
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+type finalizedTest struct {
+	name  string
+	final uint64
+	hash  common.Hash // hash of finalized block
+	req   uint64
+	pass  bool
+}
+
+func (ft *finalizedTest) Run(t *testing.T) {
+	l1Fetcher := &testutils.MockL1Source{}
+	l1Finalized := eth.L1BlockRef{Number: ft.final, Hash: ft.hash}
+	l1FinalizedGetter := func() eth.L1BlockRef { return l1Finalized }
+
+	f := NewFinalized(l1FinalizedGetter, l1Fetcher)
+
+	if ft.pass {
+		// no calls to the l1Fetcher are made if the block number is not finalized yet
+		l1Fetcher.ExpectL1BlockRefByNumber(ft.req, eth.L1BlockRef{Number: ft.req}, nil)
+	}
+
+	out, err := f.L1BlockRefByNumber(context.Background(), ft.req)
+	l1Fetcher.AssertExpectations(t)
+
+	if ft.pass {
+		require.NoError(t, err)
+		require.Equal(t, out, eth.L1BlockRef{Number: ft.req})
+	} else {
+		require.Equal(t, ethereum.NotFound, err)
+	}
+}
+
+func TestFinalized(t *testing.T) {
+	testCases := []finalizedTest{
+		{name: "finalized", final: 10, hash: exHash, req: 10, pass: true},
+		{name: "finalized past", final: 10, hash: exHash, req: 8, pass: true},
+		{name: "not finalized", final: 10, hash: exHash, req: 11, pass: false},
+		{name: "no L1 state", req: 10, pass: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.Run)
+	}
+}


### PR DESCRIPTION
Builds on #209 

- Use finalized block for derivation pipeline as well
- Use finalized block when loading runtime config
- Stall block creation when block finalization lags behind