### PR TITLE
Remove debugging function

### DIFF
--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -65,13 +65,6 @@ contract AnchorStateRegistry is Initializable, ISemver {
         superchainConfig = _superchainConfig;
     }
 
-    function setAnchorRoots(StartingAnchorRoot[] memory _startingAnchorRoots) public {
-        for (uint256 i = 0; i < _startingAnchorRoots.length; i++) {
-            StartingAnchorRoot memory startingAnchorRoot = _startingAnchorRoots[i];
-            anchors[startingAnchorRoot.gameType] = startingAnchorRoot.outputRoot;
-        }
-    }
-
     /// @notice Returns the DisputeGameFactory address.
     /// @return DisputeGameFactory address.
     function disputeGameFactory() external view returns (IDisputeGameFactory) {

--- a/packages/contracts-bedrock/src/dispute/interfaces/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IAnchorStateRegistry.sol
@@ -25,7 +25,6 @@ interface IAnchorStateRegistry {
         ICeloSuperchainConfig _superchainConfig
     )
         external;
-    function setAnchorRoots(StartingAnchorRoot[] memory _startingAnchorRoots) external;
     function setAnchorState(IFaultDisputeGame _game) external;
     function superchainConfig() external view returns (ICeloSuperchainConfig);
     function tryUpdateAnchorState() external;


### PR DESCRIPTION
`AnchorStateRegistry.setAnchorRoots` was needed temporarily for testing, this PR removes it.