### PR TITLE
Resolve fuzzing test failures for AddressSortedLinkedListWithMedian

### DIFF
--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
 import { StdCheatsSafe } from "forge-std/StdCheats.sol";
+import { AddressSortedLinkedList } from "src/celo/common/linkedlists/AddressSortedLinkedList.sol";
+import { AddressSortedLinkedListWithMedian } from "src/celo/common/linkedlists/AddressSortedLinkedListWithMedian.sol";
 
 // Target contract
 import { SafeCall } from "src/libraries/SafeCall.sol";
@@ -14,6 +16,9 @@ contract SafeCall_Test is Test {
         vm.assume(_addr.balance == 0);
         vm.assume(_addr != address(this));
         vm.assume(uint256(uint160(_addr)) > uint256(256)); // TODO temp fix until new forge-std release with modern
+        // ignore address of library contract whose functions have 'public' or 'external' visibilities
+        vm.assume(_addr != address(AddressSortedLinkedList));
+        vm.assume(_addr != address(AddressSortedLinkedListWithMedian));
             // precompiles: https://github.com/foundry-rs/forge-std/pull/594
         assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);
     }

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -19,7 +19,7 @@ contract SafeCall_Test is Test {
         // ignore address of library contract whose functions have 'public' or 'external' visibilities
         vm.assume(_addr != address(AddressSortedLinkedList));
         vm.assume(_addr != address(AddressSortedLinkedListWithMedian));
-            // precompiles: https://github.com/foundry-rs/forge-std/pull/594
+        // precompiles: https://github.com/foundry-rs/forge-std/pull/594
         assumeAddressIsNot(_addr, StdCheatsSafe.AddressType.ForgeAddress, StdCheatsSafe.AddressType.Precompile);
     }
 


### PR DESCRIPTION
Fixes https://github.com/celo-org/optimism/issues/249

This PR adds skipping of fuzzing test in `test/libraries/SafeCall.t.sol` for `AddressSortedLinkedList` and `AddressSortedLinkedListWithMedian`.

Fuzzing test in `test/libraries/SafeCall.t.sol`, which calls random address with random method ID, calls `AddressSortedLinkedList` or `AddressSortedLinkedListWithMedian` with high probability. The reason is because they are deployed before tests and their addresses are used as a input. Only library contracts having methods with `public` or `external` visibilities might be target.

This fuzzing test is just random call test and don't check functionality of these libraries. Then this PR skips testing for them.

