### PR TITLE
CeloSuperchainConfig adjustements

### DIFF
--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -22,7 +22,7 @@ contract CeloSuperchainConfig is SuperchainConfig {
     /// @notice The address of the global OP Superchain SuperchainConfig contract.
     ///         It can only be modified by an upgrade.
     bytes32 public constant SUPERCHAIN_CONFIG_SLOT =
-        bytes32(uint256(keccak256("superchainConfig.superchainConfig")) - 1);
+        bytes32(uint256(keccak256("celoSuperchainConfig.superchainConfig")) - 1);
 
     /// @notice Emitted when configuration of the Celo-specific portion of the
     ///         config is updated.

--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -53,7 +53,8 @@ contract CeloSuperchainConfig is SuperchainConfig {
     ///         propagating the paused value from Superchain to Celo if
     ///         necessary.
     function checkAndPauseIfSuperchainPaused() public returns (bool paused_) {
-        if (ISuperchainConfig(superchainConfig()).paused()) {
+        address superchainConfig_ = superchainConfig();
+        if (superchainConfig_ != address(0) && ISuperchainConfig(superchainConfig_).paused()) {
             _pause("Superchain paused");
             return true;
         }

--- a/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
@@ -268,4 +268,46 @@ contract CeloSuperchainConfig_CheckAndPauseIfSuperchainPaused_Test is CeloSuperc
         paused = celoSuperchainConfig.paused();
         assertTrue(paused);
     }
+
+    /// @dev Tests that `checkAndPauseIfSuperchainPaused` works even if Superchain is not set.
+    function test_checkAndPauseIfSuperchainPaused_whenSuperchainNotSet() external {
+        IProxy newProxy = IProxy(
+            DeployUtils.create1({
+                _name: "Proxy",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (alice)))
+            })
+        );
+        ICeloSuperchainConfig newImpl = ICeloSuperchainConfig(
+            DeployUtils.create1({
+                _name: "CeloSuperchainConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ICeloSuperchainConfig.__constructor__, ()))
+            })
+        );
+
+        vm.startPrank(alice);
+        newProxy.upgradeToAndCall(
+            address(newImpl),
+            abi.encodeWithSignature("initialize(address,bool,address)", celoGuardian, false, address(0))
+        );
+        vm.stopPrank();
+
+        ICeloSuperchainConfig newCeloSuperchainConfig = ICeloSuperchainConfig(address(newProxy));
+
+        bool paused = newCeloSuperchainConfig.checkAndPauseIfSuperchainPaused();
+        assertFalse(paused);
+
+        vm.prank(newCeloSuperchainConfig.guardian());
+        newCeloSuperchainConfig.pause("identifier");
+        assertTrue(newCeloSuperchainConfig.paused());
+
+        paused = newCeloSuperchainConfig.checkAndPauseIfSuperchainPaused();
+        assertTrue(paused);
+
+        vm.prank(newCeloSuperchainConfig.guardian());
+        newCeloSuperchainConfig.unpause();
+        assertFalse(newCeloSuperchainConfig.paused());
+
+        paused = newCeloSuperchainConfig.paused();
+        assertFalse(paused);
+    }
 }


### PR DESCRIPTION
1. Use `celoSuperchainConfig` namespace for the storage slot introduced by CeloSuperchainConfig.
2. Check if `superchainConfig` is 0, avoiding a reversion if it's left unset.