### PR TITLE
Move constants inside contracts

### DIFF
--- a/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/CeloSuperchainConfig.sol
@@ -34,6 +34,7 @@ contract CeloSuperchainConfig is Initializable, ISemver {
         bytes32(uint256(keccak256("celoSuperchainConfig.superchainConfig")) - 1);
     /// @notice Emitted when the pause is triggered.
     /// @param identifier A string helping to identify provenance of the pause transaction.
+
     event Paused(string identifier);
 
     /// @notice Emitted when the pause is lifted.

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
-string constant NAME = "Celo native asset";
-string constant SYMBOL = "CELO";
-uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
-
 contract CeloTokenL1 is ERC20Upgradeable {
+    string constant NAME = "Celo native asset";
+    string constant SYMBOL = "CELO";
+    uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
+
     constructor() {
         _disableInitializers();
     }

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.0;
 import { ERC20Permit } from "@openzeppelin/contracts-v5/token/ERC20/extensions/ERC20Permit.sol";
 import { ERC20 } from "@openzeppelin/contracts-v5/token/ERC20/ERC20.sol";
 
-string constant NAME = "Celo native asset";
-string constant SYMBOL = "CELO";
-uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
-
 contract CeloTokenL1Permit is ERC20Permit {
+    string constant NAME = "Celo native asset";
+    string constant SYMBOL = "CELO";
+    uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
+
     constructor(address portalProxyAddress) ERC20(NAME, SYMBOL) ERC20Permit(NAME) {
         _mint(portalProxyAddress, TOTAL_MARKET_CAP);
     }

--- a/packages/contracts-bedrock/src/safe/DeputyGuardianModule.sol
+++ b/packages/contracts-bedrock/src/safe/DeputyGuardianModule.sol
@@ -19,8 +19,8 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 
 /// @title DeputyGuardianModule
 /// @notice This module is intended to be enabled on the Security Council Safe, which will own the Guardian role in the
-///         CeloSuperchainConfig contract. The DeputyGuardianModule should allow a Deputy Guardian to administer any of the
-///         actions that the Guardian is authorized to take. The security council can revoke the Deputy Guardian's
+///         CeloSuperchainConfig contract. The DeputyGuardianModule should allow a Deputy Guardian to administer any of
+///         the actions that the Guardian is authorized to take. The security council can revoke the Deputy Guardian's
 ///         authorization at any time by disabling this module.
 contract DeputyGuardianModule is ISemver {
     /// @notice Error message for failed transaction execution


### PR DESCRIPTION
Small stylistic change: CeloTokenL1 and CeloTokenL1Permit had constants defined outside the `contract` declaration. Moved them inside for stylistic consistency.

And some minor whitespace changes caught by the linter.