### PR TITLE
Use upstream branch for forkdiff

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1000  # make sure to fetch the old commit we diff against
+          fetch-depth: 0  # make sure to fetch the old commit we diff against
 
       - name: Build forkdiff
         uses: "docker://protolambda/forkdiff:0.1.0"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - celo[0-9]+
+
+  workflow_dispatch:
+
 jobs:
   deploy:
     concurrency: ci-${{ github.ref }}

--- a/fork.yaml
+++ b/fork.yaml
@@ -5,8 +5,8 @@ footer: |
 
 base:
   name: OP
-  url: https://github.com/ethereum-optimism/optimism
-  hash: 224c5fd65cb4e8204258291e74263c1e70466176 # tracks the last rebased commit
+  url: https://github.com/celo-org/optimism
+  ref: refs/remotes/origin/celo10-upstream
 fork:
   name: CELO
   url: https://github.com/celo-org/optimism


### PR DESCRIPTION
This corresponds to the PRs in our op-geth repo: https://github.com/celo-org/op-geth/pull/280, https://github.com/celo-org/op-geth/pull/281