### PR TITLE
Always deal eth to precompiles

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -153,9 +153,8 @@ contract L2Genesis is L2GenesisCelo {
         vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
 
-        if (cfg.deployCeloContracts()) {
-            dealEthToPrecompiles();
-        }
+        dealEthToPrecompiles();
+
         setPredeployProxies();
         setPredeployImplementations(_l1Dependencies);
         setPreinstalls();


### PR DESCRIPTION
Seems to me that ETH should be dealt to precompiles whether or not Celo contracts are getting deployed. This was causing the `L2Gensis.t:test_allocs_size` test to fail.

Potential further work: at the moment, we're not deploying Celo contracts in the unit test setup (`deployCeloContracts` is missing from `deploy-config/hardhat.json`). If we decide to enable it, `L2Gensis.t:test_allocs_size` will have to be updated with the appropriate number of addresses added by the Celo deployment.