### PR TITLE
Fix migration script deadlock

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -106,46 +106,47 @@ func readAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, startBlock, 
 	defer close(out)
 
 	for i := startBlock; i < endBlock; i += batchSize {
+		count := min(batchSize, endBlock-i+1)
+		start := i
+
+		blockRange := RLPBlockRange{
+			start:    start,
+			hashes:   make([][]byte, count),
+			headers:  make([][]byte, count),
+			bodies:   make([][]byte, count),
+			receipts: make([][]byte, count),
+			tds:      make([][]byte, count),
+		}
+		var err error
+
+		blockRange.hashes, err = freezer.AncientRange(rawdb.ChainFreezerHashTable, start, count, 0)
+		if err != nil {
+			return fmt.Errorf("failed to read hashes from old freezer: %w", err)
+		}
+		blockRange.headers, err = freezer.AncientRange(rawdb.ChainFreezerHeaderTable, start, count, 0)
+		if err != nil {
+			return fmt.Errorf("failed to read headers from old freezer: %w", err)
+		}
+		blockRange.bodies, err = freezer.AncientRange(rawdb.ChainFreezerBodiesTable, start, count, 0)
+		if err != nil {
+			return fmt.Errorf("failed to read bodies from old freezer: %w", err)
+		}
+		blockRange.receipts, err = freezer.AncientRange(rawdb.ChainFreezerReceiptTable, start, count, 0)
+		if err != nil {
+			return fmt.Errorf("failed to read receipts from old freezer: %w", err)
+		}
+		blockRange.tds, err = freezer.AncientRange(rawdb.ChainFreezerDifficultyTable, start, count, 0)
+		if err != nil {
+			return fmt.Errorf("failed to read tds from old freezer: %w", err)
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			count := min(batchSize, endBlock-i+1)
-			start := i
-
-			blockRange := RLPBlockRange{
-				start:    start,
-				hashes:   make([][]byte, count),
-				headers:  make([][]byte, count),
-				bodies:   make([][]byte, count),
-				receipts: make([][]byte, count),
-				tds:      make([][]byte, count),
-			}
-			var err error
-
-			blockRange.hashes, err = freezer.AncientRange(rawdb.ChainFreezerHashTable, start, count, 0)
-			if err != nil {
-				return fmt.Errorf("failed to read hashes from old freezer: %w", err)
-			}
-			blockRange.headers, err = freezer.AncientRange(rawdb.ChainFreezerHeaderTable, start, count, 0)
-			if err != nil {
-				return fmt.Errorf("failed to read headers from old freezer: %w", err)
-			}
-			blockRange.bodies, err = freezer.AncientRange(rawdb.ChainFreezerBodiesTable, start, count, 0)
-			if err != nil {
-				return fmt.Errorf("failed to read bodies from old freezer: %w", err)
-			}
-			blockRange.receipts, err = freezer.AncientRange(rawdb.ChainFreezerReceiptTable, start, count, 0)
-			if err != nil {
-				return fmt.Errorf("failed to read receipts from old freezer: %w", err)
-			}
-			blockRange.tds, err = freezer.AncientRange(rawdb.ChainFreezerDifficultyTable, start, count, 0)
-			if err != nil {
-				return fmt.Errorf("failed to read tds from old freezer: %w", err)
-			}
-
-			out <- blockRange
+		case out <- blockRange:
 		}
+
+		log.Info("Read ancient blocks", "start", start, "end", start+count-1, "count", count)
 	}
 	return nil
 }
@@ -154,31 +155,31 @@ func transformBlocks(ctx context.Context, in <-chan RLPBlockRange, out chan<- RL
 	// Transform blocks from the in channel and send them to the out channel
 	defer close(out)
 	for blockRange := range in {
+		for i := range blockRange.hashes {
+			blockNumber := blockRange.start + uint64(i)
+
+			newHeader, err := transformHeader(blockRange.headers[i])
+			if err != nil {
+				return fmt.Errorf("can't transform header: %w", err)
+			}
+			newBody, err := transformBlockBody(blockRange.bodies[i])
+			if err != nil {
+				return fmt.Errorf("can't transform body: %w", err)
+			}
+
+			if yes, newHash := hasSameHash(newHeader, blockRange.hashes[i]); !yes {
+				log.Error("Hash mismatch", "block", blockNumber, "oldHash", common.BytesToHash(blockRange.hashes[i]), "newHash", newHash)
+				return fmt.Errorf("hash mismatch at block %d", blockNumber)
+			}
+
+			blockRange.headers[i] = newHeader
+			blockRange.bodies[i] = newBody
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			for i := range blockRange.hashes {
-				blockNumber := blockRange.start + uint64(i)
-
-				newHeader, err := transformHeader(blockRange.headers[i])
-				if err != nil {
-					return fmt.Errorf("can't transform header: %w", err)
-				}
-				newBody, err := transformBlockBody(blockRange.bodies[i])
-				if err != nil {
-					return fmt.Errorf("can't transform body: %w", err)
-				}
-
-				if yes, newHash := hasSameHash(newHeader, blockRange.hashes[i]); !yes {
-					log.Error("Hash mismatch", "block", blockNumber, "oldHash", common.BytesToHash(blockRange.hashes[i]), "newHash", newHash)
-					return fmt.Errorf("hash mismatch at block %d", blockNumber)
-				}
-
-				blockRange.headers[i] = newHeader
-				blockRange.bodies[i] = newBody
-			}
-			out <- blockRange
+		case out <- blockRange:
 		}
 	}
 	return nil


### PR DESCRIPTION
There's a deadlock in the migration script when migrating ancient blocks, where an error thrown in either the `transformBlocks` or `writeAncientBlocks` pipeline steps causes the previous pipeline step to hang when attempting to write to a channel that is no longer being read from by the pipeline step that threw the error.

This was detected when trying to run the migration script on an alfajores db snapshot that was taken after the alfajores cel2 migration. The script throws an error when attempting to transform a block that has no extra data field (because it is after the migration block). This error is expected, but what is unexpected is that the script ends up hanging in a deadlock instead of exiting with the error message. 

This PR fixes the bug by wrapping the channel writes in a select statement so that they don't block when the go routine that reads from the channel has already exited. 