### PR TITLE
Check DB Script fix, open DB without readonly flag

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -501,6 +501,19 @@ func runDBCheck(opts dbCheckOptions) (err error) {
 
 	log.Info("DB Continuity Check Started", "dbPath", opts.dbPath)
 
+	// We want to open the db in readonly mode to take advantage of concurrency, but opening in readonly
+	// mode will fail if the db is missing some files suffixed by ".meta". Our legacy celo db does not have
+	// ".meta" files, so opening in readonly mode will fail. Opening the db in readwrite mode will create the
+	// ".meta" files if they don't exist. So, we can open the db in readwrite mode and then close it so
+	// that the ".meta" files are created. We then reopen the db in readonly mode to run the actual script.
+	db, err := openDB(opts.dbPath, false)
+	if err != nil {
+		return fmt.Errorf("failed to open db in readwrite mode: %w", err)
+	}
+	if err = db.Close(); err != nil {
+		return fmt.Errorf("failed to close db in readwrite mode: %w", err)
+	}
+
 	ancientDB, err := NewChainFreezer(filepath.Join(opts.dbPath, "ancient"), "", true)
 	if err != nil {
 		return fmt.Errorf("failed to open ancient db: %w", err)


### PR DESCRIPTION
The optimism codebase expects there to be a certain type of file suffixed by `.meta` in the db that does not exist in our legacy dbs from cel1. These files are automatically created when we open the db in read/write mode using the optimism codebase, but not when we open in readonly mode. So, we need to add this change or else the script will fail when run on a legacy celo db for the first time.

I didn't detect this earlier because the datadirs I've been testing the continuity script with locally already had the `.meta` files created 

This came up in testing for https://github.com/celo-org/celo-l2-node-docker-compose/pull/32