### PR TITLE
[Audit -  TOB-CELOL2-3] Add error checks to migration script

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -39,27 +39,31 @@ func NewChainFreezer(datadir string, namespace string, readonly bool) (*rawdb.Fr
 	return rawdb.NewFreezer(datadir, namespace, readonly, freezerTableSize, chainFreezerNoSnappy)
 }
 
-func migrateAncientsDb(ctx context.Context, oldDBPath, newDBPath string, batchSize, bufferSize uint64) (uint64, uint64, error) {
+func migrateAncientsDb(ctx context.Context, oldDBPath, newDBPath string, batchSize, bufferSize uint64) (numAncientsNewBefore uint64, numAncientsNewAfter uint64, err error) {
 	defer timer("ancients")()
 
 	oldFreezer, err := NewChainFreezer(filepath.Join(oldDBPath, "ancient"), "", false) // Can't be readonly because we need the .meta files to be created
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to open old freezer: %w", err)
 	}
-	defer oldFreezer.Close()
+	defer func() {
+		err = errors.Join(err, oldFreezer.Close())
+	}()
 
 	newFreezer, err := NewChainFreezer(filepath.Join(newDBPath, "ancient"), "", false)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to open new freezer: %w", err)
 	}
-	defer newFreezer.Close()
+	defer func() {
+		err = errors.Join(err, newFreezer.Close())
+	}()
 
 	numAncientsOld, err := oldFreezer.Ancients()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get number of ancients in old freezer: %w", err)
 	}
 
-	numAncientsNewBefore, err := newFreezer.Ancients()
+	numAncientsNewBefore, err = newFreezer.Ancients()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get number of ancients in new freezer: %w", err)
 	}
@@ -85,7 +89,7 @@ func migrateAncientsDb(ctx context.Context, oldDBPath, newDBPath string, batchSi
 		return 0, 0, fmt.Errorf("failed to migrate ancients: %w", err)
 	}
 
-	numAncientsNewAfter, err := newFreezer.Ancients()
+	numAncientsNewAfter, err = newFreezer.Ancients()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get number of ancients in new freezer: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -226,9 +227,7 @@ func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 	defer func() {
-		if tempErr := db.Close(); tempErr != nil && err == nil {
-			err = fmt.Errorf("failed to close database: %w", tempErr)
-		}
+		err = errors.Join(err, db.Close())
 	}()
 
 	numAncients, err := db.Ancients()
@@ -236,5 +235,5 @@ func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error
 		return nil, fmt.Errorf("failed to get number of ancients in database: %w", err)
 	}
 
-	return rawdb.ReadAllHashesInRange(db, 1, numAncients-1), err
+	return rawdb.ReadAllHashesInRange(db, 1, numAncients-1), nil
 }

--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -89,6 +89,10 @@ func migrateAncientsDb(ctx context.Context, oldDBPath, newDBPath string, batchSi
 		return 0, 0, fmt.Errorf("failed to get number of ancients in new freezer: %w", err)
 	}
 
+	if numAncientsNewAfter != numAncientsOld {
+		return 0, 0, fmt.Errorf("failed to migrate all ancients from old to new db. Expected %d, got %d", numAncientsOld, numAncientsNewAfter)
+	}
+
 	log.Info("Ancient Block Migration Ended", "process", "ancients", "ancientsInOldDB", numAncientsOld, "ancientsInNewDB", numAncientsNewAfter, "migrated", numAncientsNewAfter-numAncientsNewBefore)
 	return numAncientsNewBefore, numAncientsNewAfter, nil
 }
@@ -214,19 +218,23 @@ func writeAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, in <-chan R
 }
 
 // getStrayAncientBlocks returns a list of ancient block numbers / hashes that somehow were not removed from leveldb
-func getStrayAncientBlocks(dbPath string) ([]*rawdb.NumberHash, error) {
+func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error) {
 	defer timer("getStrayAncientBlocks")()
 
 	db, err := openDB(dbPath, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
-	defer db.Close()
+	defer func() {
+		if tempErr := db.Close(); tempErr != nil && err == nil {
+			err = fmt.Errorf("failed to close database: %w", tempErr)
+		}
+	}()
 
 	numAncients, err := db.Ancients()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get number of ancients in database: %w", err)
 	}
 
-	return rawdb.ReadAllHashesInRange(db, 1, numAncients-1), nil
+	return rawdb.ReadAllHashesInRange(db, 1, numAncients-1), err
 }

--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -107,16 +107,14 @@ func getHeadHeader(dbpath string) (headHeader *types.Header, err error) {
 		return nil, fmt.Errorf("failed to open database at %q err: %w", dbpath, err)
 	}
 	defer func() {
-		if tempErr := db.Close(); tempErr != nil && err == nil {
-			err = fmt.Errorf("failed to close database: %w", tempErr)
-		}
+		err = errors.Join(err, db.Close())
 	}()
 
 	headHeader = rawdb.ReadHeadHeader(db)
 	if headHeader == nil {
 		return nil, fmt.Errorf("head header not in database at: %s", dbpath)
 	}
