### PR TITLE
Update op-geth for `celo10` branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241209113131-e6499495c176
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101408.1-0.20241211135814-0162ce9d0298
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/celo-org/op-geth v1.101408.1-0.20241209113131-e6499495c176 h1:pVzNAblfE20Lk1+zqzegjIZ/1UgwEGDpxDTzHCFP9wI=
-github.com/celo-org/op-geth v1.101408.1-0.20241209113131-e6499495c176/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
+github.com/celo-org/op-geth v1.101408.1-0.20241211135814-0162ce9d0298 h1:tv3rg2aT8xQJoL0e2hMyLG+s/a+y4GucB0Ir/TitqaQ=
+github.com/celo-org/op-geth v1.101408.1-0.20241211135814-0162ce9d0298/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -90,9 +90,9 @@ var (
 		BaklavaNetworkID:   common.HexToAddress("0x022c5d5837E177B6d145761feb4C5574e5b48F5e"),
 	}
 	celoTokenAddressMap = map[uint64]common.Address{
-		AlfajoresNetworkID: addresses.CeloTokenAlfajoresAddress,
-		BaklavaNetworkID:   addresses.CeloTokenBaklavaAddress,
-		MainnetNetworkID:   addresses.CeloTokenAddress,
+		AlfajoresNetworkID: addresses.AlfajoresAddresses.CeloToken,
+		BaklavaNetworkID:   addresses.BaklavaAddresses.CeloToken,
+		MainnetNetworkID:   addresses.MainnetAddresses.CeloToken,
 	}
 )
 

--- a/op-e2e/system/fees/fees_test.go
+++ b/op-e2e/system/fees/fees_test.go
@@ -138,7 +138,7 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 
 	baseFeeRecipient := predeploys.BaseFeeVaultAddr
 	if sys.RollupConfig.IsCel2(sys.L2GenesisCfg.Timestamp) {
-		baseFeeRecipient = addresses.FeeHandlerAddress
+		baseFeeRecipient = addresses.GetAddresses(cfg.L2ChainIDBig()).FeeHandler
 	}
 	// BaseFee Recipient
 	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(context.Background(), baseFeeRecipient, big.NewInt(rpc.EarliestBlockNumber.Int64()))

--- a/ops-bedrock/l2-op-geth.Dockerfile
+++ b/ops-bedrock/l2-op-geth.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth@sha256:6fe04ace89e6ebae1c527c2754d1eb40bcb073a85b2f23384816c53d94bbaff2
+FROM --platform=linux/amd64 us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth@sha256:2cbe7293f435d37312290c52784c3215559a4889dab686c25da677d088676fd3
 
 RUN apk add --no-cache jq
 

--- a/ops/check-changed/requirements.txt
+++ b/ops/check-changed/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2024.7.4
-cffi==1.15.1
+cffi==1.17.1
 charset-normalizer==2.1.1
 Deprecated==1.2.13
 idna==3.7


### PR DESCRIPTION
Although we will soon upgrade the default branch to `celo11`, we want to 
keep the tips of `op-geth/celoXX` / `optimism/celoXX` branches synced to it's respective counterpart.
This is a follow-up to #289, since the weekly github action seemed to have force-pushed and closed the pr.
