### PR TITLE
Set ownership of proxy contracts on deployment

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -30,6 +30,7 @@ DEVNET_L2OO = os.getenv('DEVNET_L2OO') == "true"
 DEVNET_ALTDA = os.getenv('DEVNET_ALTDA') == "true"
 GENERIC_ALTDA = os.getenv('GENERIC_ALTDA') == "true"
 DEVNET_CELO = os.getenv('DEVNET_CELO') == "true"
+SAFE_AS_OWNER = os.getenv('SAFE_AS_OWNER') == "true"
 
 class Bunch:
     def __init__(self, **kwds):
@@ -135,6 +136,8 @@ def init_devnet_l1_deploy_config(paths, update_timestamp=False):
         # Usage of the zero address in combination of the useCustomGasToken == True
         # will deploy a new contract
         deploy_config['customGasTokenAddress'] = "0x0000000000000000000000000000000000000000"
+    if SAFE_AS_OWNER:
+        deploy_config['safeAsOwner'] = True
     write_json(paths.devnet_config_path, deploy_config)
 
 def devnet_l1_allocs(paths):

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -830,6 +830,9 @@ type DeployConfig struct {
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
+
+	// SafeAsOwner indicates whether specific proxy contracts should be owned by the Safe contract.
+	SafeAsOwner bool `json:"safeAsOwner"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -94,5 +94,6 @@
   "daResolveWindow": 0,
   "daResolverRefundPercentage": 0,
   "deployCeloContracts": false,
-  "eip1559BaseFeeFloor": 5000000000
+  "eip1559BaseFeeFloor": 5000000000,
+  "safeAsOwner": false
 }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -64,7 +64,15 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the SystemConfig is setup correctly
-    function checkSystemConfig(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy, address expectedOwner) internal view {
+    function checkSystemConfig(
+        Types.ContractSet memory _contracts,
+        DeployConfig _cfg,
+        bool _isProxy,
+        address expectedOwner
+    )
+        internal
+        view
+    {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -32,6 +32,7 @@ library ChainAssertions {
 
     /// @notice Asserts the correctness of an L1 deployment. This function expects that all contracts
     ///         within the `prox` ContractSet are proxies that have been setup and initialized.
+    /// this whole method is not being used - changes only for compilation sake
     function postDeployAssertions(
         Types.ContractSet memory _prox,
         DeployConfig _cfg,
@@ -46,7 +47,7 @@ library ChainAssertions {
         ResourceMetering.ResourceConfig memory dflt = Constants.DEFAULT_RESOURCE_CONFIG();
         require(keccak256(abi.encode(rcfg)) == keccak256(abi.encode(dflt)));
 
-        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _isProxy: true, expectedOwner: address(0) });
         checkL1CrossDomainMessenger({ _contracts: _prox, _vm: _vm, _isProxy: true });
         checkL1StandardBridge({ _contracts: _prox, _isProxy: true });
         checkL2OutputOracle({
@@ -59,11 +60,11 @@ library ChainAssertions {
         checkL1ERC721Bridge({ _contracts: _prox, _isProxy: true });
         checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
         checkOptimismPortal2({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
-        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true, expectedOwner: address(0) });
     }
 
     /// @notice Asserts that the SystemConfig is setup correctly
-    function checkSystemConfig(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
+    function checkSystemConfig(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy, address expectedOwner) internal view {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
@@ -73,7 +74,7 @@ library ChainAssertions {
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
         if (_isProxy) {
-            require(config.owner() == _cfg.finalSystemOwner());
+            require(config.owner() == expectedOwner);
             require(config.basefeeScalar() == _cfg.basefeeScalar());
             require(config.blobbasefeeScalar() == _cfg.blobbasefeeScalar());
             require(config.batcherHash() == bytes32(uint256(uint160(_cfg.batchSenderAddress()))));
@@ -419,7 +420,8 @@ library ChainAssertions {
     function checkProtocolVersions(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
-        bool _isProxy
+        bool _isProxy,
+        address expectedOwner
     )
         internal
         view
@@ -431,7 +433,7 @@ library ChainAssertions {
         assertSlotValueIsOne({ _contractAddress: address(versions), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
-            require(versions.owner() == _cfg.finalSystemOwner());
+            require(versions.owner() == expectedOwner);
             require(ProtocolVersion.unwrap(versions.required()) == _cfg.requiredProtocolVersion());
             require(ProtocolVersion.unwrap(versions.recommended()) == _cfg.recommendedProtocolVersion());
         } else {

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -803,7 +803,12 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.ProtocolVersions = address(versions);
-        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false, expectedOwner: address(0) });
+        ChainAssertions.checkProtocolVersions({
+            _contracts: contracts,
+            _cfg: cfg,
+            _isProxy: false,
+            expectedOwner: address(0)
+        });
 
         addr_ = address(versions);
     }

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -858,7 +858,12 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.SystemConfig = addr_;
-        ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _isProxy: false, expectedOwner: address(0) });
+        ChainAssertions.checkSystemConfig({
+            _contracts: contracts,
+            _cfg: cfg,
+            _isProxy: false,
+            expectedOwner: address(0)
+        });
     }
 
     /// @notice Deploy the L1StandardBridge
@@ -1107,7 +1112,12 @@ contract Deploy is Deployer {
         string memory version = config.version();
         console.log("SystemConfig version: %s", version);
 
-        ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _isProxy: true, expectedOwner: systemConfigOwner });
+        ChainAssertions.checkSystemConfig({
+            _contracts: _proxies(),
+            _cfg: cfg,
+            _isProxy: true,
+            expectedOwner: systemConfigOwner
+        });
     }
 
     /// @notice Initialize the L1StandardBridge
@@ -1390,7 +1400,12 @@ contract Deploy is Deployer {
         string memory version = versions.version();
         console.log("ProtocolVersions version: %s", version);
 
-        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isProxy: true, expectedOwner: protocolVersionsOwner });
+        ChainAssertions.checkProtocolVersions({
+            _contracts: _proxiesUnstrict(),
+            _cfg: cfg,
+            _isProxy: true,
+            expectedOwner: protocolVersionsOwner
+        });
     }
 
     /// @notice Transfer ownership of the DisputeGameFactory contract to the final system owner

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1373,7 +1373,6 @@ contract Deploy is Deployer {
         address protocolVersionsProxy = mustGetAddress("ProtocolVersionsProxy");
         address protocolVersions = mustGetAddress("ProtocolVersions");
 
-        address finalSystemOwner = cfg.finalSystemOwner();
         uint256 requiredProtocolVersion = cfg.requiredProtocolVersion();
         uint256 recommendedProtocolVersion = cfg.recommendedProtocolVersion();
 
@@ -1650,7 +1649,6 @@ contract Deploy is Deployer {
         address dataAvailabilityChallengeProxy = mustGetAddress("DataAvailabilityChallengeProxy");
         address dataAvailabilityChallenge = mustGetAddress("DataAvailabilityChallenge");
 
-        address finalSystemOwner = cfg.finalSystemOwner();
         uint256 daChallengeWindow = cfg.daChallengeWindow();
         uint256 daResolveWindow = cfg.daResolveWindow();
         uint256 daBondSize = cfg.daBondSize();

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -93,6 +93,7 @@ contract DeployConfig is Script {
     bool public useInterop;
 
     bool public deployCeloContracts;
+    bool public safeAsOwner;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -181,6 +182,7 @@ contract DeployConfig is Script {
 
         // Celo specific config
         deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
+        safeAsOwner = _readOr(_json, "$.safeAsOwner", false);
     }
 
     function fork() public view returns (Fork fork_) {

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -43,6 +43,7 @@ reqenv "USE_ALTDA"
 reqenv "DEPLOY_CELO_CONTRACTS"
 reqenv "USE_CUSTOM_GAS_TOKEN"
 reqenv "CUSTOM_GAS_TOKEN_ADDRESS"
+reqenv "SAFE_AS_OWNER"
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")
@@ -97,6 +98,7 @@ cat << EOL > tmp_config.json
   "gasPriceOracleScalar": 1000000,
 
   "deployCeloContracts": $DEPLOY_CELO_CONTRACTS,
+  "safeAsOwner": $SAFE_AS_OWNER,
 
   "enableGovernance": $ENABLE_GOVERNANCE,
   "governanceTokenSymbol": "OP",
@@ -166,7 +168,8 @@ cat << EOL >> tmp_config.json
   "daResolveWindow": 1,
 
   "useCustomGasToken": $USE_CUSTOM_GAS_TOKEN,
-  "customGasTokenAddress": "$CUSTOM_GAS_TOKEN_ADDRESS"
+  "customGasTokenAddress": "$CUSTOM_GAS_TOKEN_ADDRESS",
+  "safeAsOwner": $SAFE_AS_OWNER
 }
 EOL
 

--- a/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
@@ -71,7 +71,7 @@ interface IGnosisSafe {
         uint256 baseGas,
         uint256 gasPrice,
         address gasToken,
-        address refundReceiver,
+        address payable refundReceiver,
         bytes memory signatures
     )
         external
@@ -141,7 +141,7 @@ interface IGnosisSafe {
         address fallbackHandler,
         address paymentToken,
         uint256 payment,
-        address paymentReceiver
+        address payable paymentReceiver
     )
         external;
     function signedMessages(bytes32) external view returns (uint256);

--- a/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
@@ -147,4 +147,7 @@ interface IGnosisSafe {
     function signedMessages(bytes32) external view returns (uint256);
     function simulateAndRevert(address targetContract, bytes memory calldataPayload) external;
     function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
+
+    receive() external payable;
+    fallback() external;
 }


### PR DESCRIPTION
Sets the ownership of two proxy contracts (SystemConfigProxy, ProtocolVersionsProxy, DataAvailabilityChallengeProxy) to the SystemOwnerSafe contract during deployment if the correct config var is set. This removes the deployment account from directly owning L1 contracts, and instead indirectly owns them through multisig membership.

closes https://github.com/celo-org/celo-blockchain-planning/issues/518

Original PR https://github.com/celo-org/optimism/pull/210
