### PR TITLE
Use CeloSuperchainConfig in DelayedWETH

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -153,7 +153,6 @@ contract L2Genesis is L2GenesisCelo {
         vm.startPrank(deployer);
         vm.chainId(cfg.l2ChainID());
 
-
         if (cfg.deployCeloContracts()) {
             dealEthToPrecompiles();
         }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -213,7 +213,7 @@ library ChainAssertions {
         if (_isProxy) {
             require(weth.owner() == _expectedOwner);
             require(weth.delay() == _cfg.faultGameWithdrawalDelay());
-            require(weth.config() == ISuperchainConfig(_contracts.SuperchainConfig));
+            require(weth.config() == ISuperchainConfig(_contracts.CeloSuperchainConfig));
         } else {
             require(weth.owner() == _expectedOwner);
             require(weth.delay() == _cfg.faultGameWithdrawalDelay());
@@ -239,7 +239,7 @@ library ChainAssertions {
         if (_isProxy) {
             require(weth.owner() == _expectedOwner);
             require(weth.delay() == _cfg.faultGameWithdrawalDelay());
-            require(weth.config() == ISuperchainConfig(_contracts.SuperchainConfig));
+            require(weth.config() == ISuperchainConfig(_contracts.CeloSuperchainConfig));
         } else {
             require(weth.owner() == _expectedOwner);
             require(weth.delay() == _cfg.faultGameWithdrawalDelay());

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -1081,12 +1081,14 @@ contract Deploy is Deployer {
         console.log("Upgrading and initializing DelayedWETH proxy");
         address delayedWETHProxy = mustGetAddress("DelayedWETHProxy");
         address delayedWETH = mustGetAddress("DelayedWETH");
-        address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
+        address celoSuperchainConfigProxy = mustGetAddress("CeloSuperchainConfigProxy");
 
         _upgradeAndCallViaSafe({
             _proxy: payable(delayedWETHProxy),
             _implementation: delayedWETH,
-            _innerCallData: abi.encodeCall(IDelayedWETH.initialize, (msg.sender, ISuperchainConfig(superchainConfigProxy)))
+            _innerCallData: abi.encodeCall(
+                IDelayedWETH.initialize, (msg.sender, ICeloSuperchainConfig(celoSuperchainConfigProxy))
+            )
         });
 
         string memory version = IDelayedWETH(payable(delayedWETHProxy)).version();
@@ -1104,12 +1106,14 @@ contract Deploy is Deployer {
         console.log("Upgrading and initializing permissioned DelayedWETH proxy");
         address delayedWETHProxy = mustGetAddress("PermissionedDelayedWETHProxy");
         address delayedWETH = mustGetAddress("DelayedWETH");
-        address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
+        address celoSuperchainConfigProxy = mustGetAddress("CeloSuperchainConfigProxy");
 
         _upgradeAndCallViaSafe({
             _proxy: payable(delayedWETHProxy),
             _implementation: delayedWETH,
-            _innerCallData: abi.encodeCall(IDelayedWETH.initialize, (msg.sender, ISuperchainConfig(superchainConfigProxy)))
+            _innerCallData: abi.encodeCall(
+                IDelayedWETH.initialize, (msg.sender, ICeloSuperchainConfig(celoSuperchainConfigProxy))
+            )
         });
 
         string memory version = IDelayedWETH(payable(delayedWETHProxy)).version();

--- a/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDelayedWETH.s.sol
@@ -14,7 +14,7 @@ import { LibString } from "@solady/utils/LibString.sol";
 // Interfaces
 import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 
 /// @title DeployDelayedWETH
 contract DeployDelayedWETHInput is BaseDeployIO {
@@ -22,7 +22,7 @@ contract DeployDelayedWETHInput is BaseDeployIO {
     string internal _release;
     string internal _standardVersionsToml;
     address public _proxyAdmin;
-    ISuperchainConfig public _superchainConfigProxy;
+    ICeloSuperchainConfig public _superchainConfigProxy;
     address public _delayedWethOwner;
     uint256 public _delayedWethDelay;
 
@@ -41,7 +41,7 @@ contract DeployDelayedWETHInput is BaseDeployIO {
             _proxyAdmin = _value;
         } else if (_sel == this.superchainConfigProxy.selector) {
             require(_value != address(0), "DeployDelayedWETH: superchainConfigProxy cannot be zero address");
-            _superchainConfigProxy = ISuperchainConfig(_value);
+            _superchainConfigProxy = ICeloSuperchainConfig(_value);
         } else if (_sel == this.delayedWethOwner.selector) {
             require(_value != address(0), "DeployDelayedWETH: delayedWethOwner cannot be zero address");
             _delayedWethOwner = _value;
@@ -77,7 +77,7 @@ contract DeployDelayedWETHInput is BaseDeployIO {
         return _proxyAdmin;
     }
 
-    function superchainConfigProxy() public view returns (ISuperchainConfig) {
+    function superchainConfigProxy() public view returns (ICeloSuperchainConfig) {
         require(address(_superchainConfigProxy) != address(0), "DeployDisputeGame: superchainConfigProxy not set");
         return _superchainConfigProxy;
     }

--- a/packages/contracts-bedrock/scripts/upgrades/holocene/DeployUpgrade.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/holocene/DeployUpgrade.s.sol
@@ -13,7 +13,7 @@ import { Claim, GameTypes, Duration } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 import { IProxy } from "src/universal/interfaces/IProxy.sol";
 import {
     IFaultDisputeGame,
@@ -96,7 +96,7 @@ contract DeployUpgrade is Deployer {
         public
     {
         prankDeployment("ProxyAdmin", _proxyAdmin);
-        prankDeployment("SuperchainConfig", _superchainConfig);
+        prankDeployment("CeloSuperchainConfig", _superchainConfig);
         if (_systemConfigImpl != address(0)) prankDeployment("SystemConfig", _systemConfigImpl);
         if (_mipsImpl != address(0)) prankDeployment("MIPS", _mipsImpl);
         if (_delayedWETH != address(0)) prankDeployment("DelayedWETH", _delayedWETH);
@@ -285,7 +285,7 @@ contract DeployUpgrade is Deployer {
         address delayedWethOwner = cfg.finalSystemOwner();
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         address impl = mustGetAddress("DelayedWETH");
-        ISuperchainConfig superchainConfig = ISuperchainConfig(mustGetAddress("SuperchainConfig"));
+        ICeloSuperchainConfig superchainConfig = ICeloSuperchainConfig(mustGetAddress("CeloSuperchainConfig"));
         string memory finalName = string.concat("DelayedWETHProxy", _variant);
 
         // Deploy the implementation and proxy contracts.
@@ -318,7 +318,7 @@ contract DeployUpgrade is Deployer {
             delayedWeth.delay() == cfg.faultGameWithdrawalDelay(), "DeployHoloceneUpgrade: invalid DelayedWETH delay"
         );
         require(
-            delayedWeth.config() == ISuperchainConfig(mustGetAddress("SuperchainConfig")),
+            delayedWeth.config() == ICeloSuperchainConfig(mustGetAddress("CeloSuperchainConfig")),
             "DeployHoloceneUpgrade: invalid DelayedWETH config"
         );
 

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -7,7 +7,7 @@ import { WETH98 } from "src/universal/WETH98.sol";
 
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 
 /// @custom:proxied true
 /// @title DelayedWETH
@@ -41,19 +41,19 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
     /// @notice Withdrawal delay in seconds.
     uint256 internal immutable DELAY_SECONDS;
 
-    /// @notice Address of the SuperchainConfig contract.
-    ISuperchainConfig public config;
+    /// @notice Address of the CeloSuperchainConfig contract.
+    ICeloSuperchainConfig public config;
 
     /// @param _delay The delay for withdrawals in seconds.
     constructor(uint256 _delay) {
         DELAY_SECONDS = _delay;
-        initialize({ _owner: address(0), _config: ISuperchainConfig(address(0)) });
+        initialize({ _owner: address(0), _config: ICeloSuperchainConfig(address(0)) });
     }
 
     /// @notice Initializes the contract.
     /// @param _owner The address of the owner.
-    /// @param _config Address of the SuperchainConfig contract.
-    function initialize(address _owner, ISuperchainConfig _config) public initializer {
+    /// @param _config Address of the CeloSuperchainConfig contract.
+    function initialize(address _owner, ICeloSuperchainConfig _config) public initializer {
         __Ownable_init();
         _transferOwnership(_owner);
         config = _config;
@@ -89,7 +89,7 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
     /// @param _guy Sub-account to withdraw from.
     /// @param _wad The amount of WETH to withdraw.
     function withdraw(address _guy, uint256 _wad) public {
-        require(!config.paused(), "DelayedWETH: contract is paused");
+        require(!config.checkAndPauseIfSuperchainPaused(), "DelayedWETH: contract is paused");
         WithdrawalRequest storage wd = withdrawals[msg.sender][_guy];
         require(wd.amount >= _wad, "DelayedWETH: insufficient unlocked withdrawal");
         require(wd.timestamp > 0, "DelayedWETH: withdrawal not unlocked");

--- a/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/interfaces/IDelayedWETH.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 
 interface IDelayedWETH {
     struct WithdrawalRequest {
@@ -16,10 +16,10 @@ interface IDelayedWETH {
     fallback() external payable;
     receive() external payable;
 
-    function config() external view returns (ISuperchainConfig);
+    function config() external view returns (ICeloSuperchainConfig);
     function delay() external view returns (uint256);
     function hold(address _guy, uint256 _wad) external;
-    function initialize(address _owner, ISuperchainConfig _config) external;
+    function initialize(address _owner, ICeloSuperchainConfig _config) external;
     function owner() external view returns (address);
     function recover(uint256 _wad) external;
     function transferOwnership(address newOwner) external; // nosemgrep

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -30,7 +30,7 @@ contract DelayedWETH_Initialize_Test is DelayedWETH_Init {
     /// @dev Tests that initialization is successful.
     function test_initialize_succeeds() public view {
         assertEq(delayedWeth.owner(), address(this));
-        assertEq(address(delayedWeth.config()), address(superchainConfig));
+        assertEq(address(delayedWeth.config()), address(celoSuperchainConfig));
     }
 }
 
@@ -158,7 +158,7 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_Init {
         // Pause the contract.
         address guardian = optimismPortal.guardian();
         vm.prank(guardian);
-        superchainConfig.pause("identifier");
+        celoSuperchainConfig.pause("identifier");
 
         // Withdraw fails.
         vm.expectRevert("DelayedWETH: contract is paused");

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -18,7 +18,6 @@ import "scripts/deploy/Deployer.sol";
 // Interfaces
 import { ISystemConfig } from "src/L1/interfaces/ISystemConfig.sol";
 import { IResourceMetering } from "src/L1/interfaces/IResourceMetering.sol";
-import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
 import { ICeloSuperchainConfig } from "src/L1/interfaces/ICeloSuperchainConfig.sol";
 import { ProtocolVersion } from "src/L1/interfaces/IProtocolVersions.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
@@ -112,7 +111,7 @@ contract Initializer_Test is Bridge_Initializer {
             InitializeableContract({
                 name: "DelayedWETH",
                 target: deploy.mustGetAddress("DelayedWETH"),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ISuperchainConfig(address(0))))
+                initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ICeloSuperchainConfig(address(0))))
             })
         );
         // DelayedWETHProxy
@@ -120,7 +119,7 @@ contract Initializer_Test is Bridge_Initializer {
             InitializeableContract({
                 name: "DelayedWETHProxy",
                 target: address(delayedWeth),
-                initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ISuperchainConfig(address(0))))
+                initCalldata: abi.encodeCall(delayedWeth.initialize, (address(0), ICeloSuperchainConfig(address(0))))
             })
         );
         // L2OutputOracleImpl


### PR DESCRIPTION
DelayedWETH wasn't updated to use CeloSuperchainConfig, now it does. 

This also includes changes to (necessary for compilation):
* DeployDelayedWETH.s.sol, which shouldn't matter since we deploy directly in Deploy.s.sol. 
* upgrades/holocene/DeployUpgrade.s.sol, which I'm assuming shouldn't matter since we'll be deploying a fresh system anyways, not relying on any of the current upgrade scripts?
