### PR TITLE
Implement CeloSuperchainConfig standalone, without inheritance

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -153,7 +153,6 @@ contract L2Genesis is L2GenesisCelo {
         vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
 
-
         if (cfg.deployCeloContracts()) {
             dealEthToPrecompiles();
         }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
@@ -11,7 +11,7 @@ import { Deployer } from "scripts/deploy/Deployer.sol";
 import { LivenessGuard } from "src/safe/LivenessGuard.sol";
 import { LivenessModule } from "src/safe/LivenessModule.sol";
 import { DeputyGuardianModule } from "src/safe/DeputyGuardianModule.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 
 import { Deploy } from "./Deploy.s.sol";
 
@@ -38,7 +38,7 @@ struct SecurityCouncilConfig {
 /// @notice Configuration for the Deputy Guardian Module
 struct DeputyGuardianModuleConfig {
     address deputyGuardian;
-    ISuperchainConfig superchainConfig;
+    ICeloSuperchainConfig superchainConfig;
 }
 
 /// @notice Configuration for the Guardian Safe.
@@ -56,8 +56,8 @@ contract DeployOwnership is Deploy {
     /// @notice Internal function containing the deploy logic.
     function _run() internal override {
         console.log("start of Ownership Deployment");
-        // The SuperchainConfig is needed as a constructor argument to the Deputy Guardian Module
-        deploySuperchainConfig();
+        // The CeloSuperchainConfig is needed as a constructor argument to the Deputy Guardian Module
+        deployCeloSuperchainConfig();
 
         deployFoundationOperationsSafe();
         deployFoundationUpgradeSafe();
@@ -86,7 +86,7 @@ contract DeployOwnership is Deploy {
             safeConfig: SafeConfig({ threshold: 1, owners: exampleGuardianOwners }),
             deputyGuardianModuleConfig: DeputyGuardianModuleConfig({
                 deputyGuardian: mustGetAddress("FoundationOperationsSafe"),
-                superchainConfig: ISuperchainConfig(mustGetAddress("SuperchainConfig"))
+                superchainConfig: ICeloSuperchainConfig(mustGetAddress("CeloSuperchainConfig"))
             })
         });
     }

--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { SuperchainConfig } from "./SuperchainConfig.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { ISuperchainConfig } from "./interfaces/ISuperchainConfig.sol";
 import { Storage } from "src/libraries/Storage.sol";
 
@@ -11,24 +12,43 @@ import { Storage } from "src/libraries/Storage.sol";
 /// @notice The CeloSuperchainConfig contract is used to manage values that are
 /// typically part of the global superchain configuration, but potentially need to
 /// be handled differently by Celo.
-contract CeloSuperchainConfig is SuperchainConfig {
-    /// @notice Enum representing different types of updates for the Celo
-    //          extension of SuperchainConfig.
+contract CeloSuperchainConfig is Initializable, ISemver {
+    /// @notice Enum representing different types of updates.
+    /// @custom:value GUARDIAN           Represents an update to the guardian.
     /// @custom:value SUPERCHAIN_CONFIG  Represents an update to the SuperchainConfig address.
-    enum CeloUpdateType {
+    enum UpdateType {
+        GUARDIAN,
         SUPERCHAIN_CONFIG
     }
+
+    /// @notice Whether or not the Celo system is paused.
+    bytes32 public constant PAUSED_SLOT = bytes32(uint256(keccak256("celoSuperchainConfig.paused")) - 1);
+
+    /// @notice The address of the guardian, which can pause withdrawals from the System.
+    ///         It can only be modified by an upgrade.
+    bytes32 public constant GUARDIAN_SLOT = bytes32(uint256(keccak256("celoSuperchainConfig.guardian")) - 1);
 
     /// @notice The address of the global OP Superchain SuperchainConfig contract.
     ///         It can only be modified by an upgrade.
     bytes32 public constant SUPERCHAIN_CONFIG_SLOT =
         bytes32(uint256(keccak256("celoSuperchainConfig.superchainConfig")) - 1);
 
+    /// @notice Emitted when the pause is triggered.
+    /// @param identifier A string helping to identify provenance of the pause transaction.
+    event Paused(string identifier);
+
+    /// @notice Emitted when the pause is lifted.
+    event Unpaused();
+
     /// @notice Emitted when configuration of the Celo-specific portion of the
     ///         config is updated.
     /// @param updateType Type of update.
     /// @param data       Encoded update data.
-    event CeloConfigUpdate(CeloUpdateType indexed updateType, bytes data);
+    event ConfigUpdate(UpdateType indexed updateType, bytes data);
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0-beta.1
+    string public constant version = "1.0.0-beta.1";
 
     /// @notice Constructs the CeloSuperchainConfig contract.
     constructor() {
@@ -67,10 +87,15 @@ contract CeloSuperchainConfig is SuperchainConfig {
         superchainConfig_ = Storage.getAddress(SUPERCHAIN_CONFIG_SLOT);
     }
 
+    /// @notice Getter for the guardian address.
+    function guardian() public view returns (address guardian_) {
+        guardian_ = Storage.getAddress(GUARDIAN_SLOT);
+    }
+
     /// @notice Getter for the current paused status, which depends both on the
     ///         local paused value, and the paused status of Superchain.
-    function paused() public view override returns (bool paused_) {
-        paused_ = super.paused();
+    function paused() public view returns (bool paused_) {
+        paused_ = celoPaused();
         if (paused_) {
             return paused_;
         }
@@ -82,11 +107,47 @@ contract CeloSuperchainConfig is SuperchainConfig {
         return paused_;
     }
 
+    /// @notice Pauses withdrawals.
+    /// @param _identifier (Optional) A string to identify provenance of the pause transaction.
+    function pause(string memory _identifier) external {
+        require(msg.sender == guardian(), "CeloSuperchainConfig: only guardian can pause");
+        _pause(_identifier);
+    }
+
+    /// @notice Pauses withdrawals.
+    /// @param _identifier (Optional) A string to identify provenance of the pause transaction.
+    function _pause(string memory _identifier) internal {
+        Storage.setBool(PAUSED_SLOT, true);
+        emit Paused(_identifier);
+    }
+
+    /// @notice Unpauses withdrawals.
+    function unpause() external {
+        require(msg.sender == guardian(), "CeloSuperchainConfig: only guardian can unpause");
+        Storage.setBool(PAUSED_SLOT, false);
+        emit Unpaused();
+    }
+
+    /// @notice Getter for the current local paused value. Note that the actual paused status of the
+    ///         Celo system also depends on the paused status of the Superchain. Use `paused()` to
+    ///         get that.
+    function celoPaused() public view returns (bool paused_) {
+        paused_ = Storage.getBool(PAUSED_SLOT);
+    }
+
+    /// @notice Sets the guardian address. This is only callable during initialization, so an upgrade
+    ///         will be required to change the guardian.
+    /// @param _guardian The new guardian address.
+    function _setGuardian(address _guardian) internal {
+        Storage.setAddress(GUARDIAN_SLOT, _guardian);
+        emit ConfigUpdate(UpdateType.GUARDIAN, abi.encode(_guardian));
+    }
+
     /// @notice Sets the global SuperchainConfig address. This is only callable
     ///         during initialization, so an upgrade will be required to change this address.
     /// @param _superchainConfig The new SuperchainConfig address.
     function _setSuperchainConfig(address _superchainConfig) internal {
         Storage.setAddress(SUPERCHAIN_CONFIG_SLOT, _superchainConfig);
-        emit CeloConfigUpdate(CeloUpdateType.SUPERCHAIN_CONFIG, abi.encode(_superchainConfig));
+        emit ConfigUpdate(UpdateType.SUPERCHAIN_CONFIG, abi.encode(_superchainConfig));
     }
 }

--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -22,7 +22,7 @@ contract CeloSuperchainConfig is SuperchainConfig {
     /// @notice The address of the global OP Superchain SuperchainConfig contract.
     ///         It can only be modified by an upgrade.
     bytes32 public constant SUPERCHAIN_CONFIG_SLOT =
-        bytes32(uint256(keccak256("superchainConfig.superchainConfig")) - 1);
+        bytes32(uint256(keccak256("celoSuperchainConfig.superchainConfig")) - 1);
 
     /// @notice Emitted when configuration of the Celo-specific portion of the
     ///         config is updated.

--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -53,7 +53,8 @@ contract CeloSuperchainConfig is SuperchainConfig {
     ///         propagating the paused value from Superchain to Celo if
     ///         necessary.
     function checkAndPauseIfSuperchainPaused() public returns (bool paused_) {
-        if (ISuperchainConfig(superchainConfig()).paused()) {
+        address superchainConfig_ = superchainConfig();
+        if (superchainConfig_ != address(0) && ISuperchainConfig(superchainConfig_).paused()) {
             _pause("Superchain paused");
             return true;
         }

--- a/packages/contracts-bedrock/src/L1/interfaces/ICeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/interfaces/ICeloSuperchainConfig.sol
@@ -1,19 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ISuperchainConfig } from "./ISuperchainConfig.sol";
-
-interface ICeloSuperchainConfig is ISuperchainConfig {
-    enum CeloUpdateType {
+interface ICeloSuperchainConfig {
+    enum UpdateType {
+        GUARDIAN,
         SUPERCHAIN_CONFIG
     }
 
-    event CeloConfigUpdate(CeloUpdateType indexed updateType, bytes data);
+    event ConfigUpdate(UpdateType indexed updateType, bytes data);
+    event Paused(string identifier);
+    event Unpaused();
 
+    function GUARDIAN_SLOT() external view returns (bytes32);
+    function PAUSED_SLOT() external view returns (bytes32);
     function SUPERCHAIN_CONFIG_SLOT() external view returns (bytes32);
+    function guardian() external view returns (address guardian_);
     function initialize(address _guardian, bool _paused, address _superchainConfig) external;
     function superchainConfig() external view returns (address superchainConfig_);
+    function pause(string memory _identifier) external;
     function paused() external view returns (bool paused_);
+    function unpause() external;
     function checkAndPauseIfSuperchainPaused() external returns (bool paused_);
 
     function __constructor__() external;

--- a/packages/contracts-bedrock/src/safe/DeputyGuardianModule.sol
+++ b/packages/contracts-bedrock/src/safe/DeputyGuardianModule.sol
@@ -12,24 +12,24 @@ import { GameType, Timestamp } from "src/dispute/lib/Types.sol";
 // Interfaces
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 import { IOptimismPortal2 } from "src/L1/interfaces/IOptimismPortal2.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title DeputyGuardianModule
 /// @notice This module is intended to be enabled on the Security Council Safe, which will own the Guardian role in the
-///         SuperchainConfig contract. The DeputyGuardianModule should allow a Deputy Guardian to administer any of the
+///         CeloSuperchainConfig contract. The DeputyGuardianModule should allow a Deputy Guardian to administer any of the
 ///         actions that the Guardian is authorized to take. The security council can revoke the Deputy Guardian's
 ///         authorization at any time by disabling this module.
 contract DeputyGuardianModule is ISemver {
     /// @notice Error message for failed transaction execution
     error ExecutionFailed(string);
 
-    /// @notice Emitted when the SuperchainConfig is paused
+    /// @notice Emitted when the CeloSuperchainConfig is paused
     event Paused(string identifier);
 
-    /// @notice Emitted when the SuperchainConfig is unpaused
+    /// @notice Emitted when the CeloSuperchainConfig is unpaused
     event Unpaused();
 
     /// @notice Emitted when a DisputeGame is blacklisted
@@ -41,8 +41,8 @@ contract DeputyGuardianModule is ISemver {
     /// @notice The Safe contract instance
     Safe internal immutable SAFE;
 
-    /// @notice The SuperchainConfig's address
-    ISuperchainConfig internal immutable SUPERCHAIN_CONFIG;
+    /// @notice The CeloSuperchainConfig's address
+    ICeloSuperchainConfig internal immutable SUPERCHAIN_CONFIG;
 
     /// @notice The deputy guardian's address
     address internal immutable DEPUTY_GUARDIAN;
@@ -52,7 +52,7 @@ contract DeputyGuardianModule is ISemver {
     string public constant version = "2.0.1-beta.4";
 
     // Constructor to initialize the Safe and baseModule instances
-    constructor(Safe _safe, ISuperchainConfig _superchainConfig, address _deputyGuardian) {
+    constructor(Safe _safe, ICeloSuperchainConfig _superchainConfig, address _deputyGuardian) {
         SAFE = _safe;
         SUPERCHAIN_CONFIG = _superchainConfig;
         DEPUTY_GUARDIAN = _deputyGuardian;
@@ -64,9 +64,9 @@ contract DeputyGuardianModule is ISemver {
         safe_ = SAFE;
     }
 
-    /// @notice Getter function for the SuperchainConfig's address
-    /// @return superchainConfig_ The SuperchainConfig's address
-    function superchainConfig() public view returns (ISuperchainConfig superchainConfig_) {
+    /// @notice Getter function for the CeloSuperchainConfig's address
+    /// @return superchainConfig_ The CeloSuperchainConfig's address
+    function superchainConfig() public view returns (ICeloSuperchainConfig superchainConfig_) {
         superchainConfig_ = SUPERCHAIN_CONFIG;
     }
 
@@ -84,7 +84,7 @@ contract DeputyGuardianModule is ISemver {
     }
 
     /// @notice Calls the Security Council Safe's `execTransactionFromModuleReturnData()`, with the arguments
-    ///      necessary to call `pause()` on the `SuperchainConfig` contract.
+    ///      necessary to call `pause()` on the `CeloSuperchainConfig` contract.
     ///      Only the deputy guardian can call this function.
     function pause() external {
         _onlyDeputyGuardian();
@@ -99,7 +99,7 @@ contract DeputyGuardianModule is ISemver {
     }
 
     /// @notice Calls the Security Council Safe's `execTransactionFromModuleReturnData()`, with the arguments
-    ///      necessary to call `unpause()` on the `SuperchainConfig` contract.
+    ///      necessary to call `unpause()` on the `CeloSuperchainConfig` contract.
     ///      Only the deputy guardian can call this function.
     function unpause() external {
         _onlyDeputyGuardian();

--- a/packages/contracts-bedrock/src/safe/interfaces/IDeputyGuardianModule.sol
+++ b/packages/contracts-bedrock/src/safe/interfaces/IDeputyGuardianModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 import { IOptimismPortal2 } from "src/L1/interfaces/IOptimismPortal2.sol";
 import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
@@ -20,9 +20,9 @@ interface IDeputyGuardianModule is ISemver {
     event RespectedGameTypeSet(GameType indexed gameType, Timestamp indexed updatedAt);
 
     function version() external view returns (string memory);
-    function __constructor__(Safe _safe, ISuperchainConfig _superchainConfig, address _deputyGuardian) external;
+    function __constructor__(Safe _safe, ICeloSuperchainConfig _superchainConfig, address _deputyGuardian) external;
     function safe() external view returns (Safe safe_);
-    function superchainConfig() external view returns (ISuperchainConfig superchainConfig_);
+    function superchainConfig() external view returns (ICeloSuperchainConfig superchainConfig_);
     function deputyGuardian() external view returns (address deputyGuardian_);
     function pause() external;
     function unpause() external;

--- a/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
@@ -268,4 +268,46 @@ contract CeloSuperchainConfig_CheckAndPauseIfSuperchainPaused_Test is CeloSuperc
         paused = celoSuperchainConfig.paused();
         assertTrue(paused);
     }
+
+    /// @dev Tests that `checkAndPauseIfSuperchainPaused` works even if Superchain is not set.
+    function test_checkAndPauseIfSuperchainPaused_whenSuperchainNotSet() external {
+        IProxy newProxy = IProxy(
+            DeployUtils.create1({
+                _name: "Proxy",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (alice)))
+            })
+        );
+        ICeloSuperchainConfig newImpl = ICeloSuperchainConfig(
+            DeployUtils.create1({
+                _name: "CeloSuperchainConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ICeloSuperchainConfig.__constructor__, ()))
+            })
+        );
+
+        vm.startPrank(alice);
+        newProxy.upgradeToAndCall(
+            address(newImpl),
+            abi.encodeWithSignature("initialize(address,bool,address)", celoGuardian, false, address(0))
+        );
+        vm.stopPrank();
+
+        ICeloSuperchainConfig newCeloSuperchainConfig = ICeloSuperchainConfig(address(newProxy));
+
+        bool paused = newCeloSuperchainConfig.checkAndPauseIfSuperchainPaused();
+        assertFalse(paused);
+
+        vm.prank(newCeloSuperchainConfig.guardian());
+        newCeloSuperchainConfig.pause("identifier");
+        assertTrue(newCeloSuperchainConfig.paused());
+
+        paused = newCeloSuperchainConfig.checkAndPauseIfSuperchainPaused();
+        assertTrue(paused);
+
+        vm.prank(newCeloSuperchainConfig.guardian());
+        newCeloSuperchainConfig.unpause();
+        assertFalse(newCeloSuperchainConfig.paused());
+
+        paused = newCeloSuperchainConfig.paused();
+        assertFalse(paused);
+    }
 }

--- a/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/CeloSuperchainConfig.t.sol
@@ -98,7 +98,7 @@ contract CeloSuperchainConfig_Pause_TestFail is CeloSuperchainConfig_Test_Setup 
         assertFalse(celoSuperchainConfig.paused());
 
         assertTrue(celoSuperchainConfig.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can pause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can pause");
         vm.prank(alice);
         celoSuperchainConfig.pause("identifier");
 
@@ -116,7 +116,7 @@ contract CeloSuperchainConfig_Pause_TestFail is CeloSuperchainConfig_Test_Setup 
             vm.skip(true);
         }
 
-        vm.expectRevert("SuperchainConfig: only guardian can pause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can pause");
         vm.prank(superchainConfigGuardian);
         celoSuperchainConfig.pause("identifier");
 
@@ -147,7 +147,7 @@ contract CeloSuperchainConfig_Unpause_TestFail is CeloSuperchainConfig_Test_Setu
         assertEq(celoSuperchainConfig.paused(), true);
 
         assertTrue(celoSuperchainConfig.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can unpause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can unpause");
         vm.prank(alice);
         celoSuperchainConfig.unpause();
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal.t.sol
@@ -9,9 +9,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
-// Contracts
-import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
-
 // Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
@@ -108,7 +105,7 @@ contract OptimismPortal_Test is CommonTest {
         assertEq(optimismPortal.paused(), false);
 
         assertTrue(optimismPortal.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can pause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can pause");
         vm.prank(alice);
         celoSuperchainConfig.pause("identifier");
 
@@ -141,7 +138,7 @@ contract OptimismPortal_Test is CommonTest {
         assertEq(optimismPortal.paused(), true);
 
         assertTrue(optimismPortal.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can unpause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can unpause");
         vm.prank(alice);
         celoSuperchainConfig.unpause();
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -9,9 +9,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
-// Contracts
-import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
-
 // Libraries
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
@@ -108,7 +105,7 @@ contract OptimismPortal2_Test is CommonTest {
         assertEq(optimismPortal2.paused(), false);
 
         assertTrue(optimismPortal2.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can pause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can pause");
         vm.prank(alice);
         celoSuperchainConfig.pause("identifier");
 
@@ -141,7 +138,7 @@ contract OptimismPortal2_Test is CommonTest {
         assertEq(optimismPortal2.paused(), true);
 
         assertTrue(optimismPortal2.guardian() != alice);
-        vm.expectRevert("SuperchainConfig: only guardian can unpause");
+        vm.expectRevert("CeloSuperchainConfig: only guardian can unpause");
         vm.prank(alice);
         celoSuperchainConfig.unpause();
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -927,11 +927,11 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("SUPERCHAIN_CONFIG_SLOT()") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("guardian()") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("superchainConfig()") });
-        _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("initialize(address,bool)") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("initialize(address,bool,address)") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("pause(string)") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("checkAndPauseIfSuperchainPaused()") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("paused()") });
+        _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("celoPaused()") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("unpause()") });
         _addSpec({ _name: "CeloSuperchainConfig", _sel: _getSel("version()") });
     }


### PR DESCRIPTION
To avoid interface problems (e.g. SuperchainConfig had a 2-argument `initialize`, while CeloSuperchainConfig has a 3-argument `initialize`), as well as to decouple the Celo contract from potential future changes to SuperchainConfig, CeloSuperchainConfig is now a standalone contract, without inheriting from SuperchainConfig.

This required some changes to tests, as well as to the DeputyGuardianModule (and related script/tests), which now expects a CeloSuperchainConfig.