### PR TITLE
Reenable tests

### DIFF
--- a/op-e2e/interop/interop_recipe_test.go
+++ b/op-e2e/interop/interop_recipe_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestInteropDevRecipe(t *testing.T) {
-	t.Skipf("Skipping interop tests for now. Celo doesn't use interop, so we can fix these tests at a later time")
-
 	rec := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
 		L2ChainIDs:       []uint64{900200, 900201},

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -20,8 +20,6 @@ import (
 // The balance of Bob on Chain A is checked before and after the tx.
 // The balance of Bob on Chain B is checked after the tx.
 func TestInteropTrivial(t *testing.T) {
-	t.Skipf("Skipping interop tests for now. Celo doesn't use interop, so we can fix these tests at a later time")
-
 	recipe := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
 		L2ChainIDs:       []uint64{900200, 900201},

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -267,8 +267,6 @@ func TestMixedDepositValidity(t *testing.T) {
 // TestMixedWithdrawalValidity makes a number of withdrawal transactions and ensures ones with modified parameters are
 // rejected while unmodified ones are accepted. This runs test cases in different systems.
 func TestMixedWithdrawalValidity(t *testing.T) {
-	t.Skipf("Skipping withdrawal tests for now, must check in more detail!")
-
 	op_e2e.InitParallel(t)
 
 	// There are 7 different fields we try modifying to cause a failure, plus one "good" test result we test.


### PR DESCRIPTION
During the last two rebases, multiple tests have been skipped to not delay the rebase. Fortunately, reenabling these tests can be done with only a minor change now.

Closes https://github.com/celo-org/optimism/issues/225