### PR TITLE
Fix issue causing update-geth.sh fails

### DIFF
--- a/ops/celo/update-geth.sh
+++ b/ops/celo/update-geth.sh
@@ -37,12 +37,14 @@ docker_search_string="(.*op-geth\@sha256:)(.*)"
 gomod_search_string="^(replace github.com/ethereum/go-ethereum .*=> )github.com/.*/op-geth v.*"
 
 # Check that the searches are each matching a single line
-if [ "$(perl -ne "m|${docker_search_string}| && print" ops-bedrock/l2-op-geth.Dockerfile | wc -l)" != "1" ]; then
-  echo "Failed to find exactly one match for docker search string in ops-bedrock/l2-op-geth.Dockerfile" >&2
-  exit 1
+if [ -d "ops-bedrock" ]; then
+  if [ "$(perl -ne "m|${docker_search_string}| && print" ops-bedrock/l2-op-geth.Dockerfile | wc -l | tr -d '[:space:]')" != "1" ]; then
+    echo "Failed to find exactly one match for docker search string in ops-bedrock/l2-op-geth.Dockerfile" >&2
+    exit 1
+  fi
 fi
 
-if [ "$(perl -ne "m|${gomod_search_string}| && print" go.mod | wc -l)" != "1" ]; then
+if [ "$(perl -ne "m|${gomod_search_string}| && print" go.mod | wc -l | tr -d '[:space:]')" != "1" ]; then
   echo "Failed to find exactly one match for go mod search string in go.mod" >&2
   exit 1
 fi


### PR DESCRIPTION
Closes https://github.com/celo-org/optimism/issues/317

`ops/celo/update-geth.sh` and `Update celo-org/op-geth` action fail in `celo-rebase-12` branch because `ops-bedrock` directory no longer exists upstream after a PR https://github.com/ethereum-optimism/optimism/pull/13842 was merged.

This PR adds a check of existence of the directory for existing check.