### PR TITLE
Fixes for re-running migration script on same destination db 

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -113,3 +113,21 @@ func getHeadHeader(dbpath string) (*types.Header, error) {
 	}
 	return headHeader, nil
 }
+
+func cleanupNonAncientDb(dir string) error {
+	log.Info("Cleaning up non-ancient data in new db")
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+	for _, file := range files {
+		if file.Name() != "ancient" {
+			err := os.RemoveAll(filepath.Join(dir, file.Name()))
+			if err != nil {
+				return fmt.Errorf("failed to remove file: %w", err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Adds `--reset` flag to delete everything in the destination directory except for `/ancients`. This is useful as a fallback if the destination db is failing to mirror the source db after the rsync command is executed.
- Adds `--checksum` option to rsync command to ensure that file contents (rather than just size and timestamps) are used to determine which files to transfer. This provides higher certainty that the destination directory will mirror the source directory after the transfer.