### PR TITLE
Added initializeAnchorStateRegistry config. Update Fault Proof config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -830,6 +830,9 @@ type DeployConfig struct {
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
+
+	// InitializeAnchorStateRegistry indicates whether to initialize the AnchorStateRegistry.
+	InitializeAnchorStateRegistry bool `json:"initializeAnchorStateRegistry"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -511,7 +511,9 @@ contract Deploy is Deployer {
         initializeDisputeGameFactory();
         initializeDelayedWETH();
         initializePermissionedDelayedWETH();
-        initializeAnchorStateRegistry();
+        if (cfg.initializeAnchorStateRegistry()) {
+            initializeAnchorStateRegistry();
+        }
 
         ChainAssertions.checkCustomGasTokenOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -80,6 +80,7 @@ contract DeployConfig is Script {
     uint256 public disputeGameFinalityDelaySeconds;
     uint256 public respectedGameType;
     bool public useFaultProofs;
+    bool public initializeAnchorStateRegistry;
     bool public useAltDA;
     string public daCommitmentType;
     uint256 public daChallengeWindow;
@@ -151,6 +152,7 @@ contract DeployConfig is Script {
         recommendedProtocolVersion = stdJson.readUint(_json, "$.recommendedProtocolVersion");
 
         useFaultProofs = _readOr(_json, "$.useFaultProofs", false);
+        initializeAnchorStateRegistry = _readOr(_json, "$.initializeAnchorStateRegistry", true);
         proofMaturityDelaySeconds = _readOr(_json, "$.proofMaturityDelaySeconds", 0);
         disputeGameFinalityDelaySeconds = _readOr(_json, "$.disputeGameFinalityDelaySeconds", 0);
         respectedGameType = _readOr(_json, "$.respectedGameType", 0);

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -70,7 +70,7 @@ cat << EOL > tmp_config.json
   "batchInboxAddress": "$batchInboxAddress",
   "batchSenderAddress": "$GS_BATCHER_ADDRESS",
 
-  "l2OutputOracleSubmissionInterval": 120,
+  "l2OutputOracleSubmissionInterval": 300,
   "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleStartingTimestamp": $timestamp,
 
@@ -142,20 +142,21 @@ cat << EOL >> tmp_config.json
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
 
-  "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
-  "faultGameMaxDepth": 44,
-  "faultGameClockExtension": 0,
-  "faultGameMaxClockDuration": 1200,
+  "faultGameAbsolutePrestate": "0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55",
+  "faultGameMaxDepth": 73,
+  "faultGameClockExtension": 10800,
+  "faultGameMaxClockDuration": 302400,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "faultGameSplitDepth": 14,
-  "faultGameWithdrawalDelay": 600,
+  "faultGameSplitDepth": 30,
+  "faultGameWithdrawalDelay": 604800,
 
-  "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 300,
+  "preimageOracleMinProposalSize": 126000,
+  "preimageOracleChallengePeriod": 86400,
 
   "fundDevAccounts": $FUNDS_DEV_ACCOUNTS,
   "useFaultProofs": false,
+  "initializeAnchorStateRegistry": false,
   "proofMaturityDelaySeconds": 604800,
   "disputeGameFinalityDelaySeconds": 302400,
   "respectedGameType": 0,


### PR DESCRIPTION
Added a new config flag `initializeAnchorStateRegistry` to skip the initialization of `AnchorStateRegistry` in the execution of `Deploy.s.sol`. This, can be initialized latter when the `faultGameGenesisOutputRoot` is known.

Also updated the config  template in `config-vars-celo.sh` to match OP Mainnet and Sepolia FaultProof config. 