### PR TITLE
sequencer: Use higher sequencer drift for Celo

### DIFF
--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -27,6 +27,9 @@ const (
 // ChainSpec instead of reading the rollup configuration field directly.
 const maxSequencerDriftFjord = 1800
 
+// Celo uses the finalized L1 block as the L1 origin, therefore the max sequencer drift is increased
+const MaxSequencerDriftCelo = 30_000
+
 type ForkName string
 
 const (
@@ -105,6 +108,9 @@ func (s *ChainSpec) IsFeatMaxSequencerDriftConstant(t uint64) bool {
 // should always be queried via the ChainSpec.
 func (s *ChainSpec) MaxSequencerDrift(t uint64) uint64 {
 	if s.IsFeatMaxSequencerDriftConstant(t) {
+		if s.config.IsCel2(t) {
+			return MaxSequencerDriftCelo
+		}
 		return maxSequencerDriftFjord
 	}
 	return s.config.MaxSequencerDrift

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -408,6 +408,10 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 	return c.InteropTime != nil && timestamp >= *c.InteropTime
 }
 
+func (c *Config) IsCel2(timestamp uint64) bool {
+	return c.Cel2Time != nil && timestamp >= *c.Cel2Time
+}
+
 func (c *Config) IsRegolithActivationBlock(l2BlockTime uint64) bool {
 	return c.IsRegolith(l2BlockTime) &&
 		l2BlockTime >= c.BlockTime &&


### PR DESCRIPTION
WIP to adapt sequencer drift for `use-finalized` flag.

Reference https://github.com/celo-org/celo-blockchain-planning/issues/629


## Todos
- [ ] Define concrete settings, see comments in https://github.com/celo-org/celo-blockchain-planning/issues/629#issuecomment-2386071837
- [ ] Should this be enabled for `IsCel2` or just when the `SequencerUseFinalized` setting is enabled?