### PR TITLE
Remove usage of stateful pause check

### DIFF
--- a/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -73,7 +73,7 @@ contract L1ERC721Bridge is ERC721Bridge, ISemver {
         external
         onlyOtherBridge
     {
-        require(superchainConfig.checkAndPauseIfSuperchainPaused() == false, "L1ERC721Bridge: paused");
+        require(paused() == false, "L1ERC721Bridge: paused");
         require(_localToken != address(this), "L1ERC721Bridge: local token cannot be self");
 
         // Checks that the L1/L2 NFT pair has a token ID that is escrowed in the L1 Bridge.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal.sol
@@ -141,7 +141,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
 
     /// @notice Reverts when paused.
     modifier whenNotPaused() {
-        if (superchainConfig.checkAndPauseIfSuperchainPaused()) revert CallPaused();
+        if (paused()) revert CallPaused();
         _;
     }
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -178,7 +178,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
 
     /// @notice Reverts when paused.
     modifier whenNotPaused() {
-        if (superchainConfig.checkAndPauseIfSuperchainPaused()) revert CallPaused();
+        if (paused()) revert CallPaused();
         _;
     }
 

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -89,7 +89,7 @@ contract DelayedWETH is OwnableUpgradeable, WETH98, ISemver {
     /// @param _guy Sub-account to withdraw from.
     /// @param _wad The amount of WETH to withdraw.
     function withdraw(address _guy, uint256 _wad) public {
-        require(!config.checkAndPauseIfSuperchainPaused(), "DelayedWETH: contract is paused");
+        require(!config.paused(), "DelayedWETH: contract is paused");
         WithdrawalRequest storage wd = withdrawals[msg.sender][_guy];
         require(wd.amount >= _wad, "DelayedWETH: insufficient unlocked withdrawal");
         require(wd.timestamp > 0, "DelayedWETH: withdrawal not unlocked");


### PR DESCRIPTION
`checkAndPauseIfSuperchainPaused` is useless to call from contracts, as at every callsite, the call reverts if state were to change. So changing back to the `view` `paused()` check. 