### PR TITLE
Fix missing import in celo-migrate/main.go

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"time"


### PR DESCRIPTION
Looks like this was missed on the last PR for the celo-migrate tool.