### PR TITLE
Add CLI config validation of op-batcher to prevent submitting Blobs into Alt DA

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -218,7 +218,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("unknown data availability type: %v", cfg.DataAvailabilityType)
 	}
 
-	if bs.UseAltDA && cfg.DataAvailabilityType == flags.BlobsType {
+	if bs.UseAltDA && cfg.DataAvailabilityType != flags.CalldataType {
 		return fmt.Errorf("cannot use Blobs with Alt DA")
 	}
 	if bs.UseAltDA && cc.MaxFrameSize > altda.MaxInputSize {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -218,6 +218,9 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("unknown data availability type: %v", cfg.DataAvailabilityType)
 	}
 
+	if bs.UseAltDA && cfg.DataAvailabilityType == flags.BlobsType {
+		return fmt.Errorf("cannot use Blobs with Alt DA")
+	}
 	if bs.UseAltDA && cc.MaxFrameSize > altda.MaxInputSize {
 		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, altda.MaxInputSize)
 	}


### PR DESCRIPTION
Fixes https://github.com/celo-org/celo-blockchain-planning/issues/784

This PR adds a new validation of CLI configuration of `op-batcher`. `op-batcher` throws error in runtime when submitting blobs type txdata into Alt DA.

This PR adds new validation for the 'op-batcher' CLI configuration. 'op-batcher' throws an error at runtime when submitting blobs of type txdata into Alt DA

https://github.com/celo-org/optimism/blob/81fde1ab5b9fc6dba74d1c971635b484e6b7df89/op-batcher/batcher/driver.go#L594-L601

The validation added in this PR prevents both Alt DA mode and Blob types from being enabled at the same time.

FYI: If the TxData type is 'auto', the txdata type will be set to 'calldata' for now.