-	return headHeader, err
+	return headHeader, nil
 }
 
 func cleanupNonAncientDb(dir string) error {

--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -101,7 +101,7 @@ func removeBlocks(ldb ethdb.Database, numberHashes []*rawdb.NumberHash) error {
 	return nil
 }
 
-func getHeadHeader(dbpath string) (*types.Header, err error) {
+func getHeadHeader(dbpath string) (headHeader *types.Header, err error) {
 	db, err := openDBWithoutFreezer(dbpath, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database at %q err: %w", dbpath, err)
@@ -112,7 +112,7 @@ func getHeadHeader(dbpath string) (*types.Header, err error) {
 		}
 	}()
 
-	headHeader := rawdb.ReadHeadHeader(db)
+	headHeader = rawdb.ReadHeadHeader(db)
 	if headHeader == nil {
 		return nil, fmt.Errorf("head header not in database at: %s", dbpath)
 	}

--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -38,7 +38,8 @@ func headerKey(number uint64, hash common.Hash) []byte {
 
 // Opens a database with access to AncientsDb
 func openDB(chaindataPath string, readOnly bool) (ethdb.Database, error) {
-	if _, err := os.Stat(chaindataPath); errors.Is(err, os.ErrNotExist) {
+	// Will throw an error if the chaindataPath does not exist
+	if _, err := os.Stat(chaindataPath); err != nil {
 		return nil, err
 	}
 
@@ -100,18 +101,22 @@ func removeBlocks(ldb ethdb.Database, numberHashes []*rawdb.NumberHash) error {
 	return nil
 }
 
-func getHeadHeader(dbpath string) (*types.Header, error) {
+func getHeadHeader(dbpath string) (*types.Header, err error) {
 	db, err := openDBWithoutFreezer(dbpath, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database at %q err: %w", dbpath, err)
 	}
-	defer db.Close()
+	defer func() {
+		if tempErr := db.Close(); tempErr != nil && err == nil {
+			err = fmt.Errorf("failed to close database: %w", tempErr)
+		}
+	}()
 
 	headHeader := rawdb.ReadHeadHeader(db)
 	if headHeader == nil {
 		return nil, fmt.Errorf("head header not in database at: %s", dbpath)
 	}
-	return headHeader, nil
+	return headHeader, err
 }
 
 func cleanupNonAncientDb(dir string) error {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -84,7 +84,7 @@ var (
 	batchSizeFlag = &cli.Uint64Flag{
 		Name:  "batch-size",
 		Usage: "Batch size to use for block migration, larger batch sizes can speed up migration but require more memory. If increasing the batch size consider also increasing the memory-limit",
-		Value: 50000, // TODO(Alec) optimize default parameters
+		Value: 50000,
 	}
 	bufferSizeFlag = &cli.Uint64Flag{
 		Name:  "buffer-size",
@@ -315,14 +315,18 @@ func runPreMigration(opts preMigrationOptions) ([]*rawdb.NumberHash, uint64, err
 	return strayAncientBlocks, numAncientsNewAfter, nil
 }
 
-func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.NumberHash, batchSize, numAncients uint64) error {
+func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.NumberHash, batchSize, numAncients uint64) (err error) {
 	defer timer("non-ancient migration")()
 
 	newDB, err := openDBWithoutFreezer(newDBPath, false)
 	if err != nil {
 		return fmt.Errorf("failed to open new database: %w", err)
 	}
-	defer newDB.Close()
+	defer func() {
+		if tempErr := newDB.Close(); tempErr != nil && err == nil {
+			err = fmt.Errorf("failed to close database: %w", tempErr)
+		}
+	}()
 
 	// get the last block number
 	hash := rawdb.ReadHeadHeaderHash(newDB)
@@ -344,7 +348,7 @@ func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.Number
 
 	log.Info("Non-Ancient Block Migration Completed", "process", "non-ancients", "migratedNonAncients", numNonAncients)
 
-	return nil
+	return err
 }
 
 func runStateMigration(newDBPath string, opts stateMigrationOptions) error {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -323,9 +323,7 @@ func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.Number
 		return fmt.Errorf("failed to open new database: %w", err)
 	}
 	defer func() {
-		if tempErr := newDB.Close(); tempErr != nil && err == nil {
-			err = fmt.Errorf("failed to close database: %w", tempErr)
-		}
+		err = errors.Join(err, newDB.Close())
 	}()
 
 	// get the last block number
@@ -348,7 +346,7 @@ func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.Number
 
 	log.Info("Non-Ancient Block Migration Completed", "process", "non-ancients", "migratedNonAncients", numNonAncients)
 
-	return err
+	return nil
 }
 
 func runStateMigration(newDBPath string, opts stateMigrationOptions) error {

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -19,7 +19,10 @@ func copyDbExceptAncients(oldDbPath, newDbPath string) error {
 
 	// Get rsync help output
 	cmdHelp := exec.Command("rsync", "--help")
-	output, _ := cmdHelp.CombinedOutput()
+	output, err := cmdHelp.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get rsync help output: %w", err)
+	}
 
 	// Convert output to string
 	outputStr := string(output)
@@ -113,7 +116,9 @@ func migrateNonAncientBlock(number uint64, hash common.Hash, newDB ethdb.Databas
 	// write header and body
 	batch := newDB.NewBatch()
 	rawdb.WriteBodyRLP(batch, hash, number, newBody)
-	_ = batch.Put(headerKey(number, hash), newHeader)
+	if err := batch.Put(headerKey(number, hash), newHeader); err != nil {
+		return fmt.Errorf("failed to write header: block %d - %x: %w", number, hash, err)
+	}
 	if err := batch.Write(); err != nil {
 		return fmt.Errorf("failed to write header and body: block %d - %x: %w", number, hash, err)
 	}


### PR DESCRIPTION
Addresses https://github.com/celo-org/celo-blockchain-planning/issues/845 based on audit feedback in TOB-CELOL2-3

Note that the suggestion to check if stray blocks are in the ancient db before removing them is not included here and may be added in a follow on. This change will be larger than those included here, and may have a performance impact that needs to be evaluated. We have also added a check to the migration script to ensure gaps do not exist in the block data (https://github.com/celo-org/optimism/pull/282), which will help mitigate this concern as well. 