### PR TITLE
Optional initialization of AnchorStateRegistry on Deploy.s.sol run()

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -666,6 +666,9 @@ type FaultProofDeployConfig struct {
 	// UseFaultProofs is a flag that indicates if the system is using fault
 	// proofs instead of the older output oracle mechanism.
 	UseFaultProofs bool `json:"useFaultProofs"`
+	// InitializeAnchorStateRegistry is a flag that indicates if the system should
+	// initialize the AnchorStateRegistry when running Deploy.s.sol run() function.
+	InitializeAnchorStateRegistry bool `json:"initializeAnchorStateRegistry"`
 	// FaultGameAbsolutePrestate is the absolute prestate of Cannon. This is computed
 	// by generating a proof from the 0th -> 1st instruction and grabbing the prestate from
 	// the output JSON. All honest challengers should agree on the setup state of the program.
@@ -830,6 +833,9 @@ type DeployConfig struct {
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
+
+	// InitializeAnchorStateRegistry indicates whether to initialize the AnchorStateRegistry.
+	InitializeAnchorStateRegistry bool `json:"initializeAnchorStateRegistry"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1100,6 +1100,69 @@ contract Deploy is Deployer {
         console.log("AnchorStateRegistry version: %s", version);
     }
 
+    function initializeAnchorStateRegistryStatic() public broadcast {
+        console.log("Initializing AnchorStateRegistry proxy");
+        address anchorStateRegistryProxyStatic = 0x2C352Db04D4ab5100e32a4EF9905F46F07d884a5;
+        address anchorStateRegistryStatic = 0x09c0526F6D9d80920Da46Fee92e6aA0679fbAC31;
+        ISuperchainConfig superchainConfigStatic = ISuperchainConfig(payable(0x9B776D9d1b8f0Dc25b80D83b11B91fb97eBb20f8));
+
+        IAnchorStateRegistry.StartingAnchorRoot[] memory roots = new IAnchorStateRegistry.StartingAnchorRoot[](5);
+        roots[0] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: GameTypes.CANNON,
+            outputRoot: OutputRoot({
+                root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
+                l2BlockNumber: cfg.faultGameGenesisBlock()
+            })
+        });
+        roots[1] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: GameTypes.PERMISSIONED_CANNON,
+            outputRoot: OutputRoot({
+                root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
+                l2BlockNumber: cfg.faultGameGenesisBlock()
+            })
+        });
+        roots[2] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: GameTypes.ALPHABET,
+            outputRoot: OutputRoot({
+                root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
+                l2BlockNumber: cfg.faultGameGenesisBlock()
+            })
+        });
+        roots[3] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: GameTypes.ASTERISC,
+            outputRoot: OutputRoot({
+                root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
+                l2BlockNumber: cfg.faultGameGenesisBlock()
+            })
+        });
+        roots[4] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: GameTypes.FAST,
+            outputRoot: OutputRoot({
+                root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
+                l2BlockNumber: cfg.faultGameGenesisBlock()
+            })
+        });
+
+        _upgradeAndCallViaSafeStatic({
+            _proxy: payable(anchorStateRegistryProxyStatic),
+            _implementation: anchorStateRegistryStatic,
+            _innerCallData: abi.encodeCall(IAnchorStateRegistry.initialize, (roots, superchainConfigStatic))
+        });
+
+        string memory version = IAnchorStateRegistry(payable(anchorStateRegistryProxyStatic)).version();
+        console.log("AnchorStateRegistry version: %s", version);
+    }
+
+    function _upgradeAndCallViaSafeStatic(address _proxy, address _implementation, bytes memory _innerCallData) internal {
+        address proxyAdminStatic = 0x1d461e362937906BD2F276ee74d9DB73b1E16c0d;
+
+        bytes memory data =
+            abi.encodeCall(ProxyAdmin.upgradeAndCall, (payable(_proxy), _implementation, _innerCallData));
+
+        Safe safe = Safe(payable(0x8C8d46BcF286aCEfC42B888b76A21279fe637BA6));
+        _callViaSafe({ _safe: safe, _target: proxyAdminStatic, _data: data });
+    }
+
     /// @notice Initialize the SystemConfig
     function initializeSystemConfig() public broadcast {
         console.log("Upgrading and initializing SystemConfig proxy");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -511,7 +511,9 @@ contract Deploy is Deployer {
         initializeDisputeGameFactory();
         initializeDelayedWETH();
         initializePermissionedDelayedWETH();
-        initializeAnchorStateRegistry();
+        if (cfg.initializeAnchorStateRegistry()) {
+            initializeAnchorStateRegistry();
+        }
 
         ChainAssertions.checkCustomGasTokenOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
     }

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -80,6 +80,7 @@ contract DeployConfig is Script {
     uint256 public disputeGameFinalityDelaySeconds;
     uint256 public respectedGameType;
     bool public useFaultProofs;
+    bool public initializeAnchorStateRegistry;
     bool public useAltDA;
     string public daCommitmentType;
     uint256 public daChallengeWindow;
@@ -151,6 +152,7 @@ contract DeployConfig is Script {
         recommendedProtocolVersion = stdJson.readUint(_json, "$.recommendedProtocolVersion");
 
         useFaultProofs = _readOr(_json, "$.useFaultProofs", false);
+        initializeAnchorStateRegistry = _readOr(_json, "$.initializeAnchorStateRegistry", true);
         proofMaturityDelaySeconds = _readOr(_json, "$.proofMaturityDelaySeconds", 0);
         disputeGameFinalityDelaySeconds = _readOr(_json, "$.disputeGameFinalityDelaySeconds", 0);
         respectedGameType = _readOr(_json, "$.respectedGameType", 0);

--- a/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config-vars-celo.sh
@@ -70,7 +70,7 @@ cat << EOL > tmp_config.json
   "batchInboxAddress": "$batchInboxAddress",
   "batchSenderAddress": "$GS_BATCHER_ADDRESS",
 
-  "l2OutputOracleSubmissionInterval": 120,
+  "l2OutputOracleSubmissionInterval": 300,
   "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleStartingTimestamp": $timestamp,
 
@@ -142,20 +142,21 @@ cat << EOL >> tmp_config.json
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
 
-  "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
-  "faultGameMaxDepth": 44,
-  "faultGameClockExtension": 0,
-  "faultGameMaxClockDuration": 1200,
+  "faultGameAbsolutePrestate": "0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55",
+  "faultGameMaxDepth": 73,
+  "faultGameClockExtension": 10800,
+  "faultGameMaxClockDuration": 302400,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "faultGameSplitDepth": 14,
-  "faultGameWithdrawalDelay": 600,
+  "faultGameSplitDepth": 30,
+  "faultGameWithdrawalDelay": 604800,
 
-  "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 300,
+  "preimageOracleMinProposalSize": 126000,
+  "preimageOracleChallengePeriod": 86400,
 
   "fundDevAccounts": $FUNDS_DEV_ACCOUNTS,
   "useFaultProofs": false,
+  "initializeAnchorStateRegistry": false,
   "proofMaturityDelaySeconds": 604800,
   "disputeGameFinalityDelaySeconds": 302400,
   "respectedGameType": 0,


### PR DESCRIPTION
Allow skipping the initialization of AnchorStateRegistry contract when running the testnet deployment script Deploy.s.sol.
We want to skip the initialization of this contract so we can initialize in a latter stage with the claimRoot of the migration block (that is not known when run `run()` function of Deploy.s.sol, as the value of this claimRoot depends on addresses deployed during the execution of this function).

Only intended for testnets.