### PR TITLE
Delete bad blocks during migration

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -62,7 +62,11 @@ func copyDbExceptAncients(oldDbPath, newDbPath string) error {
 func migrateNonAncientsDb(newDB ethdb.Database, lastBlock, numAncients, batchSize uint64) (uint64, error) {
 	defer timer("migrateNonAncientsDb")()
 
-	// The genesis block is also migrated in the ancient db migration as it is stored in both places.
+	// Delete bad blocks, we could migrate them, but we have no need of the historical bad blocks. AFAICS bad blocks
+	// are stored solely so that they can be retrieved or traced via the debug API, but we are no longer interested
+	// in these old bad blocks.
+	rawdb.DeleteBadBlocks(newDB)
+
 	// The genesis block is the only block that should remain stored in the non-ancient db even after it is frozen.
 	if numAncients > 0 {
 		log.Info("Migrating genesis block in non-ancient db", "process", "non-ancients")


### PR DESCRIPTION
This change deletes bad blocks at migration time, since we don't need
to keep historical bad blocks and if not transformed like the other migrated
blocks can lead to panics when trying to load them (which happens when
a new bad block is discovered).

I've tested this locally, by taking a datdir where bad blocks could be
retrieved via `geth db get 0x496e76616c6964426c6f636b` and migrated
it and verified that then the bad blocks cannot be retrieved which looks like this.

```
INFO [10-28|13:00:32.736] Get operation failed                     error="leveldb: not found"
```

Since the key is not present.