### PR TITLE
OptimismPortal2 set initial `_balance` through StorageSetter pattern

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -131,6 +131,8 @@ def init_devnet_l1_deploy_config(paths, update_timestamp=False):
     if DEVNET_CELO:
         deploy_config['useFaultProofs'] = True
         deploy_config['useCustomGasToken'] = True
+        deploy_config['gasPriceOracleBlobBaseFeeScalar'] = 0
+        deploy_config['gasPriceOracleBaseFeeScalar'] = 0
         deploy_config['deployCeloContracts'] = True
         # Usage of the zero address in combination of the useCustomGasToken == True
         # will deploy a new contract

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -129,7 +129,7 @@ def init_devnet_l1_deploy_config(paths, update_timestamp=False):
     if GENERIC_ALTDA:
         deploy_config['daCommitmentType'] = "GenericCommitment"
     if DEVNET_CELO:
-        deploy_config['useFaultProofs'] = False
+        deploy_config['useFaultProofs'] = True
         deploy_config['useCustomGasToken'] = True
         deploy_config['deployCeloContracts'] = True
         # Usage of the zero address in combination of the useCustomGasToken == True

--- a/op-e2e/celo/.prettierrc.toml
+++ b/op-e2e/celo/.prettierrc.toml
@@ -1,0 +1,4 @@
+trailingComma = "es5"
+tabWidth = 2
+semi = false
+singleQuote = true

--- a/op-e2e/celo/package-lock.json
+++ b/op-e2e/celo/package-lock.json
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2494,55 +2494,58 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/curves": "~1.6.0",
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.7"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
       "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2677,9 +2680,9 @@
       "dev": true
     },
     "node_modules/abitype": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.5.tgz",
-      "integrity": "sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -3757,13 +3760,13 @@
       "dev": true
     },
     "node_modules/isows": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.4.tgz",
-      "integrity": "sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
       "funding": [
         {
           "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
+          "url": "https://github.com/sponsors/wevm"
         }
       ],
       "peerDependencies": {
@@ -6344,9 +6347,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.17.4.tgz",
-      "integrity": "sha512-6gmBB85I7z1qt/+yPPS+i4L2jNPJqCs+SEb+26WnKVYez13svSzjYMsU9OYYlPFpQmpGSy9dV2bKW6VX68FTgg==",
+      "version": "2.21.19",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.19.tgz",
+      "integrity": "sha512-FdlkN+UI1IU5sYOmzvygkxsUNjDRD5YHht3gZFu2X9xFv6Z3h9pXq9ycrYQ3F17lNfb41O2Ot4/aqbUkwOv9dA==",
       "funding": [
         {
           "type": "github",
@@ -6354,14 +6357,15 @@
         }
       ],
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.4.0",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0",
-        "abitype": "1.0.5",
-        "isows": "1.0.4",
-        "ws": "8.17.1"
+        "@adraffy/ens-normalize": "1.11.0",
+        "@noble/curves": "1.6.0",
+        "@noble/hashes": "1.5.0",
+        "@scure/bip32": "1.5.0",
+        "@scure/bip39": "1.4.0",
+        "abitype": "1.0.6",
+        "isows": "1.0.6",
+        "webauthn-p256": "0.0.10",
+        "ws": "8.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -6379,6 +6383,21 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webauthn-p256": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
+      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0"
       }
     },
     "node_modules/which": {
@@ -6466,9 +6485,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/op-e2e/celo/package-lock.json
+++ b/op-e2e/celo/package-lock.json
@@ -16,7 +16,8 @@
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
         "babel-jest": "^29.7.0",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "prettier": "3.3.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -5800,6 +5801,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/op-e2e/celo/package.json
+++ b/op-e2e/celo/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/test.js",
   "scripts": {
-    "test": "jest tests --detectOpenHandles"
+    "test": "jest tests --detectOpenHandles",
+    "format": "npx prettier . --write"
   },
   "author": "Celo Labs Inc.",
   "license": "ISC",
@@ -17,6 +18,7 @@
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "babel-jest": "^29.7.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "prettier": "3.3.3"
   }
 }

