### PR TITLE
migration: Overwrite create2deployer code

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/state_test.go
+++ b/op-chain-ops/cmd/celo-migrate/state_test.go
@@ -82,9 +82,10 @@ func TestApplyAllocsToState(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Write account with allowlist overwrites",
+			name: "Write account with allowlist overwrite, keeps nonce",
 			existingAccount: &types.Account{
 				Balance: big.NewInt(defaultBalance),
+				Nonce:   4,
 				Code:    bytes.Repeat([]byte{0x01}, 10),
 			},
 			newAccount: types.Account{
@@ -128,8 +129,13 @@ func TestApplyAllocsToState(t *testing.T) {
 				t.Errorf("account does not exists as expected: %v", address.Hex())
 			}
 
-			assert.Equal(t, tt.newAccount.Nonce, sdb.GetNonce(address))
 			assert.Equal(t, tt.newAccount.Code, sdb.GetCode(address))
+
+			if tt.existingAccount != nil && tt.existingAccount.Nonce != 0 {
+				assert.Equal(t, tt.existingAccount.Nonce, sdb.GetNonce(address))
+			} else {
+				assert.Equal(t, tt.newAccount.Nonce, sdb.GetNonce(address))
+			}
 
 			if tt.existingAccount != nil {
 				assert.True(t, big.NewInt(defaultBalance).Cmp(sdb.GetBalance(address).ToBig()) == 0)


### PR DESCRIPTION
Resolves https://github.com/celo-org/celo-blockchain-planning/issues/551

This PR changes the migration to override the `create2deployer` contract code during the migration. OP recommends using that version and [overrides the contract code during the Canyon hardfork](https://github.com/celo-org/op-geth/blob/17790d882c77000709194fcfb54564a8ef9c57d9/consensus/misc/create2deployer.go#L19-L38).

As only the code, but not the nonce or state, must be changed, this requires small changes to the migration code.