### PR TITLE
migration: Add tests

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -273,14 +273,14 @@ func applyAllocsToState(db vm.StateDB, genesis *core.Genesis, allowlist map[comm
 			if db.GetCodeSize(k) == 0 && db.GetNonce(k) == 0 {
 				overwrite = true
 			}
-
-			overwriteCounter++
 		}
 
 		// This carries over any existing balance
 		db.CreateAccount(k)
 
 		if overwrite {
+			overwriteCounter++
+
 			db.SetCode(k, v.Code)
 			db.SetNonce(k, v.Nonce)
 			for key, value := range v.Storage {

--- a/op-chain-ops/cmd/celo-migrate/state_test.go
+++ b/op-chain-ops/cmd/celo-migrate/state_test.go
@@ -7,138 +7,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 )
-
-type mockDB struct {
-	accounts map[common.Address]*types.Account
-}
-
-func (db *mockDB) CreateAccount(addr common.Address) {
-	account, ok := db.accounts[addr]
-	db.accounts[addr] = &types.Account{
-		Balance: big.NewInt(0),
-	}
-	if ok {
-		db.accounts[addr].Balance = account.Balance
-	}
-}
-
-func (db *mockDB) SubBalance(common.Address, *uint256.Int) {}
-
-func (db *mockDB) AddBalance(common.Address, *uint256.Int) {}
-
-func (db *mockDB) GetBalance(addr common.Address) *uint256.Int {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return common.U2560
-	}
-	return uint256.MustFromBig(account.Balance)
-}
-
-func (db *mockDB) GetNonce(addr common.Address) uint64 {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return 0
-	}
-	return account.Nonce
-}
-
-func (db *mockDB) SetNonce(addr common.Address, nonce uint64) {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return
-	}
-	account.Nonce = nonce
-}
-
-func (db *mockDB) GetCodeHash(common.Address) common.Hash {
-	return common.Hash{}
-}
-
-func (db *mockDB) GetCode(addr common.Address) []byte {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return []byte{}
-	}
-	return account.Code
-}
-
-func (db *mockDB) SetCode(addr common.Address, code []byte) {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return
-	}
-	account.Code = code
-}
-
-func (db *mockDB) GetCodeSize(addr common.Address) int {
-	account, ok := db.accounts[addr]
-	if !ok {
-		return 0
-	}
-	return len(account.Code)
-}
-
-func (db *mockDB) AddRefund(uint64) {}
-func (db *mockDB) SubRefund(uint64) {}
-func (db *mockDB) GetRefund() uint64 {
-	return 0
-}
-
-func (db *mockDB) GetCommittedState(common.Address, common.Hash) common.Hash {
-	return common.Hash{}
-}
-func (db *mockDB) GetState(common.Address, common.Hash) common.Hash {
-	return common.Hash{}
-}
-func (db *mockDB) SetState(common.Address, common.Hash, common.Hash) {
-
-}
-
-func (db *mockDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash{}
-}
-func (db *mockDB) SetTransientState(addr common.Address, key, value common.Hash) {}
-
-func (db *mockDB) SelfDestruct(common.Address) {}
-func (db *mockDB) HasSelfDestructed(common.Address) bool {
-	return false
-}
-
-func (db *mockDB) Selfdestruct6780(common.Address) {}
-
-func (db *mockDB) Exist(addr common.Address) bool {
-	_, exists := db.accounts[addr]
-	return exists
-}
-
-func (db *mockDB) Empty(addr common.Address) bool {
-	return !db.Exist(addr)
-}
-
-func (db *mockDB) AddressInAccessList(addr common.Address) bool {
-	return false
-}
-func (db *mockDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	return false, false
-}
-func (db *mockDB) AddAddressToAccessList(addr common.Address) {}
-
-func (db *mockDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {}
-func (db *mockDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-}
-
-func (db *mockDB) RevertToSnapshot(int) {}
-func (db *mockDB) Snapshot() int {
-	return 0
-}
-
-func (db *mockDB) AddLog(*types.Log)               {}
-func (db *mockDB) AddPreimage(common.Hash, []byte) {}
 
 var (
 	contractCode         = []byte{0x01, 0x02}
@@ -146,30 +20,11 @@ var (
 )
 
 func TestApplyAllocsToState(t *testing.T) {
-	db := mockDB{
-		accounts: map[common.Address]*types.Account{
-			common.HexToAddress("a"): {
-				Balance: big.NewInt(defaultBalance),
-			},
-			common.HexToAddress("b"): {
-				Balance: big.NewInt(defaultBalance),
-				Code:    bytes.Repeat([]byte{0x01}, 10),
-			},
-			common.HexToAddress("c"): {
-				Balance: big.NewInt(defaultBalance),
-				Nonce:   5,
-			},
-			common.HexToAddress("d"): {
-				Balance: big.NewInt(defaultBalance),
-				Code:    bytes.Repeat([]byte{0x01}, 10),
-			},
-		},
-	}
-
 	tests := []struct {
 		name             string
 		addr             common.Address
-		account          types.Account
+		existingAccount  *types.Account
+		newAccount       types.Account
 		allowlist        map[common.Address]bool
 		balanceInAccount bool
 		wantErr          bool
@@ -177,7 +32,7 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Write to empty account",
 			addr: common.HexToAddress("01"),
-			account: types.Account{
+			newAccount: types.Account{
 				Code:  contractCode,
 				Nonce: 1,
 			},
@@ -187,7 +42,10 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Copy account with non-zero balance fails",
 			addr: common.HexToAddress("a"),
-			account: types.Account{
+			existingAccount: &types.Account{
+				Balance: big.NewInt(defaultBalance),
+			},
+			newAccount: types.Account{
 				Balance: big.NewInt(1),
 			},
 			wantErr: true,
@@ -195,7 +53,10 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Write to account with only balance should overwrite and keep balance",
 			addr: common.HexToAddress("a"),
-			account: types.Account{
+			existingAccount: &types.Account{
+				Balance: big.NewInt(defaultBalance),
+			},
+			newAccount: types.Account{
 				Code:  contractCode,
 				Nonce: 5,
 			},
@@ -205,7 +66,11 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Write to account with existing nonce fails",
 			addr: common.HexToAddress("c"),
-			account: types.Account{
+			existingAccount: &types.Account{
+				Balance: big.NewInt(defaultBalance),
+				Nonce:   5,
+			},
+			newAccount: types.Account{
 				Code:  contractCode,
 				Nonce: 5,
 			},
@@ -214,7 +79,11 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Write to account with contract code fails",
 			addr: common.HexToAddress("b"),
-			account: types.Account{
+			existingAccount: &types.Account{
+				Balance: big.NewInt(defaultBalance),
+				Code:    bytes.Repeat([]byte{0x01}, 10),
+			},
+			newAccount: types.Account{
 				Code:  contractCode,
 				Nonce: 5,
 			},
@@ -223,7 +92,11 @@ func TestApplyAllocsToState(t *testing.T) {
 		{
 			name: "Write account with allowlist overwrites",
 			addr: common.HexToAddress("d"),
-			account: types.Account{
+			existingAccount: &types.Account{
+				Balance: big.NewInt(defaultBalance),
+				Code:    bytes.Repeat([]byte{0x01}, 10),
+			},
+			newAccount: types.Account{
 				Code:  contractCode,
 				Nonce: 5,
 			},
@@ -234,7 +107,25 @@ func TestApplyAllocsToState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := applyAllocsToState(&db, &core.Genesis{Alloc: types.GenesisAlloc{tt.addr: tt.account}}, tt.allowlist); (err != nil) != tt.wantErr {
+			db := rawdb.NewMemoryDatabase()
+			tdb := state.NewDatabase(db)
+			sdb, _ := state.New(types.EmptyRootHash, tdb, nil)
+
+			if tt.existingAccount != nil {
+				sdb.CreateAccount(tt.addr)
+
+				if tt.existingAccount.Balance != nil {
+					sdb.SetBalance(tt.addr, uint256.MustFromBig(tt.existingAccount.Balance))
+				}
+				if tt.existingAccount.Nonce != 0 {
+					sdb.SetNonce(tt.addr, tt.existingAccount.Nonce)
+				}
+				if tt.existingAccount.Code != nil {
+					sdb.SetCode(tt.addr, tt.existingAccount.Code)
+				}
+			}
+
+			if err := applyAllocsToState(sdb, &core.Genesis{Alloc: types.GenesisAlloc{tt.addr: tt.newAccount}}, tt.allowlist); (err != nil) != tt.wantErr {
 				t.Errorf("applyAllocsToState() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -243,18 +134,17 @@ func TestApplyAllocsToState(t *testing.T) {
 				return
 			}
 
-			account, exists := db.accounts[tt.addr]
-			if !exists {
+			if !sdb.Exist(tt.addr) {
 				t.Errorf("account does not exists as expected: %v", tt.addr.Hex())
 			}
 
-			assert.Equal(t, tt.account.Nonce, account.Nonce)
-			assert.Equal(t, tt.account.Code, account.Code)
+			assert.Equal(t, tt.newAccount.Nonce, sdb.GetNonce(tt.addr))
+			assert.Equal(t, tt.newAccount.Code, sdb.GetCode(tt.addr))
 
 			if tt.balanceInAccount {
-				assert.Equal(t, big.NewInt(defaultBalance), account.Balance)
+				assert.True(t, big.NewInt(defaultBalance).Cmp(sdb.GetBalance(tt.addr).ToBig()) == 0)
 			} else {
-				assert.Equal(t, big.NewInt(0), account.Balance)
+				assert.True(t, big.NewInt(0).Cmp(sdb.GetBalance(tt.addr).ToBig()) == 0)
 			}
 		})
 	}

--- a/op-chain-ops/cmd/celo-migrate/state_test.go
+++ b/op-chain-ops/cmd/celo-migrate/state_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDB struct {
+	accounts map[common.Address]*types.Account
+}
+
+func (db *mockDB) CreateAccount(addr common.Address) {
+	account, ok := db.accounts[addr]
+	db.accounts[addr] = &types.Account{
+		Balance: big.NewInt(0),
+	}
+	if ok {
+		db.accounts[addr].Balance = account.Balance
+	}
+}
+
+func (db *mockDB) SubBalance(common.Address, *uint256.Int) {}
+
+func (db *mockDB) AddBalance(common.Address, *uint256.Int) {}
+
+func (db *mockDB) GetBalance(addr common.Address) *uint256.Int {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return common.U2560
+	}
+	return uint256.MustFromBig(account.Balance)
+}
+
+func (db *mockDB) GetNonce(addr common.Address) uint64 {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return 0
+	}
+	return account.Nonce
+}
+
+func (db *mockDB) SetNonce(addr common.Address, nonce uint64) {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return
+	}
+	account.Nonce = nonce
+}
+
+func (db *mockDB) GetCodeHash(common.Address) common.Hash {
+	return common.Hash{}
+}
+
+func (db *mockDB) GetCode(addr common.Address) []byte {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return []byte{}
+	}
+	return account.Code
+}
+
+func (db *mockDB) SetCode(addr common.Address, code []byte) {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return
+	}
+	account.Code = code
+}
+
+func (db *mockDB) GetCodeSize(addr common.Address) int {
+	account, ok := db.accounts[addr]
+	if !ok {
+		return 0
+	}
+	return len(account.Code)
+}
+
+func (db *mockDB) AddRefund(uint64) {}
+func (db *mockDB) SubRefund(uint64) {}
+func (db *mockDB) GetRefund() uint64 {
+	return 0
+}
+
+func (db *mockDB) GetCommittedState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (db *mockDB) GetState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (db *mockDB) SetState(common.Address, common.Hash, common.Hash) {
+
+}
+
+func (db *mockDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (db *mockDB) SetTransientState(addr common.Address, key, value common.Hash) {}
+
+func (db *mockDB) SelfDestruct(common.Address) {}
+func (db *mockDB) HasSelfDestructed(common.Address) bool {
+	return false
+}
+
+func (db *mockDB) Selfdestruct6780(common.Address) {}
+
+func (db *mockDB) Exist(addr common.Address) bool {
+	_, exists := db.accounts[addr]
+	return exists
+}
+
+func (db *mockDB) Empty(addr common.Address) bool {
+	return !db.Exist(addr)
+}
+
+func (db *mockDB) AddressInAccessList(addr common.Address) bool {
+	return false
+}
+func (db *mockDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	return false, false
+}
+func (db *mockDB) AddAddressToAccessList(addr common.Address) {}
+
+func (db *mockDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {}
+func (db *mockDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+}
+
+func (db *mockDB) RevertToSnapshot(int) {}
+func (db *mockDB) Snapshot() int {
+	return 0
+}
+
+func (db *mockDB) AddLog(*types.Log)               {}
+func (db *mockDB) AddPreimage(common.Hash, []byte) {}
+
+var (
+	contractCode         = []byte{0x01, 0x02}
+	defaultBalance int64 = 123
+)
+
+func TestApplyAllocsToState(t *testing.T) {
+	db := mockDB{
+		accounts: map[common.Address]*types.Account{
+			common.HexToAddress("a"): {
+				Balance: big.NewInt(defaultBalance),
+			},
+			common.HexToAddress("b"): {
+				Balance: big.NewInt(defaultBalance),
+				Code:    bytes.Repeat([]byte{0x01}, 10),
+			},
+			common.HexToAddress("c"): {
+				Balance: big.NewInt(defaultBalance),
+				Nonce:   5,
+			},
+		},
+	}
+
+	config := &params.ChainConfig{
+		ChainID: big.NewInt(1),
+	}
+
+	tests := []struct {
+		name             string
+		addr             common.Address
+		account          types.Account
+		balanceInAccount bool
+		wantErr          bool
+	}{
+		{
+			name: "Write to empty account",
+			addr: common.HexToAddress("01"),
+			account: types.Account{
+				Code:  contractCode,
+				Nonce: 1,
+			},
+			balanceInAccount: false,
+			wantErr:          false,
+		},
+		{
+			name: "Write to account with only balance should overwrite and keep balance",
+			addr: common.HexToAddress("a"),
+			account: types.Account{
+				Code:  contractCode,
+				Nonce: 5,
+			},
+			balanceInAccount: true,
+			wantErr:          false,
+		},
+		{
+			name: "Write to account with existing nonce fails",
+			addr: common.HexToAddress("c"),
+			account: types.Account{
+				Code:  contractCode,
+				Nonce: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Write to account with contract code fails",
+			addr: common.HexToAddress("b"),
+			account: types.Account{
+				Code:  contractCode,
+				Nonce: 5,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := applyAllocsToState(&db, &core.Genesis{Alloc: types.GenesisAlloc{tt.addr: tt.account}}, config); (err != nil) != tt.wantErr {
+				t.Errorf("applyAllocsToState() error = %v, wantErr %v", err, tt.wantErr)
+
+				account, exists := db.accounts[tt.addr]
+				if !exists {
+					t.Errorf("account does not exists as expected: %v", tt.addr.Hex())
+				}
+
+				assert.Equal(t, tt.account.Nonce, account.Nonce)
+				assert.Equal(t, tt.account.Code, account.Code)
+
+				if tt.balanceInAccount {
+					assert.Equal(t, big.NewInt(defaultBalance), account.Balance)
+				} else {
+					assert.Equal(t, big.NewInt(0), account.Balance)
+				}
+			}
+		})
+	}
+}

--- a/op-chain-ops/cmd/celo-migrate/state_test.go
+++ b/op-chain-ops/cmd/celo-migrate/state_test.go
@@ -162,14 +162,11 @@ func TestApplyAllocsToState(t *testing.T) {
 		},
 	}
 
-	config := &params.ChainConfig{
-		ChainID: big.NewInt(1),
-	}
-
 	tests := []struct {
 		name             string
 		addr             common.Address
 		account          types.Account
+		allowlist        map[common.Address]bool
 		balanceInAccount bool
 		wantErr          bool
 	}{
@@ -214,7 +211,7 @@ func TestApplyAllocsToState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := applyAllocsToState(&db, &core.Genesis{Alloc: types.GenesisAlloc{tt.addr: tt.account}}, config); (err != nil) != tt.wantErr {
+			if err := applyAllocsToState(&db, &core.Genesis{Alloc: types.GenesisAlloc{tt.addr: tt.account}}, tt.allowlist); (err != nil) != tt.wantErr {
 				t.Errorf("applyAllocsToState() error = %v, wantErr %v", err, tt.wantErr)
 
 				account, exists := db.accounts[tt.addr]


### PR DESCRIPTION
Adds test for the state migration.

- Fixes a problem where accounts with some balance but no other state would not be overwritten. This is common and should be handled. This was introduced in https://github.com/celo-org/optimism/pull/202