### PR TITLE
Change name of Celo L1 Token

### DIFF
--- a/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
-string constant NAME = "Celo";
-string constant SYMBOL = "CELO";
-uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 
 contract CeloTokenL1 is ERC20Upgradeable {
+    string constant NAME = "Celo";
+    string constant SYMBOL = "CELO";
+    uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
     constructor() {
         _disableInitializers();
     }

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
-
 contract CeloTokenL1 is ERC20Upgradeable {
     string constant NAME = "Celo";
     string constant SYMBOL = "CELO";

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
-string constant NAME = "Celo native asset";
+string constant NAME = "Celo";
 string constant SYMBOL = "CELO";
 uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.0;
 import { ERC20Permit } from "@openzeppelin/contracts-v5/token/ERC20/extensions/ERC20Permit.sol";
 import { ERC20 } from "@openzeppelin/contracts-v5/token/ERC20/ERC20.sol";
 
-
-
 contract CeloTokenL1Permit is ERC20Permit {
     string constant NAME = "Celo";
     string constant SYMBOL = "CELO";

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.0;
 import { ERC20Permit } from "@openzeppelin/contracts-v5/token/ERC20/extensions/ERC20Permit.sol";
 import { ERC20 } from "@openzeppelin/contracts-v5/token/ERC20/ERC20.sol";
 
-string constant NAME = "Celo";
-string constant SYMBOL = "CELO";
-uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
+
 
 contract CeloTokenL1Permit is ERC20Permit {
+    string constant NAME = "Celo";
+    string constant SYMBOL = "CELO";
+    uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 
     constructor(address portalProxyAddress) ERC20(NAME, SYMBOL) ERC20Permit(NAME) {
         _mint(portalProxyAddress, TOTAL_MARKET_CAP);

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import { ERC20Permit } from "@openzeppelin/contracts-v5/token/ERC20/extensions/ERC20Permit.sol";
 import { ERC20 } from "@openzeppelin/contracts-v5/token/ERC20/ERC20.sol";
 
-string constant NAME = "Celo native asset";
+string constant NAME = "Celo";
 string constant SYMBOL = "CELO";
 uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 


### PR DESCRIPTION
After some internal discussion we wanted to change the name of the L1 Celo token representation.
Not sure if this was the final name we settled on, but putting this here so we don't forget.

Also, the future L2 representation (current L1 GoldToken token) has the name _"Celo native asset"_, so I don't know if this should actually change, since the names would differ.

@palango did we figure this out and also consider the discrepancy to the name on the current L1?