### PR TITLE
Increase MaxFrameLen to 16 MB

### DIFF
--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -85,7 +85,7 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 		return fmt.Errorf("reading frame_data_length: %w", eofAsUnexpectedMissing(err))
 	}
 
-	// Cap frame length to MaxFrameLen (currently 1MB)
+	// Cap frame length to MaxFrameLen
 	if frameLength > MaxFrameLen {
 		return fmt.Errorf("frame_data_length is too large: %d", frameLength)
 	}

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -8,10 +8,11 @@ import (
 	"io"
 )
 
-// Frames cannot be larger than 1 MB.
+// For EthDA, frames cannot be larger than 1 MB.
 // Data transactions that carry frames are generally not larger than 128 KB due to L1 network conditions,
 // but we leave space to grow larger anyway (gas limit allows for more data).
-const MaxFrameLen = 1_000_000
+// For AltDA, frames size can be larger. Setting to 16 MB as current blob limit for EigenDA.
+const MaxFrameLen = 16_000_000
 
 // Data Format
 //

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -8,7 +8,6 @@ import (
 	"io"
 )
 
-// For EthDA, frames cannot be larger than 1 MB.
 // Data transactions that carry frames are generally not larger than 128 KB due to L1 network conditions,
 // but we leave space to grow larger anyway (gas limit allows for more data).
 // For AltDA, frames size can be larger. Setting to 16 MB as current blob limit for EigenDA.


### PR DESCRIPTION
EigenDA current limit for Holesky (their documentation is currently outdated but the limit seems to be set to 16 MB based on the updated tests from [this PR](https://github.com/Layr-Labs/eigenda-proxy/pull/100)).