### PR TITLE
Update op-geth dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20240925125220-83ce94f606e4
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003173630-fd593f27afa2
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297 h1:KFM2tTv01/3uQLG/ibNzNHx3v0ETzhF5+220RiiAP2s=
-github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd h1:HFYXyaD3rarL+v5nrjYSnpB2EWUkqcw8hELbTbbz1gQ=
+github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20240925125220-83ce94f606e4 h1:YlNGQZukgmhSu+uQeKpttK599ZiGYLVZ4lqb6LnAM2w=
-github.com/celo-org/op-geth v1.101408.1-0.20240925125220-83ce94f606e4/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297 h1:KFM2tTv01/3uQLG/ibNzNHx3v0ETzhF5+220RiiAP2s=
+github.com/celo-org/op-geth v1.101408.1-0.20241001133457-97726b604297/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187 h1:m5Nv4NSNEUc2Svaht/xWyv3fBJQ2oU1FL3WYySiS1l4=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3 h1:RbbJgb6L8z0OwQXGSMmJ1ESuAUnBOXBLygfxa1F+FtU=
+github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3 h1:RbbJgb6L8z0OwQXGSMmJ1ESuAUnBOXBLygfxa1F+FtU=
-github.com/celo-org/op-geth v1.101408.1-0.20241003144129-d4f2cf367ce3/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241003173630-fd593f27afa2 h1:uNjQB6rkdWDza/dfkvBW35MAVnfXaNmE67BFr3rVR7g=
+github.com/celo-org/op-geth v1.101408.1-0.20241003173630-fd593f27afa2/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664 h1:QUEGasXB6ZGw6xwY2csvSZJKk/RuAt0elcyWUcGo8P8=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0 h1:RgxoDBCGwiX1uGW9SEqKlEcbBFWlo1hU5Uhbfrj9H/A=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0 h1:RgxoDBCGwiX1uGW9SEqKlEcbBFWlo1hU5Uhbfrj9H/A=
-github.com/celo-org/op-geth v1.101408.1-0.20241003115934-a2ee078c81b0/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187 h1:m5Nv4NSNEUc2Svaht/xWyv3fBJQ2oU1FL3WYySiS1l4=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-fd39ac075187/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd h1:HFYXyaD3rarL+v5nrjYSnpB2EWUkqcw8hELbTbbz1gQ=
-github.com/celo-org/op-geth v1.101408.1-0.20241002210005-9fb0fe6b79cd/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664 h1:QUEGasXB6ZGw6xwY2csvSZJKk/RuAt0elcyWUcGo8P8=
+github.com/celo-org/op-geth v1.101408.1-0.20241003115934-230c979b0664/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=


### PR DESCRIPTION
So this is a pretty simple pr to update the op-geth reference. Unfortunately updating the geth reference broke some stuff so we needed to fix that (fixed here https://github.com/celo-org/op-geth/pull/247) and then I think the tests are just really flaky and I didn't realise so spent some time trying different versions of op-geth but what was really required was just re-running the ci workflow.

Anyway now it seems to be working with an up to date op-geth reference.