### PR TITLE
migration: Make migration-block-time a required flag

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -66,8 +66,9 @@ var (
 		Required: true,
 	}
 	migrationBlockTimeFlag = &cli.Uint64Flag{
-		Name:  "migration-block-time",
-		Usage: "Specifies a unix timestamp to use for the migration block. If not provided, the current time will be used.",
+		Name:     "migration-block-time",
+		Usage:    "Specifies a unix timestamp to use for the migration block. This should be set to the same timestamp as was used for the sequencer migration. If performing the sequencer migration, this should set to a time in the future around when the migration script is expected to complete.",
+		Required: true,
 	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
@@ -157,7 +156,9 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, l2Allocs types.Gen
 	}
 
 	if migrationBlockTime == 0 {
-		migrationBlockTime = uint64(time.Now().Unix())
+		// If the migration block time is not set, use the time of the last block incremented by one.
+		// This makes sure the migration is deterministic.
+		migrationBlockTime = header.Time + config.L2BlockTime
 	}
 
 	// Set the standard options.

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -155,12 +155,6 @@ func applyStateMigrationChanges(config *genesis.DeployConfig, l2Allocs types.Gen
 		return nil, err
 	}
 
-	if migrationBlockTime == 0 {
-		// If the migration block time is not set, use the time of the last block incremented by one.
-		// This makes sure the migration is deterministic.
-		migrationBlockTime = header.Time + config.L2BlockTime
-	}
-
 	// Set the standard options.
 	cfg.LondonBlock = migrationBlockNumber
 	cfg.BerlinBlock = migrationBlockNumber


### PR DESCRIPTION
Resolves https://github.com/celo-org/celo-blockchain-planning/issues/627

By making the flag required, we ensure node operators will always add one. So long as the correct number is passed as an argument (to be shared by the sequencer) the resulting block hash will match the sequencer's 