--- a/op-e2e/celo/run_all_tests.sh
+++ b/op-e2e/celo/run_all_tests.sh
@@ -10,7 +10,7 @@ if [[ $spawn_devnet != false ]]; then
   ## Start geth
   cd "$SCRIPT_DIR/../.." || exit 1
   trap 'cd "$SCRIPT_DIR/../.." && make devnet-down' EXIT # kill bg job at exit
-  DEVNET_L2OO=true DEVNET_CELO=true make devnet-up
+  DEVNET_CELO=true make devnet-up
 fi
 
 cd "$SCRIPT_DIR" || exit 1

--- a/op-e2e/celo/src/chain.js
+++ b/op-e2e/celo/src/chain.js
@@ -30,6 +30,11 @@ export function makeChainConfigs(l1ChainID, l2ChainID, contractAddresses) {
             address: contractAddresses.L2OutputOracleProxy,
           },
         },
+        disputeGameFactory: {
+          [l1ChainID]: {
+            address: contractAddresses.DisputeGameFactoryProxy,
+          },
+        },
         portal: {
           [l1ChainID]: {
             address: contractAddresses.OptimismPortalProxy,

--- a/op-e2e/celo/src/withdraw.js
+++ b/op-e2e/celo/src/withdraw.js
@@ -46,6 +46,12 @@ export const withdraw = async function (args, config) {
     targetChain: config.client.l2.public.chain,
   })
 
+  // HACK: the waitToFinalize does not seem to calculate the wait time
+  // correctly..., lets hardcode a wait time for now to see if it can work.
+  // In theory viem is not waiting an additional DISPUTE_GAME_FINALITY_DELAY_SECONDS.
+  // The current default value for this is 6, but this was not enough in manual testing.
+  // TODO: fix this upstream in viem...
+  await new Promise((res) => setTimeout(res, 16 * 1000));
   const finalizeHash = await config.client.l1.wallet.finalizeWithdrawal({
     targetChain: config.client.l2.public.chain,
     withdrawal,

--- a/op-e2e/celo/src/withdraw.js
+++ b/op-e2e/celo/src/withdraw.js
@@ -9,9 +9,10 @@ export const withdraw = async function (args, config) {
   const receipt = await config.client.l2.public.waitForTransactionReceipt({
     hash: initiateHash,
   })
+  console.log('receipt', receipt)
 
   const l2GasPayment =
-    receipt.gasUsed * receipt.effectiveGasPrice + receipt.l1Fee
+    receipt.gasUsed * receipt.effectiveGasPrice + receipt.l1fee
 
   // FIXME: this blocks longer, the longer the devnet is running, see
   // https://github.com/ethereum-optimism/optimism/issues/7668
@@ -51,7 +52,7 @@ export const withdraw = async function (args, config) {
   // In theory viem is not waiting an additional DISPUTE_GAME_FINALITY_DELAY_SECONDS.
   // The current default value for this is 6, but this was not enough in manual testing.
   // TODO: fix this upstream in viem...
-  await new Promise((res) => setTimeout(res, 16 * 1000));
+  await new Promise((res) => setTimeout(res, 16 * 1000))
   const finalizeHash = await config.client.l1.wallet.finalizeWithdrawal({
     targetChain: config.client.l2.public.chain,
     withdrawal,

--- a/op-e2e/celo/tests/setup.js
+++ b/op-e2e/celo/tests/setup.js
@@ -16,7 +16,7 @@ async function waitForNoError(func, timeout) {
     try {
       await func()
       return true
-    } catch (error) { }
+    } catch (error) {}
     await new Promise((r) => setTimeout(r, 1000))
   }
   return false
@@ -56,7 +56,7 @@ export async function setup() {
     waitReachable(config.client.l1.public, 10_000),
     waitReachable(config.client.l2.public, 10_000),
     waitForNextGame(config.client.l1.public, chainConfig.l2, 60_000),
-  ]);
+  ])
   if (success.every((v) => v == true)) {
     return config
   }

--- a/op-e2e/celo/tests/setup.js
+++ b/op-e2e/celo/tests/setup.js
@@ -27,9 +27,9 @@ async function waitReachable(client, timeout) {
   return waitForNoError(f, timeout)
 }
 
-async function waitForNextL2Output(client, l2ChainConfig, timeout) {
+async function waitForNextGame(client, l2ChainConfig, timeout) {
   const f = async () =>
-    client.waitForNextL2Output({
+    client.waitForNextGame({
       pollingInterval: 500,
       l2BlockNumber: 0,
       targetChain: l2ChainConfig,
@@ -55,8 +55,8 @@ export async function setup() {
   const success = await Promise.all([
     waitReachable(config.client.l1.public, 10_000),
     waitReachable(config.client.l2.public, 10_000),
-    waitForNextL2Output(config.client.l1.public, chainConfig.l2, 60_000),
-  ])
+    waitForNextGame(config.client.l1.public, chainConfig.l2, 60_000),
+  ]);
   if (success.every((v) => v == true)) {
     return config
   }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -423,7 +423,7 @@ library ChainAssertions {
         }
         // This slot is the custom gas token _balance and this check ensures
         // that it stays unset for forwards compatibility with custom gas token.
-        // if we use the pre-locked storage modification, the comprison
+        // if we use the pre-locked storage modification, the comparison
         // against 0 doesn't hold anymore.
         // We do a check of the balance field downstream anyways, that's why we
         // can disable this check

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -27,6 +27,10 @@ import { console2 as console } from "forge-std/console2.sol";
 import { CeloTokenL1 } from "src/celo/CeloTokenL1.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+interface IOptimismPortalBalance {
+    function balance() external view returns (uint256);
+}
+
 library ChainAssertions {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
@@ -359,7 +363,13 @@ library ChainAssertions {
         internal
         view
     {
-        OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
+        address payable portalAddress;
+        if (_cfg.useFaultProofs()) {
+            portalAddress = payable(_contracts.OptimismPortal2);
+        } else {
+            portalAddress = payable(_contracts.OptimismPortal);
+        }
+        IOptimismPortalBalance portal = IOptimismPortalBalance(portalAddress);
 
         uint256 expectedInitialBalance = 0;
         if (_isProxy && _cfg.useCustomGasToken()) {
@@ -374,6 +384,7 @@ library ChainAssertions {
         } else {
             require(portal.balance() == 0);
         }
+        require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(portal.balance()));
     }
 
     /// @notice Asserts the OptimismPortal2 is setup correctly
@@ -412,7 +423,13 @@ library ChainAssertions {
         }
         // This slot is the custom gas token _balance and this check ensures
         // that it stays unset for forwards compatibility with custom gas token.
-        require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(0));
+        // if we use the pre-locked storage modification, the comprison
+        // against 0 doesn't hold anymore.
+        // We do a check of the balance field downstream anyways, that's why we
+        // can disable this check
+        if (!_cfg.useCustomGasToken()) {
+            require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(0));
+        }
     }
 
     /// @notice Asserts that the ProtocolVersions is setup correctly


### PR DESCRIPTION
Fixes #239

The custom gas-token feature adaptation for the fault-proof system using the `OptimismPortal2` contract has been merged recently upstream.

We are using the custom-gas-token feature and additionally require a modification of the OptimismPortal's `_balance` value to be set to the entire allocation of Celo on the L2 - meaning that all L1 token is initially locked in the bridge and only usable on the L2.

Those changes are now adapted also to the `OptimismPortal2`, which was a requirement to make our custom-gas-token pre-locked balance feature work in conjunction with fault-proofs.