### PR TITLE
Fix migration script failure to delete frozen canonical blocks

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -225,16 +225,8 @@ func writeAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, in <-chan R
 }
 
 // getStrayAncientBlocks returns a list of ancient block numbers / hashes that somehow were not removed from leveldb
-func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error) {
+func getStrayAncientBlocks(dbPath string, numAncients uint64) (blocks []*rawdb.NumberHash, err error) {
 	defer timer("getStrayAncientBlocks")()
-
-	ancientDB, err := NewChainFreezer(filepath.Join(dbPath, "ancient"), "", true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open ancient db: %w", err)
-	}
-	defer func() {
-		err = errors.Join(err, ancientDB.Close())
-	}()
 
 	db, err := openDBWithoutFreezer(dbPath, true)
 	if err != nil {
@@ -243,11 +235,6 @@ func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error
 	defer func() {
 		err = errors.Join(err, db.Close())
 	}()
-
-	numAncients, err := ancientDB.Ancients()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get number of ancients in database: %w", err)
-	}
 
 	return rawdb.ReadAllHashesInRange(db, 1, numAncients-1), nil
 }

--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -228,15 +228,23 @@ func writeAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, in <-chan R
 func getStrayAncientBlocks(dbPath string) (blocks []*rawdb.NumberHash, err error) {
 	defer timer("getStrayAncientBlocks")()
 
-	db, err := openDB(dbPath, true)
+	ancientDB, err := NewChainFreezer(filepath.Join(dbPath, "ancient"), "", true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database: %w", err)
+		return nil, fmt.Errorf("failed to open ancient db: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, ancientDB.Close())
+	}()
+
+	db, err := openDBWithoutFreezer(dbPath, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open non-ancient database: %w", err)
 	}
 	defer func() {
 		err = errors.Join(err, db.Close())
 	}()
 
-	numAncients, err := db.Ancients()
+	numAncients, err := ancientDB.Ancients()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get number of ancients in database: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -68,25 +68,6 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
-// Opens a database with access to AncientsDb
-func openDB(chaindataPath string, readOnly bool) (ethdb.Database, error) {
-	// Will throw an error if the chaindataPath does not exist
-	if _, err := os.Stat(chaindataPath); err != nil {
-		return nil, err
-	}
-
-	kvs, err := leveldb.New(chaindataPath, 1024, 60, "", readOnly)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open leveldb: %w", err)
-	}
-	db, err := rawdb.NewDatabaseWithFreezer(kvs, filepath.Join(chaindataPath, "ancient"), "", false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open db with freezer: %w", err)
-	}
-
-	return db, nil
-}
-
 // Opens a database without access to AncientsDb
 func openDBWithoutFreezer(chaindataPath string, readOnly bool) (ethdb.Database, error) {
 	if _, err := os.Stat(chaindataPath); err != nil {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -501,20 +501,21 @@ func runDBCheck(opts dbCheckOptions) (err error) {
 
 	log.Info("DB Continuity Check Started", "dbPath", opts.dbPath)
 
-	// We want to open the db in readonly mode to take advantage of concurrency, but opening in readonly
+	// We want to open the ancient db in readonly mode to take advantage of concurrency, but opening in readonly
 	// mode will fail if the db is missing some files suffixed by ".meta". Our legacy celo db does not have
 	// ".meta" files, so opening in readonly mode will fail. Opening the db in readwrite mode will create the
 	// ".meta" files if they don't exist. So, we can open the db in readwrite mode and then close it so
 	// that the ".meta" files are created. We then reopen the db in readonly mode to run the actual script.
-	db, err := openDB(opts.dbPath, false)
+	ancientDB, err := NewChainFreezer(filepath.Join(opts.dbPath, "ancient"), "", false)
 	if err != nil {
-		return fmt.Errorf("failed to open db in readwrite mode: %w", err)
+		return fmt.Errorf("failed to open ancient db: %w", err)
 	}
-	if err = db.Close(); err != nil {
-		return fmt.Errorf("failed to close db in readwrite mode: %w", err)
+	err = ancientDB.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close ancient db: %w", err)
 	}
 
-	ancientDB, err := NewChainFreezer(filepath.Join(opts.dbPath, "ancient"), "", true)
+	ancientDB, err = NewChainFreezer(filepath.Join(opts.dbPath, "ancient"), "", true)
 	if err != nil {
 		return fmt.Errorf("failed to open ancient db: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -343,7 +343,7 @@ func runPreMigration(opts preMigrationOptions) ([]*rawdb.NumberHash, uint64, err
 		}
 		// Scanning for stray ancient blocks is slow, so we do it as soon as we can after the lock on oldDB is released by migrateAncientsDb
 		// Doing this in parallel with copyDbExceptAncients still saves time if ancients have already been pre-migrated
-		if strayAncientBlocks, err = getStrayAncientBlocks(opts.oldDBPath); err != nil {
+		if strayAncientBlocks, err = getStrayAncientBlocks(opts.oldDBPath, numAncientsNewAfter); err != nil {
 			return fmt.Errorf("failed to get stray ancient blocks: %w", err)
 		}
 		return nil


### PR DESCRIPTION
The script was failing with the following error:

CRIT [02-18|12:13:04.161] Failed to delete frozen canonical blocks err="leveldb: read-only mode"

This was due to use of NewDatabaseWithFreezer with the readonly parameter set to true. Internally NewDatabaseWithFreezer kicks off a go-routine that freezes blocks and deletes the frozen blocks from the non-ancient db.

If it tries to delete frozen blocks when read-only is true it results in a critical failure.

The fix here is to avoid using NewDatabaseWithFreezer at all, since we do not want the migrations script to actually modify the source datadir.

# Tested
~~Not yet, I'm not sure how to test this, we require local blocks in the non-ancients db that haven't been frozen at the time the migration script is run, will probably need to go through a bit of trial and error to set that up.~~

Update: I synced an alfajores node for a while, stopped it. Manually inspected the db to see that there were blocks needing to be frozen, made a copy of that datadir then used that with the failing version of the migration tool to run pre-migrate and reproduced the error. Then made another copy of the original datadir and tried with this version and saw that pre-migrate worked. Also checked that a fresh full-migrate worked and full-migrate following a pre-migrate worked.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/912