### PR TITLE
Deterministic L1 starting block selection (Config in advance)

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -16,6 +16,7 @@ import (
 const (
 	beaconChainGenesisTimeSeconds  = 1606824000
 	beaconChainSlotDurationSeconds = 12
+	beaconSlotsPerEpoch            = 32
 )
 
 type beaconClient struct {

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -37,12 +37,12 @@ func NewBeaconClient(beaconRPC string, beaconchainURL string) *beaconClient {
 }
 
 // MostRecentFinalizedL1BlockAtTime returns the hash of the most recent
-// finalized L1 block at the L2 start time. It finds the epoch which started
-// most recently before the L2 start time (or on the L2 start time) and then
-// looks back from there to find the first finalized block.
-func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, l2StartTimeSeconds uint64) (common.Hash, error) {
+// finalized L1 block at the given point in time. It finds the epoch within which the
+// given time falls and then looks back from there to find the first finalized
+// block.
+func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, pointInTime uint64) (common.Hash, error) {
 	// Find the epoch starting at or before the L2 start time.
-	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
+	epochNumber := ContainingSlot(pointInTime) / beaconSlotsPerEpoch
 
 	// This epoch is guaranteed to not be complete at L2 start time (if the L2 start time falls in the last
 	// second of the epoch the epoch is still not complete, and if it was we'd be selecting the next epoch)
@@ -61,7 +61,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, l2S
 			return common.Hash{}, fmt.Errorf("error fetching epoch %d: %w", epochNumber-i, err)
 		}
 		if epoch.Data.Globalparticipationrate < 0.67 {
-			return common.Hash{}, fmt.Errorf("most recent %s epoch before the L2 start time (%d) has less than 0.67 participation rate (%.2f)", names[i-1], l2StartTimeSeconds, epoch.Data.Globalparticipationrate)
+			return common.Hash{}, fmt.Errorf("most recent %s epoch before the L2 start time (%d) has less than 0.67 participation rate (%.2f)", names[i-1], pointInTime, epoch.Data.Globalparticipationrate)
 		}
 	}
 	// Calculate the first slot of the most recent justified epoch.
@@ -86,7 +86,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, l2S
 		break // We found a good block.
 	}
 	if beaconBlock == nil {
-		return common.Hash{}, fmt.Errorf("failed to find finalized block searching up to 10 slots back from the most recent finalized slot (%d) at the L2 fork time (%d)", mostRecentFinalizedSlot, l2StartTimeSeconds)
+		return common.Hash{}, fmt.Errorf("failed to find finalized block searching up to 10 slots back from the most recent finalized slot (%d) at the L2 fork time (%d)", mostRecentFinalizedSlot, pointInTime)
 	}
 	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), nil
 }
@@ -144,13 +144,13 @@ func EpochStartTime(epoch uint64) uint64 {
 	return beaconChainGenesisTimeSeconds + (epoch * beaconSlotsPerEpoch * beaconChainSlotDurationSeconds)
 }
 
-// EpochAtOrBefore returns the number of the epoch starting at or before the given time.
-func EpochAtOrBefore(unixTime uint64) uint64 {
-	return SlotAtOrBefore(unixTime) / beaconSlotsPerEpoch
+// ContainingEpoch returns the number of the epoch whithin which the given time falls.
+func ContainingEpoch(unixTime uint64) uint64 {
+	return ContainingSlot(unixTime) / beaconSlotsPerEpoch
 }
 
-// SlotAtOrBefore returns the slot at or before the given time.
-func SlotAtOrBefore(unixTime uint64) uint64 {
+// ContainingSlot returns the slot within which the given time falls.
+func ContainingSlot(unixTime uint64) uint64 {
 	// Get the slot at or before the given time.
 	// Slot = (start - genesis) / slotDuration
 	return (unixTime - beaconChainGenesisTimeSeconds) / beaconChainSlotDurationSeconds

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -22,14 +22,14 @@ const (
 	beaconSlotsPerEpoch            = 32
 )
 
-type beaconClient struct {
+type BeaconClient struct {
 	cl *http.Client
 	// A beaconchain RPC API endpoint.
 	beaconRPC string
 }
 
-func NewBeaconClient(beaconRPC string) *beaconClient {
-	return &beaconClient{
+func NewBeaconClient(beaconRPC string) *BeaconClient {
+	return &BeaconClient{
 		beaconRPC: beaconRPC,
 		cl:        &http.Client{},
 	}
@@ -53,7 +53,7 @@ func AwaitEpoch(epoch uint64) {
 // looking back from the epoch containing the given time, but if no finalized
 // block is found it will consider future epochs that may have finalized a block
 // ocurring before the given time.
-func (c *beaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.Hash, error) {
+func (c *BeaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.Hash, error) {
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
 	// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
@@ -135,7 +135,7 @@ func withinMaxSequencerDrift(l1StartingBlockTime, l2StartBlockTime uint64) bool 
 
 // FindFinalityCheckpointForSlot returns the finality checkpoints for 'slot'
 // searching up to 'tries' slots back if only empty slots are encountered.
-func (c *beaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64) (*FinalityCheckpoints, error) {
+func (c *BeaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64) (*FinalityCheckpoints, error) {
 	var finalityCheckpoints *FinalityCheckpoints
 	var err error
 	for i := range tries {
@@ -157,7 +157,7 @@ func (c *beaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64)
 
 // FindBlockForSlot returns the hash and timestamp of the block at the given slot,
 // looking up to 'tries' slots back if only empty slots are encountered.
-func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash common.Hash, blockTime uint64, err error) {
+func (c *BeaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash common.Hash, blockTime uint64, err error) {
 	// Find the most recent actual finalized block, slots can be empty so we
 	// search back if we encounter empty slots. We check up to 10 slots, if they
 	// are all empty something serious is wrong with the L1 so we abort.
@@ -185,7 +185,7 @@ func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash co
 	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), uint64(beaconBlock.Data.Message.Body.ExecutionPayload.Timestamp), nil
 }
 
-func (c *beaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (checkpoints *FinalityCheckpoints, err error) {
+func (c *BeaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (checkpoints *FinalityCheckpoints, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v1/beacon/states/%d/finality_checkpoints", c.beaconRPC, slot), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request to get finality checkpoints for slot %d: %w", slot, err)
@@ -212,7 +212,7 @@ func (c *beaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (ch
 }
 
 // BeaconBlock gets the beacon block from the beacon rpc api.
-func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
+func (c *BeaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", c.beaconRPC, slot), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request to get beacon block: %w", err)

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -38,7 +38,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
 
 	fmt.Printf("initial epoch number: %d\n", epochNumber)
-	// This epoch is not guaranted to be complete at L2 start time, so assuming it is not complete.
+	// This epoch is not guaranteed to be complete at L2 start time, so assuming it is not complete.
 	// The previous epoch is the most recent completed epoch.
 	// The one prior to that is the most recent justified epoch.
 	// And the first block of the justified epoch (the epoch boundary block) will be finalized.

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	beaconChainGenesisTimeSeconds  = 1606824000
+	beaconChainSlotDurationSeconds = 12
+)
+
+type beaconClient struct {
+	cl *http.Client
+}
+
+func NewBeaconClient() *beaconClient {
+	return &beaconClient{
+		cl: &http.Client{},
+	}
+}
+
+// MostRecentFinalizedL1BlockAtTime returns the hash of the most recent
+// finalized L1 block at the L2 start time. It finds the epoch which started
+// most recently before the L2 start time (or on the L2 start time) and then
+// looks back from there to find the first finalized block.
+func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint64) (common.Hash, error) {
+	// Find the epoch starting at or before the L2 start time.
+	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / 32
+	// This epoch is not guaranted to be complete at L2 start time, so assuming it is not complete.
+	// The previous epoch is the most recent completed epoch.
+	// The one prior to that is the most recent justified epoch.
+	// And the first block of the justified epoch (the epoch boundary block) will be finalized.
+	// This is assuming that there was at least 2/3 participation in the completed and justified epochs.
+	var epoch *Epoch
+	var err error
+	names := [2]string{"completed", "justified"}
+
+	// Check the most recent completed and justified epochs had a participation rate of at least 0.76.
+	for i := uint64(1); i <= 2; i++ {
+		epoch, err = c.Epoch(context.Background(), epochNumber-i)
+		if err != nil {
+			return common.Hash{}, fmt.Errorf("error fetching epoch %d: %w", epochNumber-i, err)
+		}
+		if epoch.Data.Globalparticipationrate < 0.67 {
+			return common.Hash{}, fmt.Errorf("most recent %s epoch before the L2 start time (%d) has less than 0.67 participation rate (%.2f)", names[i-1], l2StartTimeSeconds, epoch.Data.Globalparticipationrate)
+		}
+	}
+	// Calculate the first slot of the most recent justified epoch.
+	mostRecentFinalizedSlot := (epochNumber - 2) * 32
+
+	// Find the most recent actual finalized block, slots can be empty so we search back if we encounter empty slots.
+	// We check up to 10 slots, if they are all empty something must be wrong.
+	var beaconBlock *BeaconBlock
+	for i := uint64(0); i < 10; i++ {
+		beaconBlock, err = c.BeaconBlock(context.Background(), mostRecentFinalizedSlot-i)
+		if errors.Is(err, ethereum.NotFound) {
+			// If there is not block for this slot then skip to the next.
+			continue
+		}
+		if err != nil {
+			return common.Hash{}, fmt.Errorf("error fetching beacon block at slot %d: %w", mostRecentFinalizedSlot, err)
+		}
+		if !beaconBlock.Finalized {
+			return common.Hash{}, fmt.Errorf("expecting beacon block at slot %d to be finalized", mostRecentFinalizedSlot)
+		}
+	}
+	if beaconBlock == nil {
+		return common.Hash{}, fmt.Errorf("failed to find finalized block searching up to 10 slots back from the most recent finalized slot (%d) at the L2 fork time (%d)", mostRecentFinalizedSlot, l2StartTimeSeconds)
+	}
+	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), nil
+}
+
+func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
+	headers := http.Header{}
+	headers.Add("Accept", "application/json")
+	resp, err := c.cl.Get(path.Join("https://beaconcha.in/api/v1/epoch/", fmt.Sprintf("%d", num)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch epoch: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, resp.Body.Close())
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch epoch, http status %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(epoch); err != nil {
+		return nil, fmt.Errorf("failed to decode epoch: %w", err)
+	}
+	return epoch, nil
+}
+
+func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
+	headers := http.Header{}
+	headers.Add("Accept", "application/json")
+	resp, err := c.cl.Get(path.Join("https://eth-beacon-chain.drpc.org/rest/eth/v2/beacon/blocks", fmt.Sprintf("%d", slot)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch becon block: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, resp.Body.Close())
+	}()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("failed to fetch beacon block at slot %d: %w", slot, ethereum.NotFound)
+		}
+		return nil, fmt.Errorf("failed to fetch beacon block at slot %d, http status %d", slot, resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&block); err != nil {
+		return nil, fmt.Errorf("failed to decode beacon block: %w", err)
+	}
+	return block, nil
+}
+
+// Returns the start time of an epoch
+func EpochStartTime(epoch uint64) uint64 {
+	return beaconChainGenesisTimeSeconds + epoch*32*beaconChainSlotDurationSeconds
+}
+
+// Returns the number of the epoch starting at or before the given time.
+func EpochAtOrBefore(unixTime uint64) uint64 {
+	return SlotAtOrBefore(unixTime) / 32
+}
+
+func SlotAtOrBefore(unixTime uint64) uint64 {
+	// Get the slot at or before the given time.
+	// Slot = (start - genesis) / slotDuration
+	return (unixTime - beaconChainGenesisTimeSeconds) / beaconChainSlotDurationSeconds
+}
+
+type BeaconBlock struct {
+	Version             string `json:"version"`
+	ExecutionOptimistic bool   `json:"execution_optimistic"`
+	Finalized           bool   `json:"finalized"`
+	Data                struct {
+		Message struct {
+			Slot          eth.Uint64String `json:"slot"`
+			ProposerIndex string           `json:"proposer_index"`
+			ParentRoot    string           `json:"parent_root"`
+			StateRoot     string           `json:"state_root"`
+			Body          struct {
+				RandaoReveal string `json:"randao_reveal"`
+				Eth1Data     struct {
+					DepositRoot  string `json:"deposit_root"`
+					DepositCount string `json:"deposit_count"`
+					BlockHash    string `json:"block_hash"`
+				} `json:"eth1_data"`
+				Graffiti          string        `json:"graffiti"`
+				ProposerSlashings []interface{} `json:"proposer_slashings"`
+				AttesterSlashings []interface{} `json:"attester_slashings"`
+				Attestations      []struct {
+					AggregationBits string `json:"aggregation_bits"`
+					Data            struct {
+						Slot            string `json:"slot"`
+						Index           string `json:"index"`
+						BeaconBlockRoot string `json:"beacon_block_root"`
+						Source          struct {
+							Epoch string `json:"epoch"`
+							Root  string `json:"root"`
+						} `json:"source"`
+						Target struct {
+							Epoch string `json:"epoch"`
+							Root  string `json:"root"`
+						} `json:"target"`
+					} `json:"data"`
+					Signature string `json:"signature"`
+				} `json:"attestations"`
+				Deposits       []interface{} `json:"deposits"`
+				VoluntaryExits []interface{} `json:"voluntary_exits"`
+				SyncAggregate  struct {
+					SyncCommitteeBits      string `json:"sync_committee_bits"`
+					SyncCommitteeSignature string `json:"sync_committee_signature"`
+				} `json:"sync_aggregate"`
+				ExecutionPayload struct {
+					ParentHash    string           `json:"parent_hash"`
+					FeeRecipient  string           `json:"fee_recipient"`
+					StateRoot     string           `json:"state_root"`
+					ReceiptsRoot  string           `json:"receipts_root"`
+					LogsBloom     string           `json:"logs_bloom"`
+					PrevRandao    string           `json:"prev_randao"`
+					BlockNumber   eth.Uint64String `json:"block_number"`
+					GasLimit      string           `json:"gas_limit"`
+					GasUsed       string           `json:"gas_used"`
+					Timestamp     eth.Uint64String `json:"timestamp"`
+					ExtraData     string           `json:"extra_data"`
+					BaseFeePerGas string           `json:"base_fee_per_gas"`
+					BlockHash     string           `json:"block_hash"`
+					Transactions  []string         `json:"transactions"`
+					Withdrawals   []struct {
+						Index          string `json:"index"`
+						ValidatorIndex string `json:"validator_index"`
+						Address        string `json:"address"`
+						Amount         string `json:"amount"`
+					} `json:"withdrawals"`
+					BlobGasUsed   string `json:"blob_gas_used"`
+					ExcessBlobGas string `json:"excess_blob_gas"`
+				} `json:"execution_payload"`
+				BlsToExecutionChanges []interface{} `json:"bls_to_execution_changes"`
+				BlobKzgCommitments    []string      `json:"blob_kzg_commitments"`
+			} `json:"body"`
+		} `json:"message"`
+		Signature string `json:"signature"`
+	} `json:"data"`
+}
+
+type Epoch struct {
+	Status string `json:"status"`
+	Data   struct {
+		Attestationscount       int       `json:"attestationscount"`
+		Attesterslashingscount  int       `json:"attesterslashingscount"`
+		Averagevalidatorbalance int64     `json:"averagevalidatorbalance"`
+		Blockscount             int       `json:"blockscount"`
+		Depositscount           int       `json:"depositscount"`
+		Eligibleether           int64     `json:"eligibleether"`
+		Epoch                   int       `json:"epoch"`
+		Finalized               bool      `json:"finalized"`
+		Globalparticipationrate float64   `json:"globalparticipationrate"`
+		Missedblocks            int       `json:"missedblocks"`
+		Orphanedblocks          int       `json:"orphanedblocks"`
+		Proposedblocks          int       `json:"proposedblocks"`
+		Proposerslashingscount  int       `json:"proposerslashingscount"`
+		RewardsExported         bool      `json:"rewards_exported"`
+		Scheduledblocks         int       `json:"scheduledblocks"`
+		Totalvalidatorbalance   int64     `json:"totalvalidatorbalance"`
+		Ts                      time.Time `json:"ts"`
+		Validatorscount         int       `json:"validatorscount"`
+		Voluntaryexitscount     int       `json:"voluntaryexitscount"`
+		Votedether              int64     `json:"votedether"`
+		Withdrawalcount         int       `json:"withdrawalcount"`
+	} `json:"data"`
+}

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
@@ -24,94 +25,99 @@ type beaconClient struct {
 	cl *http.Client
 	// A beaconchain RPC API endpoint.
 	beaconRPC string
-	// A beaconcha.in api endpoint.
-	beaconchainURL string
 }
 
-func NewBeaconClient(beaconRPC string, beaconchainURL string) *beaconClient {
+func NewBeaconClient(beaconRPC string) *beaconClient {
 	return &beaconClient{
-		beaconRPC:      beaconRPC,
-		beaconchainURL: beaconchainURL,
-		cl:             &http.Client{},
+		beaconRPC: beaconRPC,
+		cl:        &http.Client{},
 	}
 }
 
 // MostRecentFinalizedL1BlockAtTime returns the hash of the most recent
-// finalized L1 block at the given point in time. It finds the epoch within which the
-// given time falls and then looks back from there to find the first finalized
-// block.
-func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, pointInTime uint64) (common.Hash, error) {
-	// Find the epoch starting at or before the L2 start time.
-	epochNumber := ContainingSlot(pointInTime) / beaconSlotsPerEpoch
+// finalized L1 block during the execution of the given epoch.
+func (c *beaconClient) MostRecentFinalizedSlotAtEpoch(currentEpoch uint64) (uint64, error) {
+	start := EpochStartTime(currentEpoch)
 
-	// This epoch is guaranteed to not be complete at L2 start time (if the L2 start time falls in the last
-	// second of the epoch the epoch is still not complete, and if it was we'd be selecting the next epoch)
+	// Wait till the beginning of the epoch in which our point in time falls. We wait an extra 10 seconds to be sure that
+	// the network has had time to update.
+	waitTimeSeconds := int64(start) - time.Now().Unix() + 10
+	if waitTimeSeconds > 0 {
+		log.Info("Waiting %v + additional 10 seconds for start of epoch %d, to check for finalized slot at that time", waitTimeSeconds-10, currentEpoch)
+		time.Sleep(time.Duration(waitTimeSeconds) * time.Second)
+	}
+
+	// Get the finality checkpoint for the first slot of the containing epoch.
+	firstSlot := currentEpoch * beaconSlotsPerEpoch
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	finalityCheckpoints, err := c.FinalityCheckpoints(ctx, firstSlot)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching finality checkpoint for slot %d: %w", firstSlot, err)
+	}
+
+	// containingEpoch is guaranteed to not be complete at pointInTime (if pointInTime falls in the last
+	// second of the epoch the epoch is still not complete, and if it was a second later we'd be selecting the next epoch)
 	// The previous epoch is the most recent completed epoch.
 	// The one prior to that is the most recent justified epoch.
 	// And the first block of the justified epoch (the epoch boundary block) will be finalized.
 	// This is assuming that there was at least 2/3 participation in the completed and justified epochs.
-	var epoch *Epoch
-	var err error
-	names := [2]string{"completed", "justified"}
 
-	// Check the most recent completed and justified epochs had a participation rate of at least 0.67.
-	for i := uint64(1); i <= 2; i++ {
-		epoch, err = c.Epoch(ctx, epochNumber-i)
-		if err != nil {
-			return common.Hash{}, fmt.Errorf("error fetching epoch %d: %w", epochNumber-i, err)
-		}
-		if epoch.Data.Globalparticipationrate < 0.67 {
-			return common.Hash{}, fmt.Errorf("most recent %s epoch before the L2 start time (%d) has less than 0.67 participation rate (%.2f)", names[i-1], pointInTime, epoch.Data.Globalparticipationrate)
-		}
-	}
 	// Calculate the first slot of the most recent justified epoch.
-	mostRecentFinalizedSlot := (epochNumber - 2) * beaconSlotsPerEpoch
+	finalizedSlot := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch) * beaconSlotsPerEpoch
+	return finalizedSlot, nil
+}
 
+// FindBlockForSlot returns the hash and timestamp of the block at the given slot,
+// looking up to 'tries' slots back if only empty slots are encountered.
+func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash common.Hash, blockTime uint64, err error) {
 	// Find the most recent actual finalized block, slots can be empty so we
 	// search back if we encounter empty slots. We check up to 10 slots, if they
 	// are all empty something serious is wrong with the L1 so we abort.
 	var beaconBlock *BeaconBlock
 	for i := range uint64(10) {
-		beaconBlock, err = c.BeaconBlock(ctx, mostRecentFinalizedSlot-i)
+		targetSlot := slot - i
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		beaconBlock, err := c.BeaconBlock(ctx, targetSlot)
 		if errors.Is(err, ethereum.NotFound) {
 			// If there is not block for this slot then skip to the next.
 			continue
 		}
 		if err != nil {
-			return common.Hash{}, fmt.Errorf("error fetching beacon block at slot %d: %w", mostRecentFinalizedSlot, err)
+			return common.Hash{}, 0, fmt.Errorf("error fetching beacon block at slot %d: %w", targetSlot, err)
 		}
 		if !beaconBlock.Finalized {
-			return common.Hash{}, fmt.Errorf("expecting beacon block at slot %d to be finalized", mostRecentFinalizedSlot)
+			return common.Hash{}, 0, fmt.Errorf("expecting beacon block at slot %d to be finalized", targetSlot)
 		}
 		break // We found a good block.
 	}
 	if beaconBlock == nil {
-		return common.Hash{}, fmt.Errorf("failed to find finalized block searching up to 10 slots back from the most recent finalized slot (%d) at the L2 fork time (%d)", mostRecentFinalizedSlot, pointInTime)
+		return common.Hash{}, 0, fmt.Errorf("finalized block %w searching up to 10 slots back from slot (%d)", ethereum.NotFound, slot)
 	}
-	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), nil
+	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), uint64(beaconBlock.Data.Message.Body.ExecutionPayload.Timestamp), nil
 }
 
-// Epoch gets the requested epoch from the beaconcha.in api.
-func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/epoch/%d", c.beaconchainURL, num), nil)
+func (c *beaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (checkpoints *FinalityCheckpoints, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v1/beacon/states/%d/finality_checkpoints", c.beaconRPC, slot), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request to get epoch: %w", err)
+		return nil, fmt.Errorf("failed to create request to get finality checkpoints for slot %d: %w", slot, err)
 	}
 	resp, err := c.cl.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch epoch: %w", err)
+		return nil, fmt.Errorf("failed to fetch finality checkpoints for slot %d: %w", slot, err)
 	}
 	defer func() {
 		err = errors.Join(err, resp.Body.Close())
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch epoch, http status %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to fetch finality checkpoints for slot %d, http status %d: %w", slot, resp.StatusCode, err)
 	}
-	epoch = &Epoch{}
-	if err := json.NewDecoder(resp.Body).Decode(epoch); err != nil {
-		return nil, fmt.Errorf("failed to decode epoch: %w", err)
+
+	if err := json.NewDecoder(resp.Body).Decode(checkpoints); err != nil {
+		return nil, fmt.Errorf("failed to decode finality checkpoints: %w", err)
 	}
-	return epoch, nil
+	return checkpoints, nil
 }
 
 // BeaconBlock gets the beacon block from the beacon rpc api.
@@ -142,6 +148,10 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 // EpochStartTime returns the start time of an epoch.
 func EpochStartTime(epoch uint64) uint64 {
 	return beaconChainGenesisTimeSeconds + (epoch * beaconSlotsPerEpoch * beaconChainSlotDurationSeconds)
+}
+
+func SlotTime(slot uint64) uint64 {
+	return beaconChainGenesisTimeSeconds + (slot * beaconChainSlotDurationSeconds)
 }
 
 // ContainingEpoch returns the number of the epoch whithin which the given time falls.
@@ -231,29 +241,21 @@ type BeaconBlock struct {
 	} `json:"data"`
 }
 
-type Epoch struct {
-	Status string `json:"status"`
-	Data   struct {
-		Attestationscount       int       `json:"attestationscount"`
-		Attesterslashingscount  int       `json:"attesterslashingscount"`
-		Averagevalidatorbalance int64     `json:"averagevalidatorbalance"`
-		Blockscount             int       `json:"blockscount"`
-		Depositscount           int       `json:"depositscount"`
-		Eligibleether           int64     `json:"eligibleether"`
-		Epoch                   int       `json:"epoch"`
-		Finalized               bool      `json:"finalized"`
-		Globalparticipationrate float64   `json:"globalparticipationrate"`
-		Missedblocks            int       `json:"missedblocks"`
-		Orphanedblocks          int       `json:"orphanedblocks"`
-		Proposedblocks          int       `json:"proposedblocks"`
-		Proposerslashingscount  int       `json:"proposerslashingscount"`
-		RewardsExported         bool      `json:"rewards_exported"`
-		Scheduledblocks         int       `json:"scheduledblocks"`
-		Totalvalidatorbalance   int64     `json:"totalvalidatorbalance"`
-		Ts                      time.Time `json:"ts"`
-		Validatorscount         int       `json:"validatorscount"`
-		Voluntaryexitscount     int       `json:"voluntaryexitscount"`
-		Votedether              int64     `json:"votedether"`
-		Withdrawalcount         int       `json:"withdrawalcount"`
+type FinalityCheckpoints struct {
+	ExecutionOptimistic bool `json:"execution_optimistic"`
+	Finalized           bool `json:"finalized"`
+	Data                struct {
+		PreviousJustified struct {
+			Epoch eth.Uint64String `json:"epoch"`
+			Root  string           `json:"root"`
+		} `json:"previous_justified"`
+		CurrentJustified struct {
+			Epoch eth.Uint64String `json:"epoch"`
+			Root  string           `json:"root"`
+		} `json:"current_justified"`
+		Finalized struct {
+			Epoch eth.Uint64String `json:"epoch"`
+			Root  string           `json:"root"`
+		} `json:"finalized"`
 	} `json:"data"`
 }

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -35,6 +35,7 @@ func NewBeaconClient(beaconRPC string) *beaconClient {
 	}
 }
 
+// Waits for the given epoch start time plus an extra 10 seconds just to ensure that infrastructure has had time to update.
 func AwaitEpoch(epoch uint64) {
 	start := EpochStartTime(epoch)
 
@@ -47,6 +48,11 @@ func AwaitEpoch(epoch uint64) {
 	}
 }
 
+// MostRecentFinalizedBlockAtTime returns the hash of the most recent finalized
+// block that is up to maxSequencerDrift before the L2 fork block. It starts by
+// looking back from the epoch containing the given time, but if no finalized
+// block is found it will consider future epochs that may have finalized a block
+// ocurring before the given time.
 func (c *beaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.Hash, error) {
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
@@ -89,6 +95,7 @@ func (c *beaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.H
 	// cannot find a finalized block ocurring before the L2 fork block.
 	if l1StartBlockHash == (common.Hash{}) {
 		for epoch := ContainingEpoch(unixTime) + 1; ; epoch++ {
+			AwaitEpoch(epoch)
 			slot := FirstSlotOfEpoch(epoch)
 			finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
 			if err != nil {
@@ -191,6 +198,9 @@ func (c *beaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (ch
 		err = errors.Join(err, resp.Body.Close())
 	}()
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("finality checkpoints for slot %d %w", slot, ethereum.NotFound)
+		}
 		return nil, fmt.Errorf("failed to fetch finality checkpoints for slot %d, http status %d: %w", slot, resp.StatusCode, err)
 	}
 
@@ -216,7 +226,7 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 	}()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("failed to fetch beacon block at slot %d: %w", slot, ethereum.NotFound)
+			return nil, fmt.Errorf("beacon block at slot %d %w", slot, ethereum.NotFound)
 		}
 		return nil, fmt.Errorf("failed to fetch beacon block at slot %d, http status %d", slot, resp.StatusCode)
 	}

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -24,7 +24,7 @@ type beaconClient struct {
 	cl *http.Client
 	// A beaconchain RPC API endpoint.
 	beaconRPC string
-	// A becaoncha.in api endpoint.
+	// A beaconcha.in api endpoint.
 	beaconchainURL string
 }
 

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -57,18 +57,15 @@ func AwaitEpoch(chainID *big.Int, epoch uint64) {
 	}
 }
 
-// MostRecentFinalizedBlockAtTime returns the hash of the most recent finalized
-// block that is up to maxSequencerDrift before the L2 fork block. It starts by
-// looking back from the epoch containing the given time, but if no finalized
-// block is found it will consider future epochs that may have finalized a block
-// ocurring before the given time.
-func (c *BeaconClient) MostRecentFinalizedBlockAtTime(chainID *big.Int, unixTime uint64) (common.Hash, error) {
+// findL1StartingBlock looks back or forward (depending on the epochIncrement)
+// for a finalized L1 block that is up to maxSequencerDrift before the L2 fork
+// block.
+func (c *BeaconClient) findL1StartingBlock(chainID *big.Int, unixTime uint64, epochIncrement int64) (common.Hash, error) {
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
-	// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
-	for epoch := ContainingEpoch(chainID, unixTime); ; epoch-- {
-		AwaitEpoch(chainID, epoch)
-		slot := FirstSlotOfEpoch(epoch)
+	for epoch := int64(ContainingEpoch(chainID, unixTime)); ; epoch += epochIncrement {
+		AwaitEpoch(chainID, uint64(epoch))
+		slot := FirstSlotOfEpoch(uint64(epoch))
 		finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
 		if err != nil {
 			if errors.Is(err, ethereum.NotFound) {
@@ -81,7 +78,6 @@ func (c *BeaconClient) MostRecentFinalizedBlockAtTime(chainID *big.Int, unixTime
 			// We've gone too far back and not found a suitable block, so break.
 			break
 		}
-
 		finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
 		l1StartBlockHash, l1StartBlockTime, err = c.FindBlockForSlot(finalizedSlot, 10)
 		if err != nil {
@@ -90,49 +86,40 @@ func (c *BeaconClient) MostRecentFinalizedBlockAtTime(chainID *big.Int, unixTime
 			}
 			return common.Hash{}, fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
 		}
-		if !withinMaxSequencerDrift(l1StartBlockTime, unixTime) {
+		switch {
+		case !withinMaxSequencerDrift(l1StartBlockTime, unixTime):
 			// This block is too old to use with the L2 fork block. Nullify the hash
 			// to signify that no suitable block was yet found.
 			l1StartBlockHash = common.Hash{}
-		} else {
+		case l1StartBlockTime >= unixTime:
+			// We've gone too far forward and not found a suitable block, so nullify the hash and break.
+			l1StartBlockHash = common.Hash{}
+		default:
 			log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
 		}
 		break
 	}
+	return l1StartBlockHash, nil
+}
 
-	// If no block found start looking to future epochs, failing if we
-	// cannot find a finalized block ocurring before the L2 fork block.
-	if l1StartBlockHash == (common.Hash{}) {
-		for epoch := ContainingEpoch(chainID, unixTime) + 1; ; epoch++ {
-			AwaitEpoch(chainID, epoch)
-			slot := FirstSlotOfEpoch(epoch)
-			finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
-			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
-					continue
-				}
-				return common.Hash{}, fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
-			}
-			justifiedEpoch := uint64(finalityCheckpoints.Data.Finalized.Epoch)
-			finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
-			l1StartBlockHash, l1StartBlockTime, err = c.FindBlockForSlot(finalizedSlot, 10)
-			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
-					continue
-				}
-				return common.Hash{}, fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
-			}
-			if l1StartBlockTime >= unixTime {
-				// We've gone too far forward and not found a suitable block, so nullify the hash and break.
-				l1StartBlockHash = common.Hash{}
-			} else {
-				log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
-			}
-			break
+// MostRecentFinalizedBlockAtTime returns the hash of the most recent finalized
+// block that is up to maxSequencerDrift before the L2 fork block. It starts by
+// looking back from the epoch containing the given time, but if no finalized
+// block is found it will consider future epochs that may have finalized a block
+// ocurring before the given time.
+func (c *BeaconClient) MostRecentFinalizedBlockAtTime(chainID *big.Int, unixTime uint64) (common.Hash, error) {
+	hash, err := c.findL1StartingBlock(chainID, unixTime, -1)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if hash == (common.Hash{}) {
+		// Try searching forward
+		hash, err = c.findL1StartingBlock(chainID, unixTime, 1)
+		if err != nil {
+			return common.Hash{}, err
 		}
 	}
-
-	return l1StartBlockHash, nil
+	return hash, nil
 }
 
 func withinMaxSequencerDrift(l1StartingBlockTime, l2StartBlockTime uint64) bool {

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -34,8 +34,8 @@ func NewBeaconClient(beaconRPC string) *beaconClient {
 	}
 }
 
-// MostRecentFinalizedL1BlockAtTime returns the hash of the most recent
-// finalized L1 block during the execution of the given epoch.
+// MostRecentFinalizedSlotAtEpoch returns the slot of the most recent
+// finalized block during the execution of the given epoch.
 func (c *beaconClient) MostRecentFinalizedSlotAtEpoch(currentEpoch uint64) (uint64, error) {
 	start := EpochStartTime(currentEpoch)
 

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -38,7 +38,6 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// Find the epoch starting at or before the L2 start time.
 	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
 
-	fmt.Printf("initial epoch number: %d\n", epochNumber)
 	// This epoch is not guaranteed to be complete at L2 start time, so assuming it is not complete.
 	// The previous epoch is the most recent completed epoch.
 	// The one prior to that is the most recent justified epoch.
@@ -48,7 +47,6 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	var err error
 	names := [2]string{"completed", "justified"}
 
-	fmt.Printf("starting epochNumber %d\n", epochNumber)
 	// Check the most recent completed and justified epochs had a participation rate of at least 0.67.
 	for i := uint64(1); i <= 2; i++ {
 		epoch, err = c.Epoch(context.Background(), epochNumber-i)
@@ -62,8 +60,6 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// Calculate the first slot of the most recent justified epoch.
 	mostRecentFinalizedSlot := (epochNumber - 2) * beaconSlotsPerEpoch
 
-	fmt.Printf("most recent finalized slot %d\n", mostRecentFinalizedSlot)
-
 	// Find the most recent actual finalized block, slots can be empty so we search back if we encounter empty slots.
 	// We check up to 10 slots, if they are all empty something must be wrong.
 	var beaconBlock *BeaconBlock
@@ -71,7 +67,6 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 		beaconBlock, err = c.BeaconBlock(context.Background(), mostRecentFinalizedSlot-i)
 		if errors.Is(err, ethereum.NotFound) {
 			// If there is not block for this slot then skip to the next.
-			println("checking prev block")
 			continue
 		}
 		if err != nil {

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -36,6 +35,8 @@ func NewBeaconClient() *beaconClient {
 func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint64) (common.Hash, error) {
 	// Find the epoch starting at or before the L2 start time.
 	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / 32
+
+	fmt.Printf("initial epoch number: %d\n", epochNumber)
 	// This epoch is not guaranted to be complete at L2 start time, so assuming it is not complete.
 	// The previous epoch is the most recent completed epoch.
 	// The one prior to that is the most recent justified epoch.
@@ -45,6 +46,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	var err error
 	names := [2]string{"completed", "justified"}
 
+	fmt.Printf("starting epochNumber %d\n", epochNumber)
 	// Check the most recent completed and justified epochs had a participation rate of at least 0.76.
 	for i := uint64(1); i <= 2; i++ {
 		epoch, err = c.Epoch(context.Background(), epochNumber-i)
@@ -58,6 +60,8 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// Calculate the first slot of the most recent justified epoch.
 	mostRecentFinalizedSlot := (epochNumber - 2) * 32
 
+	fmt.Printf("most recent finalized slot %d\n", mostRecentFinalizedSlot)
+
 	// Find the most recent actual finalized block, slots can be empty so we search back if we encounter empty slots.
 	// We check up to 10 slots, if they are all empty something must be wrong.
 	var beaconBlock *BeaconBlock
@@ -65,6 +69,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 		beaconBlock, err = c.BeaconBlock(context.Background(), mostRecentFinalizedSlot-i)
 		if errors.Is(err, ethereum.NotFound) {
 			// If there is not block for this slot then skip to the next.
+			println("checking prev block")
 			continue
 		}
 		if err != nil {
@@ -73,6 +78,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 		if !beaconBlock.Finalized {
 			return common.Hash{}, fmt.Errorf("expecting beacon block at slot %d to be finalized", mostRecentFinalizedSlot)
 		}
+		break // We found a good block.
 	}
 	if beaconBlock == nil {
 		return common.Hash{}, fmt.Errorf("failed to find finalized block searching up to 10 slots back from the most recent finalized slot (%d) at the L2 fork time (%d)", mostRecentFinalizedSlot, l2StartTimeSeconds)
@@ -83,7 +89,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(path.Join("https://beaconcha.in/api/v1/epoch/", fmt.Sprintf("%d", num)))
+	resp, err := c.cl.Get(fmt.Sprintf("https://beaconcha.in/api/v1/epoch/%d", num))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch epoch: %w", err)
 	}
@@ -93,6 +99,7 @@ func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch epoch, http status %d", resp.StatusCode)
 	}
+	epoch = &Epoch{}
 	if err := json.NewDecoder(resp.Body).Decode(epoch); err != nil {
 		return nil, fmt.Errorf("failed to decode epoch: %w", err)
 	}
@@ -102,7 +109,7 @@ func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err
 func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(path.Join("https://eth-beacon-chain.drpc.org/rest/eth/v2/beacon/blocks", fmt.Sprintf("%d", slot)))
+	resp, err := c.cl.Get(fmt.Sprintf("https://eth-beacon-chain.drpc.org/rest/eth/v2/beacon/blocks/%d", slot))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch becon block: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -159,6 +159,10 @@ func (c *BeaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching finality checkpoints for slot %d: %w", targetSlot, err)
 		}
+		if finalityCheckpoints.Data.Finalized.Epoch == 0 {
+			// In the case that finality has not yet been achieved, skip to the previous slot.
+			continue
+		}
 		return finalityCheckpoints, nil
 	}
 	return nil, fmt.Errorf("finality_checkpoints %w searching up to %d slots back from slot (%d)", ethereum.NotFound, tries, slot)

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -17,7 +17,7 @@ import (
 const (
 	// See - https://eth2book.info/capella/part3/containers/state/
 	// TODO get values for holesky and sepolia here.
-	beaconChainGenesisTimeSeconds  = 1606824000
+	beaconChainGenesisTimeSeconds  = 1606824023
 	beaconChainSlotDurationSeconds = 12
 	beaconSlotsPerEpoch            = 32
 )
@@ -47,12 +47,91 @@ func AwaitEpoch(epoch uint64) {
 	}
 }
 
+func (c *beaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.Hash, error) {
+	var l1StartBlockHash common.Hash
+	var l1StartBlockTime uint64
+	// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
+	for epoch := ContainingEpoch(unixTime); ; epoch-- {
+		AwaitEpoch(epoch)
+		slot := FirstSlotOfEpoch(epoch)
+		finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				continue
+			}
+			return common.Hash{}, fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
+		}
+		justifiedEpoch := uint64(finalityCheckpoints.Data.Finalized.Epoch)
+		if !withinMaxSequencerDrift(EpochStartTime(justifiedEpoch), unixTime) {
+			// We've gone too far back and not found a suitable block, so break.
+			break
+		}
+
+		finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
+		l1StartBlockHash, l1StartBlockTime, err = c.FindBlockForSlot(finalizedSlot, 10)
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				continue
+			}
+			return common.Hash{}, fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
+		}
+		if !withinMaxSequencerDrift(l1StartBlockTime, unixTime) {
+			// This block is too old to use with the L2 fork block. Nullify the hash
+			// to signify that no suitable block was yet found.
+			l1StartBlockHash = common.Hash{}
+		} else {
+			log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
+		}
+		break
+	}
+
+	// If no block found start looking to future epochs, failing if we
+	// cannot find a finalized block ocurring before the L2 fork block.
+	if l1StartBlockHash == (common.Hash{}) {
+		for epoch := ContainingEpoch(unixTime) + 1; ; epoch++ {
+			slot := FirstSlotOfEpoch(epoch)
+			finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
+			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					continue
+				}
+				return common.Hash{}, fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
+			}
+			justifiedEpoch := uint64(finalityCheckpoints.Data.Finalized.Epoch)
+			finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
+			l1StartBlockHash, l1StartBlockTime, err = c.FindBlockForSlot(finalizedSlot, 10)
+			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					continue
+				}
+				return common.Hash{}, fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
+			}
+			if l1StartBlockTime >= unixTime {
+				// We've gone too far forward and not found a suitable block, so nullify the hash and break.
+				l1StartBlockHash = common.Hash{}
+			} else {
+				log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
+			}
+			break
+		}
+	}
+
+	return l1StartBlockHash, nil
+}
+
+func withinMaxSequencerDrift(l1StartingBlockTime, l2StartBlockTime uint64) bool {
+	// Used to check block validity, duplicate of the
+	// value defined at op-node/rollup.maxSequencerDriftCelo.
+	var maxSequencerDriftCelo uint64 = 2892
+	return l2StartBlockTime-l1StartingBlockTime <= maxSequencerDriftCelo
+}
+
 // FindFinalityCheckpointForSlot returns the finality checkpoints for 'slot'
 // searching up to 'tries' slots back if only empty slots are encountered.
 func (c *beaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64) (*FinalityCheckpoints, error) {
 	var finalityCheckpoints *FinalityCheckpoints
 	var err error
-	for i := range uint64(tries) {
+	for i := range tries {
 		targetSlot := slot - i
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -76,11 +155,11 @@ func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash co
 	// search back if we encounter empty slots. We check up to 10 slots, if they
 	// are all empty something serious is wrong with the L1 so we abort.
 	var beaconBlock *BeaconBlock
-	for i := range uint64(10) {
+	for i := range tries {
 		targetSlot := slot - i
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		beaconBlock, err := c.BeaconBlock(ctx, targetSlot)
+		beaconBlock, err = c.BeaconBlock(ctx, targetSlot)
 		if errors.Is(err, ethereum.NotFound) {
 			// If there is not block for this slot then skip to the next.
 			continue
@@ -115,6 +194,7 @@ func (c *beaconClient) FinalityCheckpoints(ctx context.Context, slot uint64) (ch
 		return nil, fmt.Errorf("failed to fetch finality checkpoints for slot %d, http status %d: %w", slot, resp.StatusCode, err)
 	}
 
+	checkpoints = &FinalityCheckpoints{}
 	if err := json.NewDecoder(resp.Body).Decode(checkpoints); err != nil {
 		return nil, fmt.Errorf("failed to decode finality checkpoints: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -15,11 +16,19 @@ import (
 )
 
 const (
-	// See - https://eth2book.info/capella/part3/containers/state/
-	// TODO get values for holesky and sepolia here.
-	beaconChainGenesisTimeSeconds  = 1606824023
 	beaconChainSlotDurationSeconds = 12
 	beaconSlotsPerEpoch            = 32
+)
+
+var (
+	Mainnet                        = big.NewInt(1)
+	Holesky                        = big.NewInt(17000)
+	Sepolia                        = big.NewInt(11155111)
+	beaconChainGenesisTimesSeconds = map[*big.Int]uint64{
+		Mainnet: 1606824023,
+		Holesky: 1695902400,
+		Sepolia: 1655733600,
+	}
 )
 
 type BeaconClient struct {
@@ -36,8 +45,8 @@ func NewBeaconClient(beaconRPC string) *BeaconClient {
 }
 
 // Waits for the given epoch start time plus an extra 10 seconds just to ensure that infrastructure has had time to update.
-func AwaitEpoch(epoch uint64) {
-	start := EpochStartTime(epoch)
+func AwaitEpoch(chainID *big.Int, epoch uint64) {
+	start := EpochStartTime(chainID, epoch)
 
 	// Wait till the beginning of the epoch in which our point in time falls. We wait an extra 10 seconds to be sure that
 	// the network has had time to update.
@@ -53,12 +62,12 @@ func AwaitEpoch(epoch uint64) {
 // looking back from the epoch containing the given time, but if no finalized
 // block is found it will consider future epochs that may have finalized a block
 // ocurring before the given time.
-func (c *BeaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.Hash, error) {
+func (c *BeaconClient) MostRecentFinalizedBlockAtTime(chainID *big.Int, unixTime uint64) (common.Hash, error) {
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
 	// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
-	for epoch := ContainingEpoch(unixTime); ; epoch-- {
-		AwaitEpoch(epoch)
+	for epoch := ContainingEpoch(chainID, unixTime); ; epoch-- {
+		AwaitEpoch(chainID, epoch)
 		slot := FirstSlotOfEpoch(epoch)
 		finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
 		if err != nil {
@@ -68,7 +77,7 @@ func (c *BeaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.H
 			return common.Hash{}, fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
 		}
 		justifiedEpoch := uint64(finalityCheckpoints.Data.Finalized.Epoch)
-		if !withinMaxSequencerDrift(EpochStartTime(justifiedEpoch), unixTime) {
+		if !withinMaxSequencerDrift(EpochStartTime(chainID, justifiedEpoch), unixTime) {
 			// We've gone too far back and not found a suitable block, so break.
 			break
 		}
@@ -94,8 +103,8 @@ func (c *BeaconClient) MostRecentFinalizedBlockAtTime(unixTime uint64) (common.H
 	// If no block found start looking to future epochs, failing if we
 	// cannot find a finalized block ocurring before the L2 fork block.
 	if l1StartBlockHash == (common.Hash{}) {
-		for epoch := ContainingEpoch(unixTime) + 1; ; epoch++ {
-			AwaitEpoch(epoch)
+		for epoch := ContainingEpoch(chainID, unixTime) + 1; ; epoch++ {
+			AwaitEpoch(chainID, epoch)
 			slot := FirstSlotOfEpoch(epoch)
 			finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)
 			if err != nil {
@@ -237,12 +246,12 @@ func (c *BeaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 }
 
 // EpochStartTime returns the start time of an epoch.
-func EpochStartTime(epoch uint64) uint64 {
-	return beaconChainGenesisTimeSeconds + (FirstSlotOfEpoch(epoch) * beaconChainSlotDurationSeconds)
+func EpochStartTime(chainID *big.Int, epoch uint64) uint64 {
+	return beaconChainGenesisTimesSeconds[chainID] + (FirstSlotOfEpoch(epoch) * beaconChainSlotDurationSeconds)
 }
 
-func SlotTime(slot uint64) uint64 {
-	return beaconChainGenesisTimeSeconds + (slot * beaconChainSlotDurationSeconds)
+func SlotTime(chainID *big.Int, slot uint64) uint64 {
+	return beaconChainGenesisTimesSeconds[chainID] + (slot * beaconChainSlotDurationSeconds)
 }
 
 // FirstSlotOfEpoch returns the number of the first slot of an epoch.
@@ -251,15 +260,15 @@ func FirstSlotOfEpoch(epoch uint64) uint64 {
 }
 
 // ContainingEpoch returns the number of the epoch whithin which the given time falls.
-func ContainingEpoch(unixTime uint64) uint64 {
-	return ContainingSlot(unixTime) / beaconSlotsPerEpoch
+func ContainingEpoch(chainID *big.Int, unixTime uint64) uint64 {
+	return ContainingSlot(chainID, unixTime) / beaconSlotsPerEpoch
 }
 
 // ContainingSlot returns the slot within which the given time falls.
-func ContainingSlot(unixTime uint64) uint64 {
+func ContainingSlot(chainID *big.Int, unixTime uint64) uint64 {
 	// Get the slot at or before the given time.
 	// Slot = (start - genesis) / slotDuration
-	return (unixTime - beaconChainGenesisTimeSeconds) / beaconChainSlotDurationSeconds
+	return (unixTime - beaconChainGenesisTimesSeconds[chainID]) / beaconChainSlotDurationSeconds
 }
 
 type BeaconBlock struct {

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// See - https://eth2book.info/capella/part3/containers/state/
 	beaconChainGenesisTimeSeconds  = 1606824000
 	beaconChainSlotDurationSeconds = 12
 	beaconSlotsPerEpoch            = 32

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -35,7 +35,7 @@ func NewBeaconClient() *beaconClient {
 // looks back from there to find the first finalized block.
 func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint64) (common.Hash, error) {
 	// Find the epoch starting at or before the L2 start time.
-	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / 32
+	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
 
 	fmt.Printf("initial epoch number: %d\n", epochNumber)
 	// This epoch is not guaranted to be complete at L2 start time, so assuming it is not complete.
@@ -48,7 +48,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	names := [2]string{"completed", "justified"}
 
 	fmt.Printf("starting epochNumber %d\n", epochNumber)
-	// Check the most recent completed and justified epochs had a participation rate of at least 0.76.
+	// Check the most recent completed and justified epochs had a participation rate of at least 0.67.
 	for i := uint64(1); i <= 2; i++ {
 		epoch, err = c.Epoch(context.Background(), epochNumber-i)
 		if err != nil {
@@ -59,7 +59,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 		}
 	}
 	// Calculate the first slot of the most recent justified epoch.
-	mostRecentFinalizedSlot := (epochNumber - 2) * 32
+	mostRecentFinalizedSlot := (epochNumber - 2) * beaconSlotsPerEpoch
 
 	fmt.Printf("most recent finalized slot %d\n", mostRecentFinalizedSlot)
 
@@ -131,12 +131,12 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 
 // Returns the start time of an epoch
 func EpochStartTime(epoch uint64) uint64 {
-	return beaconChainGenesisTimeSeconds + epoch*32*beaconChainSlotDurationSeconds
+	return beaconChainGenesisTimeSeconds + epoch*beaconSlotsPerEpoch*beaconChainSlotDurationSeconds
 }
 
 // Returns the number of the epoch starting at or before the given time.
 func EpochAtOrBefore(unixTime uint64) uint64 {
-	return SlotAtOrBefore(unixTime) / 32
+	return SlotAtOrBefore(unixTime) / beaconSlotsPerEpoch
 }
 
 func SlotAtOrBefore(unixTime uint64) uint64 {

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	// See - https://eth2book.info/capella/part3/containers/state/
+	// TODO get values for holesky and sepolia here.
 	beaconChainGenesisTimeSeconds  = 1606824000
 	beaconChainSlotDurationSeconds = 12
 	beaconSlotsPerEpoch            = 32
@@ -34,38 +35,38 @@ func NewBeaconClient(beaconRPC string) *beaconClient {
 	}
 }
 
-// MostRecentFinalizedSlotAtEpoch returns the slot of the most recent
-// finalized block during the execution of the given epoch.
-func (c *beaconClient) MostRecentFinalizedSlotAtEpoch(currentEpoch uint64) (uint64, error) {
-	start := EpochStartTime(currentEpoch)
+func AwaitEpoch(epoch uint64) {
+	start := EpochStartTime(epoch)
 
 	// Wait till the beginning of the epoch in which our point in time falls. We wait an extra 10 seconds to be sure that
 	// the network has had time to update.
 	waitTimeSeconds := int64(start) - time.Now().Unix() + 10
 	if waitTimeSeconds > 0 {
-		log.Info("Waiting %v + additional 10 seconds for start of epoch %d, to check for finalized slot at that time", waitTimeSeconds-10, currentEpoch)
+		log.Info("Waiting %v + additional 10 seconds for start of epoch %d, to check for finalized slot at that time", waitTimeSeconds-10, epoch)
 		time.Sleep(time.Duration(waitTimeSeconds) * time.Second)
 	}
+}
 
-	// Get the finality checkpoint for the first slot of the containing epoch.
-	firstSlot := currentEpoch * beaconSlotsPerEpoch
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	finalityCheckpoints, err := c.FinalityCheckpoints(ctx, firstSlot)
-	if err != nil {
-		return 0, fmt.Errorf("error fetching finality checkpoint for slot %d: %w", firstSlot, err)
+// FindFinalityCheckpointForSlot returns the finality checkpoints for 'slot'
+// searching up to 'tries' slots back if only empty slots are encountered.
+func (c *beaconClient) FindFinalityCheckpointsForSlot(slot uint64, tries uint64) (*FinalityCheckpoints, error) {
+	var finalityCheckpoints *FinalityCheckpoints
+	var err error
+	for i := range uint64(tries) {
+		targetSlot := slot - i
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		finalityCheckpoints, err = c.FinalityCheckpoints(ctx, targetSlot)
+		if errors.Is(err, ethereum.NotFound) {
+			// If there is no checkpoint at this slot, skip to the previous slot.
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error fetching finality checkpoints for slot %d: %w", targetSlot, err)
+		}
+		return finalityCheckpoints, nil
 	}
-
-	// containingEpoch is guaranteed to not be complete at pointInTime (if pointInTime falls in the last
-	// second of the epoch the epoch is still not complete, and if it was a second later we'd be selecting the next epoch)
-	// The previous epoch is the most recent completed epoch.
-	// The one prior to that is the most recent justified epoch.
-	// And the first block of the justified epoch (the epoch boundary block) will be finalized.
-	// This is assuming that there was at least 2/3 participation in the completed and justified epochs.
-
-	// Calculate the first slot of the most recent justified epoch.
-	finalizedSlot := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch) * beaconSlotsPerEpoch
-	return finalizedSlot, nil
+	return nil, fmt.Errorf("finality_checkpoints %w searching up to %d slots back from slot (%d)", ethereum.NotFound, tries, slot)
 }
 
 // FindBlockForSlot returns the hash and timestamp of the block at the given slot,
@@ -77,7 +78,7 @@ func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash co
 	var beaconBlock *BeaconBlock
 	for i := range uint64(10) {
 		targetSlot := slot - i
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		beaconBlock, err := c.BeaconBlock(ctx, targetSlot)
 		if errors.Is(err, ethereum.NotFound) {
@@ -93,7 +94,7 @@ func (c *beaconClient) FindBlockForSlot(slot uint64, tries uint64) (blockHash co
 		break // We found a good block.
 	}
 	if beaconBlock == nil {
-		return common.Hash{}, 0, fmt.Errorf("finalized block %w searching up to 10 slots back from slot (%d)", ethereum.NotFound, slot)
+		return common.Hash{}, 0, fmt.Errorf("finalized block %w searching up to %d slots back from slot (%d)", ethereum.NotFound, tries, slot)
 	}
 	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), uint64(beaconBlock.Data.Message.Body.ExecutionPayload.Timestamp), nil
 }
@@ -147,11 +148,16 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 
 // EpochStartTime returns the start time of an epoch.
 func EpochStartTime(epoch uint64) uint64 {
-	return beaconChainGenesisTimeSeconds + (epoch * beaconSlotsPerEpoch * beaconChainSlotDurationSeconds)
+	return beaconChainGenesisTimeSeconds + (FirstSlotOfEpoch(epoch) * beaconChainSlotDurationSeconds)
 }
 
 func SlotTime(slot uint64) uint64 {
 	return beaconChainGenesisTimeSeconds + (slot * beaconChainSlotDurationSeconds)
+}
+
+// FirstSlotOfEpoch returns the number of the first slot of an epoch.
+func FirstSlotOfEpoch(epoch uint64) uint64 {
+	return epoch * beaconSlotsPerEpoch
 }
 
 // ContainingEpoch returns the number of the epoch whithin which the given time falls.

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -38,7 +38,8 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// Find the epoch starting at or before the L2 start time.
 	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
 
-	// This epoch is not guaranteed to be complete at L2 start time, so assuming it is not complete.
+	// This epoch is guaranteed to not be complete at L2 start time (if the L2 start time falls in the last
+	// second of the epoch the epoch is still not complete, and if it was we'd be selecting the next epoch)
 	// The previous epoch is the most recent completed epoch.
 	// The one prior to that is the most recent justified epoch.
 	// And the first block of the justified epoch (the epoch boundary block) will be finalized.
@@ -60,8 +61,9 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// Calculate the first slot of the most recent justified epoch.
 	mostRecentFinalizedSlot := (epochNumber - 2) * beaconSlotsPerEpoch
 
-	// Find the most recent actual finalized block, slots can be empty so we search back if we encounter empty slots.
-	// We check up to 10 slots, if they are all empty something must be wrong.
+	// Find the most recent actual finalized block, slots can be empty so we
+	// search back if we encounter empty slots. We check up to 10 slots, if they
+	// are all empty something serious is wrong with the L1 so we abort.
 	var beaconBlock *BeaconBlock
 	for i := uint64(0); i < 10; i++ {
 		beaconBlock, err = c.BeaconBlock(context.Background(), mostRecentFinalizedSlot-i)
@@ -83,6 +85,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), nil
 }
 
+// Gets the epoch from the beaconcha.in api
 func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
@@ -103,6 +106,7 @@ func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err
 	return epoch, nil
 }
 
+// Gets the beacon block from the beacon rpc api
 func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -141,7 +141,7 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 
 // EpochStartTime returns the start time of an epoch.
 func EpochStartTime(epoch uint64) uint64 {
-	return beaconChainGenesisTimeSeconds + epoch*beaconSlotsPerEpoch*beaconChainSlotDurationSeconds
+	return beaconChainGenesisTimeSeconds + (epoch * beaconSlotsPerEpoch * beaconChainSlotDurationSeconds)
 }
 
 // EpochAtOrBefore returns the number of the epoch starting at or before the given time.

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -40,7 +40,7 @@ func NewBeaconClient(beaconRPC string, beaconchainURL string) *beaconClient {
 // finalized L1 block at the L2 start time. It finds the epoch which started
 // most recently before the L2 start time (or on the L2 start time) and then
 // looks back from there to find the first finalized block.
-func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint64) (common.Hash, error) {
+func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(ctx context.Context, l2StartTimeSeconds uint64) (common.Hash, error) {
 	// Find the epoch starting at or before the L2 start time.
 	epochNumber := SlotAtOrBefore(l2StartTimeSeconds) / beaconSlotsPerEpoch
 
@@ -56,7 +56,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 
 	// Check the most recent completed and justified epochs had a participation rate of at least 0.67.
 	for i := uint64(1); i <= 2; i++ {
-		epoch, err = c.Epoch(context.Background(), epochNumber-i)
+		epoch, err = c.Epoch(ctx, epochNumber-i)
 		if err != nil {
 			return common.Hash{}, fmt.Errorf("error fetching epoch %d: %w", epochNumber-i, err)
 		}
@@ -71,8 +71,8 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	// search back if we encounter empty slots. We check up to 10 slots, if they
 	// are all empty something serious is wrong with the L1 so we abort.
 	var beaconBlock *BeaconBlock
-	for i := uint64(0); i < 10; i++ {
-		beaconBlock, err = c.BeaconBlock(context.Background(), mostRecentFinalizedSlot-i)
+	for i := range uint64(10) {
+		beaconBlock, err = c.BeaconBlock(ctx, mostRecentFinalizedSlot-i)
 		if errors.Is(err, ethereum.NotFound) {
 			// If there is not block for this slot then skip to the next.
 			continue
@@ -91,11 +91,13 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 	return common.HexToHash(beaconBlock.Data.Message.Body.ExecutionPayload.BlockHash), nil
 }
 
-// Gets the epoch from the beaconcha.in api
+// Epoch gets the requested epoch from the beaconcha.in api.
 func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
-	headers := http.Header{}
-	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(fmt.Sprintf("%s/v1/epoch/%d", c.beaconchainURL, num))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/epoch/%d", c.beaconchainURL, num), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request to get epoch: %w", err)
+	}
+	resp, err := c.cl.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch epoch: %w", err)
 	}
@@ -112,13 +114,15 @@ func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err
 	return epoch, nil
 }
 
-// Gets the beacon block from the beacon rpc api
+// BeaconBlock gets the beacon block from the beacon rpc api.
 func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
-	headers := http.Header{}
-	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", c.beaconRPC, slot))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", c.beaconRPC, slot), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch becon block: %w", err)
+		return nil, fmt.Errorf("failed to create request to get beacon block: %w", err)
+	}
+	resp, err := c.cl.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch beacon block: %w", err)
 	}
 	defer func() {
 		err = errors.Join(err, resp.Body.Close())
@@ -135,16 +139,17 @@ func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *Bea
 	return block, nil
 }
 
-// Returns the start time of an epoch
+// EpochStartTime returns the start time of an epoch.
 func EpochStartTime(epoch uint64) uint64 {
 	return beaconChainGenesisTimeSeconds + epoch*beaconSlotsPerEpoch*beaconChainSlotDurationSeconds
 }
 
-// Returns the number of the epoch starting at or before the given time.
+// EpochAtOrBefore returns the number of the epoch starting at or before the given time.
 func EpochAtOrBefore(unixTime uint64) uint64 {
 	return SlotAtOrBefore(unixTime) / beaconSlotsPerEpoch
 }
 
+// SlotAtOrBefore returns the slot at or before the given time.
 func SlotAtOrBefore(unixTime uint64) uint64 {
 	// Get the slot at or before the given time.
 	// Slot = (start - genesis) / slotDuration

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -22,11 +22,17 @@ const (
 
 type beaconClient struct {
 	cl *http.Client
+	// A beaconchain RPC API endpoint.
+	beaconRPC string
+	// A becaoncha.in api endpoint.
+	beaconchainURL string
 }
 
-func NewBeaconClient() *beaconClient {
+func NewBeaconClient(beaconRPC string, beaconchainURL string) *beaconClient {
 	return &beaconClient{
-		cl: &http.Client{},
+		beaconRPC:      beaconRPC,
+		beaconchainURL: beaconchainURL,
+		cl:             &http.Client{},
 	}
 }
 
@@ -89,7 +95,7 @@ func (c *beaconClient) MostRecentFinalizedL1BlockAtTime(l2StartTimeSeconds uint6
 func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(fmt.Sprintf("https://beaconcha.in/api/v1/epoch/%d", num))
+	resp, err := c.cl.Get(fmt.Sprintf("%s/v1/epoch/%d", c.beaconchainURL, num))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch epoch: %w", err)
 	}
@@ -110,7 +116,7 @@ func (c *beaconClient) Epoch(ctx context.Context, num uint64) (epoch *Epoch, err
 func (c *beaconClient) BeaconBlock(ctx context.Context, slot uint64) (block *BeaconBlock, err error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
-	resp, err := c.cl.Get(fmt.Sprintf("https://eth-beacon-chain.drpc.org/rest/eth/v2/beacon/blocks/%d", slot))
+	resp, err := c.cl.Get(fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", c.beaconRPC, slot))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch becon block: %w", err)
 	}

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 11161216 retreived by test
+func TestFinalizedL1BlockSelection(t *testing.T) {
+	bc := NewBeaconClient()
+	var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
+	var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
+	expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")
+
+	// We expect the same block to be chosen regardless of which slot in an epoch the target time falls in. The only thing that would change the chosen block would be if the
+	// target time fell in a different epoch.
+
+	t.Run("MidEpochSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, targetTime, expectedSlot, expectedL1BlockHash)
+	})
+
+	epochFirstSlotTime := EpochStartTime(EpochAtOrBefore(targetTime))
+	t.Run("StartEpochSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime, expectedSlot, expectedL1BlockHash)
+	})
+
+	epochLastSlotTime := epochFirstSlotTime + beaconChainSlotDurationSeconds*(beaconSlotsPerEpoch-1)
+	t.Run("EndEpochSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, epochLastSlotTime, expectedSlot, expectedL1BlockHash)
+	})
+
+	// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161184
+	expectedL1BlockHashPrevEpoch := common.HexToHash("0xca6237f41190e1adfa52ba20fadb03ef14a7f57c516806edf7660f301b08de36")
+	t.Run("PriorEpochEndSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime-1, expectedSlot-beaconSlotsPerEpoch, expectedL1BlockHashPrevEpoch)
+	})
+
+	// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161248
+	expectedL1BlockHashNextEpoch := common.HexToHash("0x7892cbc14d57ab7036a722306bcae1fc07a202fc5907a227cce539b5f1ca41b3")
+	t.Run("NextEpochStartSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, epochLastSlotTime+beaconChainSlotDurationSeconds, expectedSlot+beaconSlotsPerEpoch, expectedL1BlockHashNextEpoch)
+	})
+}
+
+func checkFinalizedL1BlockSelection(t *testing.T, bc *beaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
+	fmt.Printf("checking finalized L1 block selection for target time %d, expected slot %d, expected block hash %s\n", targetTime, expectedSlot, expectedBlockHash.String())
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	calculatedHash, err := bc.MostRecentFinalizedL1BlockAtTime(targetTime)
+	require.NoError(t, err)
+	assert.Equal(t, expectedBlockHash, calculatedHash)
+	// Double check that we are targeting the correct slot
+	block, err := bc.BeaconBlock(ctx, expectedSlot)
+	require.NoError(t, err)
+	assert.Equal(t, expectedBlockHash.String(), block.Data.Message.Body.ExecutionPayload.BlockHash)
+}

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -28,7 +28,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, targetTime+beaconChainSlotDurationSeconds/2, expectedSlot, expectedL1BlockHash)
 	})
 
-	epochFirstSlotTime := EpochStartTime(ContainingEpoch(targetTime))
+	epochFirstSlotTime := EpochStartTime(Mainnet, ContainingEpoch(Mainnet, targetTime))
 	t.Run("StartEpochSlot", func(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime, expectedSlot, expectedL1BlockHash)
 	})
@@ -54,7 +54,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 func checkFinalizedL1BlockSelection(t *testing.T, bc *BeaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(targetTime)
+	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(Mainnet, targetTime)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBlockHash, calculatedHash)
 	// Double check that we are targeting the correct slot

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFinalizedL1BlockSelection(t *testing.T) {
-	bc := NewBeaconClient()
+	bc := NewBeaconClient("https://eth-beacon-chain.drpc.org/rest", "https://beaconcha.in/api")
 	var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
 	var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
 	expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -51,7 +51,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 	})
 }
 
-func checkFinalizedL1BlockSelection(t *testing.T, bc *beaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
+func checkFinalizedL1BlockSelection(t *testing.T, bc *BeaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
 	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(targetTime)

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFinalizedL1BlockSelection(t *testing.T) {
-	bc := NewBeaconClient("https://eth-beacon-chain.drpc.org/rest", "https://beaconcha.in/api")
+	bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
 	var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
 	var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
 	expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")
@@ -54,7 +54,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 func checkFinalizedL1BlockSelection(t *testing.T, bc *beaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-	calculatedHash, err := bc.MostRecentFinalizedL1BlockAtTime(ctx, targetTime)
+	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(targetTime)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBlockHash, calculatedHash)
 	// Double check that we are targeting the correct slot

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -10,18 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// 11161216 retreived by test
 func TestFinalizedL1BlockSelection(t *testing.T) {
 	bc := NewBeaconClient()
 	var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
 	var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
 	expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")
 
-	// We expect the same block to be chosen regardless of which slot in an epoch the target time falls in. The only thing that would change the chosen block would be if the
-	// target time fell in a different epoch.
+	// We expect the same block to be chosen regardless of which slot in an
+	// epoch the target time falls in. The only thing that would change the
+	// chosen block would be if the target time fell in a different epoch.
 
 	t.Run("MidEpochSlot", func(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, targetTime, expectedSlot, expectedL1BlockHash)
+	})
+
+	t.Run("MidEpochMidSlot", func(t *testing.T) {
+		checkFinalizedL1BlockSelection(t, bc, targetTime+beaconChainSlotDurationSeconds/2, expectedSlot, expectedL1BlockHash)
 	})
 
 	epochFirstSlotTime := EpochStartTime(EpochAtOrBefore(targetTime))

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -49,7 +48,6 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 }
 
 func checkFinalizedL1BlockSelection(t *testing.T, bc *beaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
-	fmt.Printf("checking finalized L1 block selection for target time %d, expected slot %d, expected block hash %s\n", targetTime, expectedSlot, expectedBlockHash.String())
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
 	calculatedHash, err := bc.MostRecentFinalizedL1BlockAtTime(targetTime)

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -28,7 +28,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, targetTime+beaconChainSlotDurationSeconds/2, expectedSlot, expectedL1BlockHash)
 	})
 
-	epochFirstSlotTime := EpochStartTime(EpochAtOrBefore(targetTime))
+	epochFirstSlotTime := EpochStartTime(ContainingEpoch(targetTime))
 	t.Run("StartEpochSlot", func(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime, expectedSlot, expectedL1BlockHash)
 	})

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -54,7 +54,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 func checkFinalizedL1BlockSelection(t *testing.T, bc *beaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-	calculatedHash, err := bc.MostRecentFinalizedL1BlockAtTime(targetTime)
+	calculatedHash, err := bc.MostRecentFinalizedL1BlockAtTime(ctx, targetTime)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBlockHash, calculatedHash)
 	// Double check that we are targeting the correct slot

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -116,12 +116,12 @@ var (
 	}
 	l1BeaconRPCFlag = &cli.StringFlag{
 		Name:     "l1-beacon-rpc",
-		Usage:    "RPC URL for a node of the L1 beacon chain",
+		Usage:    "RPC URL for a node of the L1 beacon chain, required for mainnet migrations but not for alfajores or baklava",
 		Required: false,
 	}
 	l1BeaconchainURLFlag = &cli.StringFlag{
 		Name:     "l1-beaconcha.in-url",
-		Usage:    "API URL for beaconcha.in",
+		Usage:    "API URL for beaconcha.in, (https://beaconcha.in/api) required for mainnet migrations but not for alfajores or baklava",
 		Required: false,
 	}
 
@@ -143,6 +143,8 @@ var (
 		outfileGenesisFlag,
 		migrationBlockTimeFlag,
 		migrationBlockNumberFlag,
+		l1BeaconRPCFlag,
+		l1BeaconchainURLFlag,
 	)
 	dbCheckFlags = []cli.Flag{
 		dbCheckPathFlag,

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -451,6 +451,8 @@ func runStateMigration(newDBPath string, opts stateMigrationOptions) error {
 	if l1StartBlock == nil {
 		return fmt.Errorf("no starting L1 block")
 	}
+	l1startingBlockHash := l1StartBlock.Hash()
+	config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1startingBlockHash}
 
 	// Sanity check the config. Do this after filling in the L1StartingBlockTag
 	// if it is not defined.

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -451,74 +451,77 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		return fmt.Errorf("cannot dial %s: %w", opts.l1RPC, err)
 	}
 
-	// Used to check block validity, duplicate of the
-	// value defined at op-node/rollup.maxSequencerDriftCelo.
-	var maxSequencerDriftCelo uint64 = 2892
-	var blockTime uint64 = 1
-
 	// If the L1 starting block tag is not set, we determine it dynamically by
 	// finding the most recent final L1 block at the time of the L2 fork block.
-	// If we don't find a block in that slot we consider previous slots, until
-	// we can look no further before the time between the L1 starting block
-	// and the L2 fork block exceeds maxSequencerDrift. Once that point is
-	// reached we look forwards to see if future epochs may finalise a block.
 	if config.L1StartingBlockTag == nil {
 		// Find the L1 starting block, the L2 fork block occurs 1 minute after the last celo L1 block.
 		opts.migrationBlockTime = celoL1Head.Time + 60
-		// Wait for the L2 start time before we calculate the L1 starting block.
-		epoch := ContainingEpoch(opts.migrationBlockTime)
-
 		bc := NewBeaconClient(opts.l1BeaconRPC)
 
 		var l1StartBlockHash common.Hash
 		var l1StartBlockTime uint64
-		for {
-			slot, err := bc.MostRecentFinalizedSlotAtEpoch(epoch)
-			if err != nil {
-				return fmt.Errorf("failed fetching most recent finalized slot at epoch (%v): %w", epoch, err)
-			}
 
-			l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(slot, 10)
+		// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
+		for epoch := ContainingEpoch(opts.migrationBlockTime); ; epoch-- {
+			AwaitEpoch(epoch)
+			slot := FirstSlotOfEpoch(epoch)
+			finalityCheckpoints, err := bc.FindFinalityCheckpointsForSlot(slot, 10)
 			if err != nil {
 				if errors.Is(err, ethereum.NotFound) {
-					// If we couldn't find a block we skip an epoch back and see what we can find.
-					epoch--
 					continue
 				}
-				return fmt.Errorf("failed fetching L1 block for slot (%v): %w", slot, err)
+				return fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
 			}
-			// We want to ensure that the L2 fork block is not more than maxSequencerDrift after the L1 starting block.
-			if opts.migrationBlockTime+blockTime-l1StartBlockTime > maxSequencerDriftCelo {
+			justifiedEpoch := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch)
+			if !withinMaxSequencerDrift(opts.migrationBlockTime, EpochStartTime(justifiedEpoch)) {
+				// We've gone too far back and not found a suitable block, so break.
+				break
+			}
+
+			finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
+			l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(finalizedSlot, 10)
+			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					continue
+				}
+				return fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
+			}
+			if !withinMaxSequencerDrift(opts.migrationBlockTime, l1StartBlockTime) {
 				// This block is too old to use with the L2 fork block. Nullify the hash
 				// to signify that no suitable block was yet found.
 				l1StartBlockHash = common.Hash{}
+			} else {
+				log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
 			}
 			break
 		}
 
-		// If no block found start looking to future epochs.
+		// If no block found start looking to future epochs, failing if we
+		// cannot find a finalized block ocurring before the L2 fork block.
 		if l1StartBlockHash == (common.Hash{}) {
-			epoch = ContainingEpoch(opts.migrationBlockTime)
-			for {
-				epoch++
-				slot, err := bc.MostRecentFinalizedSlotAtEpoch(epoch)
-				if err != nil {
-					return fmt.Errorf("failed fetching most recent finalized slot at epoch (%v): %w", epoch, err)
-				}
-
-				l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(slot, 10)
+			for epoch := ContainingEpoch(opts.migrationBlockTime) + 1; ; epoch++ {
+				slot := FirstSlotOfEpoch(epoch)
+				finalityCheckpoints, err := bc.FindFinalityCheckpointsForSlot(slot, 10)
 				if err != nil {
 					if errors.Is(err, ethereum.NotFound) {
-						// If we couldn't find a block we skip an epoch back and see what we can find.
-						epoch--
 						continue
 					}
-					return fmt.Errorf("failed fetching L1 block for slot (%v): %w", slot, err)
+					return fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
 				}
-
-				// Check to see if the block time exceeds the migration block time, in which case it will not be valid.
-				if l1StartBlockTime > opts.migrationBlockTime {
-					return fmt.Errorf("failed to find Finalized L1 block between unix timestamps %d-%d", opts.migrationBlockTime+blockTime-maxSequencerDriftCelo, opts.migrationBlockTime)
+				justifiedEpoch := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch)
+				finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
+				l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(finalizedSlot, 10)
+				if err != nil {
+					if errors.Is(err, ethereum.NotFound) {
+						continue
+					}
+					return fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
+				}
+				if l1StartBlockTime >= opts.migrationBlockTime {
+					// We've gone too far forward and not found a suitable block, so nullify the hash and break.
+					l1StartBlockHash = common.Hash{}
+				} else {
+					log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
 				}
 				break
 			}
@@ -582,6 +585,13 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 	log.Info("State Migration Completed")
 
 	return nil
+}
+
+func withinMaxSequencerDrift(l1StartingBlockTime, l2StartBlockTime uint64) bool {
+	// Used to check block validity, duplicate of the
+	// value defined at op-node/rollup.maxSequencerDriftCelo.
+	var maxSequencerDriftCelo uint64 = 2892
+	return l2StartBlockTime-l1StartingBlockTime <= maxSequencerDriftCelo
 }
 
 func runDBCheck(opts dbCheckOptions) (err error) {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -449,6 +449,11 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		return fmt.Errorf("cannot dial %s: %w", opts.l1RPC, err)
 	}
 
+	chainID, err := client.ChainID(context.Background())
+	if err != nil {
+		return fmt.Errorf("cannot get L1 chain ID: %w", err)
+	}
+
 	// If the L1 starting block tag is not set, we determine it dynamically by
 	// finding the most recent final L1 block at the time of the L2 fork block.
 	if config.L1StartingBlockTag == nil {
@@ -456,7 +461,7 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		opts.migrationBlockTime = celoL1Head.Time + 60
 		bc := NewBeaconClient(opts.l1BeaconRPC)
 
-		l1StartBlockHash, err := bc.MostRecentFinalizedBlockAtTime(opts.migrationBlockTime)
+		l1StartBlockHash, err := bc.MostRecentFinalizedBlockAtTime(chainID, opts.migrationBlockTime)
 		if err != nil {
 			return fmt.Errorf("failed to find finalized L1 starting block: %w", err)
 		}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,8 +71,8 @@ var (
 	}
 	migrationBlockTimeFlag = &cli.Uint64Flag{
 		Name:     "migration-block-time",
-		Usage:    "Specifies a unix timestamp to use for the migration block. This should be set to the same timestamp as was used for the sequencer migration. If performing the sequencer migration, this should set to a time in the future around when the migration script is expected to complete.",
-		Required: true,
+		Usage:    "Specifies a unix timestamp to use for the migration block, a required parameter for alfajores(1727339320) and baklava(1740081460) migrations, but not required for the mainnet migration.",
+		Required: false,
 	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",
@@ -286,6 +287,15 @@ func runFullMigration(opts fullMigrationOptions) error {
 		return fmt.Errorf("old-db head block number not synced to the block immediately before the migration block number: %d != %d", head.Number.Uint64(), opts.migrationBlockNumber-1)
 	}
 
+	// Check that either both migration block time and l1StartingBlockTag are set or unset.
+	config, err := genesis.NewDeployConfig(opts.deployConfig)
+	if err != nil {
+		return err
+	}
+	if (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil) {
+		return fmt.Errorf("if the migration-block-time flag is specified, the l1StartingBlockTag in the deploy config must also be specified and vice versa")
+	}
+
 	log.Info("Source db is synced to correct height", "head", head.Number.Uint64(), "migrationBlock", opts.migrationBlockNumber)
 
 	var numAncients uint64
@@ -419,30 +429,53 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 	}
 	config.SetDeployments(deployments)
 
-	if config.L1StartingBlockTag != nil {
-		log.Info(fmt.Sprintf("Ignoring l1StartingBlockTag set to %v, the l1StartingBlockTag all be selected by the migration script", config.L1StartingBlockTag))
-	}
-
-	// Find the L1 starting block, make the L2 fork block occur 1 minute after the last celo L1 block.
-	l2ForkBlockTime := celoL1Head.Time + 60
-	// Wait for the L2 start time before we calculate the L1 starting block.
-	tillL2Start := int64(l2ForkBlockTime) - time.Now().Unix()
-	if tillL2Start >= 0 {
-		time.Sleep(time.Duration(tillL2Start+1) * time.Second)
-	}
-	l1StartingBlockHash, err := NewBeaconClient().MostRecentFinalizedL1BlockAtTime(l2ForkBlockTime)
 	var l1StartBlock *types.Block
 	client, err := ethclient.Dial(opts.l1RPC)
 	if err != nil {
 		return fmt.Errorf("cannot dial %s: %w", opts.l1RPC, err)
 	}
-	l1StartBlock, err = client.BlockByHash(context.Background(), l1StartingBlockHash)
-	if err != nil {
-		return fmt.Errorf("failed to fetch l1startingBlock by hash (%v): %w", l1StartingBlockHash, err)
+	// If the L1 starting block tag is not set, we determine it dynamically by
+	// finding the most recent final L1 block at the time of the L2 fork block.
+	if config.L1StartingBlockTag == nil {
+		// Find the L1 starting block, the L2 fork block occurs 1 minute after the last celo L1 block.
+		opts.migrationBlockTime = celoL1Head.Time + 60
+		// Wait for the L2 start time before we calculate the L1 starting block.
+		tillL2Start := int64(opts.migrationBlockTime) - time.Now().Unix()
+		if tillL2Start >= 0 {
+			time.Sleep(time.Duration(tillL2Start+1) * time.Second)
+		}
+		l1StartingBlockHash, err := NewBeaconClient().MostRecentFinalizedL1BlockAtTime(opts.migrationBlockTime)
+		if err != nil {
+			return fmt.Errorf("failed to fetch l1startingBlock by time (%v): %w", opts.migrationBlockTime, err)
+		}
+		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
 	}
-	log.Info(fmt.Sprintf("Selected l1StartingBlock as block (%d), with hash (%v)", l1StartBlock.Number(), l1StartBlock.Hash()))
 
-	config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
+	if config.L1StartingBlockTag.BlockHash != nil {
+		l1StartBlock, err = client.BlockByHash(context.Background(), *config.L1StartingBlockTag.BlockHash)
+		if err != nil {
+			return fmt.Errorf("failed to fetch l1startingBlock by hash (%v): %w", config.L1StartingBlockTag.BlockHash, err)
+		}
+	} else if config.L1StartingBlockTag.BlockNumber != nil {
+		l1StartBlock, err = client.BlockByNumber(context.Background(), big.NewInt(config.L1StartingBlockTag.BlockNumber.Int64()))
+		if err != nil {
+			return fmt.Errorf("failed to fetch l1startingBlock by number (%v): %w", config.L1StartingBlockTag.BlockNumber, err)
+		}
+	}
+
+	// We want to ensure that we have sufficient time to start the sequencer
+	// before it exceeds max sequencer drift which is currently 2892s ==
+	// 48.2mins. Devops need about 7 mins to get the sequencer started after the
+	// migration script is run. We give them a 10 minute buffer in case of any
+	// issues, but if we are outside of this range we will fail here.
+	if config.MaxSequencerDrift-(opts.migrationBlockTime-l1StartBlock.Time()) < 17*60 {
+		return fmt.Errorf(
+			"l1StartingBlock is too far in the past, too much chance that the first sequencer block will exceed max sequencer drift: %v",
+			l1StartBlock.Time(),
+		)
+	}
+
+	log.Info(fmt.Sprintf("Selected l1StartingBlock as block (%d), with hash (%v)", l1StartBlock.Number(), l1StartBlock.Hash()))
 	// Sanity check the config. Do this after filling in the L1StartingBlockTag
 	// if it is not defined.
 	if err := config.Check(log.New()); err != nil {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -69,11 +69,6 @@ var (
 		Usage:    "Specifies the migration block number. If the source db is not synced exactly to the block immediately before this number (i.e. migration-block-number - 1), the migration will fail.",
 		Required: true,
 	}
-	migrationBlockTimeFlag = &cli.Uint64Flag{
-		Name:     "migration-block-time",
-		Usage:    "Specifies a unix timestamp to use for the migration block, a required parameter for alfajores(1727339320) and baklava(1740081460) migrations, but not required for the mainnet migration.",
-		Required: false,
-	}
 	oldDBPathFlag = &cli.PathFlag{
 		Name:     "old-db",
 		Usage:    "Path to the old Celo chaindata dir, can be found at '<datadir>/celo/chaindata'",
@@ -136,7 +131,6 @@ var (
 		l2AllocsFlag,
 		outfileRollupConfigFlag,
 		outfileGenesisFlag,
-		migrationBlockTimeFlag,
 		migrationBlockNumberFlag,
 		l1BeaconRPCFlag,
 	)
@@ -198,7 +192,6 @@ func parseStateMigrationOptions(ctx *cli.Context) stateMigrationOptions {
 		l2AllocsPath:        ctx.Path(l2AllocsFlag.Name),
 		outfileRollupConfig: ctx.Path(outfileRollupConfigFlag.Name),
 		outfileGenesis:      ctx.Path(outfileGenesisFlag.Name),
-		migrationBlockTime:  ctx.Uint64(migrationBlockTimeFlag.Name),
 		l1BeaconRPC:         ctx.String(l1BeaconRPCFlag.Name),
 	}
 }
@@ -301,15 +294,17 @@ func runFullMigration(opts fullMigrationOptions) error {
 	if err != nil {
 		return err
 	}
-
-	// Verify that either (migration-block-time and l1StartingBlockTag) are set or l1-beacon-rpc is set.
-	switch {
-	case (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil):
-		// Check that either both migration block time and l1StartingBlockTag are set or unset.
-		return fmt.Errorf("if the migration-block-time flag is specified, the l1StartingBlockTag in the deploy config must also be specified and vice versa")
-	case opts.l1BeaconRPC != "" && opts.migrationBlockTime != 0:
-		// Check that l1BeaconRPC is not set with migrationBlockTime and l1StartingBlockTag.
-		return fmt.Errorf("if the l1-beacon-rpc flag is specified, the migration-block-time flag and l1StartingBlockTag in the deploy config must be unset")
+	switch config.L2ChainID {
+	case 62320: // baklava
+		opts.migrationBlockTime = 1740081460
+	case 44787: // alfajores
+		opts.migrationBlockTime = 1727339320
+	default:
+		opts.migrationBlockTime = head.Time + 60
+	}
+	// Verify that one of l1StartingBlockTag or l1BeaconRPC is set, but not both.
+	if !((config.L1StartingBlockTag != nil) != (opts.l1BeaconRPC != "")) {
+		return fmt.Errorf("exactly one of l1StartingBlockTag or l1BeaconRPC must be set")
 	}
 
 	var numAncients uint64

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -471,7 +471,7 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		}
 		l1StartingBlockHash, err := NewBeaconClient(opts.l1BeaconRPC, opts.l1BeaconchainURL).MostRecentFinalizedL1BlockAtTime(opts.migrationBlockTime)
 		if err != nil {
-			return fmt.Errorf("failed to fetch l1startingBlock by time (%v): %w", opts.migrationBlockTime, err)
+			return fmt.Errorf("failed to fetch l1startingBlock based on L2 starting block time time (%v): %w", opts.migrationBlockTime, err)
 		}
 		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
 	}
@@ -493,10 +493,11 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 	// 48.2mins. Devops need about 7 mins to get the sequencer started after the
 	// migration script is run. We give them a 10 minute buffer in case of any
 	// issues, but if we are outside of this range we will fail here.
-	if config.MaxSequencerDrift-(opts.migrationBlockTime-l1StartBlock.Time()) < 17*60 {
+	var maxSequencerDriftCelo uint64 = 2892 // Duplicate of the value defined at op-node/rollup.maxSequencerDriftCelo
+	if maxSequencerDriftCelo-(opts.migrationBlockTime-l1StartBlock.Time()) < 17*60 {
 		return fmt.Errorf(
-			"l1StartingBlock is too far in the past, too much chance that the first sequencer block will exceed max sequencer drift: %v",
-			l1StartBlock.Time(),
+			"l1StartingBlock time (%v) is too far before L2 start block time (%v), too much chance that the first sequencer block will exceed max sequencer drift (%v)",
+			l1StartBlock.Time(), opts.migrationBlockTime, maxSequencerDriftCelo,
 		)
 	}
 

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -119,11 +121,6 @@ var (
 		Usage:    "RPC URL for a node of the L1 beacon chain, required for mainnet migrations but not for alfajores or baklava",
 		Required: false,
 	}
-	l1BeaconchainURLFlag = &cli.StringFlag{
-		Name:     "l1-beaconcha.in-url",
-		Usage:    "API URL for beaconcha.in, (https://beaconcha.in/api) required for mainnet migrations but not for alfajores or baklava",
-		Required: false,
-	}
 
 	preMigrationFlags = []cli.Flag{
 		oldDBPathFlag,
@@ -144,7 +141,6 @@ var (
 		migrationBlockTimeFlag,
 		migrationBlockNumberFlag,
 		l1BeaconRPCFlag,
-		l1BeaconchainURLFlag,
 	)
 	dbCheckFlags = []cli.Flag{
 		dbCheckPathFlag,
@@ -171,7 +167,6 @@ type stateMigrationOptions struct {
 	outfileGenesis      string
 	migrationBlockTime  uint64
 	l1BeaconRPC         string
-	l1BeaconchainURL    string
 }
 
 type fullMigrationOptions struct {
@@ -207,7 +202,6 @@ func parseStateMigrationOptions(ctx *cli.Context) stateMigrationOptions {
 		outfileGenesis:      ctx.Path(outfileGenesisFlag.Name),
 		migrationBlockTime:  ctx.Uint64(migrationBlockTimeFlag.Name),
 		l1BeaconRPC:         ctx.String(l1BeaconRPCFlag.Name),
-		l1BeaconchainURL:    ctx.String(l1BeaconchainURLFlag.Name),
 	}
 }
 
@@ -310,17 +304,14 @@ func runFullMigration(opts fullMigrationOptions) error {
 		return err
 	}
 
-	// Verify that (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) are set.
+	// Verify that either (migration-block-time and l1StartingBlockTag) are set or l1-beacon-rpc is set.
 	switch {
 	case (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil):
 		// Check that either both migration block time and l1StartingBlockTag are set or unset.
 		return fmt.Errorf("if the migration-block-time flag is specified, the l1StartingBlockTag in the deploy config must also be specified and vice versa")
-	case (opts.l1BeaconRPC != "") != (opts.l1BeaconchainURL != ""):
-		// Check that either both l1BeaconRPC and l1BeaconchainURL are set or unset.
-		return fmt.Errorf("if the l1-beacon-rpc flag is specified, the l1-beaconchain-url must also be specified and vice versa")
-	case (opts.migrationBlockTime == 0) == (opts.l1BeaconRPC == ""):
-		// Check that either the migration block time and l1StartingBlockTag pair or the l1BeaconRPC and l1BeaconchainURL pair is set but not both.
-		return fmt.Errorf("either (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) flags must be specified")
+	case opts.l1BeaconRPC != "" && opts.migrationBlockTime != 0:
+		// Check that l1BeaconRPC is not set with migrationBlockTime and l1StartingBlockTag.
+		return fmt.Errorf("if the l1-beacon-rpc flag is specified, the migration-block-time flag and l1StartingBlockTag in the deploy config must be unset")
 	}
 
 	var numAncients uint64
@@ -459,24 +450,81 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 	if err != nil {
 		return fmt.Errorf("cannot dial %s: %w", opts.l1RPC, err)
 	}
+
+	// Used to check block validity, duplicate of the
+	// value defined at op-node/rollup.maxSequencerDriftCelo.
+	var maxSequencerDriftCelo uint64 = 2892
+	var blockTime uint64 = 1
+
 	// If the L1 starting block tag is not set, we determine it dynamically by
 	// finding the most recent final L1 block at the time of the L2 fork block.
+	// If we don't find a block in that slot we consider previous slots, until
+	// we can look no further before the time between the L1 starting block
+	// and the L2 fork block exceeds maxSequencerDrift. Once that point is
+	// reached we look forwards to see if future epochs may finalise a block.
 	if config.L1StartingBlockTag == nil {
 		// Find the L1 starting block, the L2 fork block occurs 1 minute after the last celo L1 block.
 		opts.migrationBlockTime = celoL1Head.Time + 60
 		// Wait for the L2 start time before we calculate the L1 starting block.
-		tillL2Start := int64(opts.migrationBlockTime) - time.Now().Unix()
-		if tillL2Start >= 0 {
-			time.Sleep(time.Duration(tillL2Start+1) * time.Second)
+		epoch := ContainingEpoch(opts.migrationBlockTime)
+
+		bc := NewBeaconClient(opts.l1BeaconRPC)
+
+		var l1StartBlockHash common.Hash
+		var l1StartBlockTime uint64
+		for {
+			slot, err := bc.MostRecentFinalizedSlotAtEpoch(epoch)
+			if err != nil {
+				return fmt.Errorf("failed fetching most recent finalized slot at epoch (%v): %w", epoch, err)
+			}
+
+			l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(slot, 10)
+			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					// If we couldn't find a block we skip an epoch back and see what we can find.
+					epoch--
+					continue
+				}
+				return fmt.Errorf("failed fetching L1 block for slot (%v): %w", slot, err)
+			}
+			// We want to ensure that the L2 fork block is not more than maxSequencerDrift after the L1 starting block.
+			if opts.migrationBlockTime+blockTime-l1StartBlockTime > maxSequencerDriftCelo {
+				// This block is too old to use with the L2 fork block. Nullify the hash
+				// to signify that no suitable block was yet found.
+				l1StartBlockHash = common.Hash{}
+			}
+			break
 		}
-		// MostRecentFinalizedL1BlockAtTime can a few seconds so we provide a suitably long context.
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-		l1StartingBlockHash, err := NewBeaconClient(opts.l1BeaconRPC, opts.l1BeaconchainURL).MostRecentFinalizedL1BlockAtTime(ctx, opts.migrationBlockTime)
-		if err != nil {
-			return fmt.Errorf("failed to fetch l1startingBlock based on L2 starting block time (%v): %w", opts.migrationBlockTime, err)
+
+		// If no block found start looking to future epochs.
+		if l1StartBlockHash == (common.Hash{}) {
+			epoch = ContainingEpoch(opts.migrationBlockTime)
+			for {
+				epoch++
+				slot, err := bc.MostRecentFinalizedSlotAtEpoch(epoch)
+				if err != nil {
+					return fmt.Errorf("failed fetching most recent finalized slot at epoch (%v): %w", epoch, err)
+				}
+
+				l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(slot, 10)
+				if err != nil {
+					if errors.Is(err, ethereum.NotFound) {
+						// If we couldn't find a block we skip an epoch back and see what we can find.
+						epoch--
+						continue
+					}
+					return fmt.Errorf("failed fetching L1 block for slot (%v): %w", slot, err)
+				}
+
+				// Check to see if the block time exceeds the migration block time, in which case it will not be valid.
+				if l1StartBlockTime > opts.migrationBlockTime {
+					return fmt.Errorf("failed to find Finalized L1 block between unix timestamps %d-%d", opts.migrationBlockTime+blockTime-maxSequencerDriftCelo, opts.migrationBlockTime)
+				}
+				break
+			}
 		}
-		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
+
+		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartBlockHash}
 	}
 
 	if config.L1StartingBlockTag.BlockHash != nil {
@@ -489,19 +537,6 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		if err != nil {
 			return fmt.Errorf("failed to fetch l1startingBlock by number (%v): %w", config.L1StartingBlockTag.BlockNumber, err)
 		}
-	}
-
-	// We want to ensure that we have sufficient time to start the sequencer
-	// before it exceeds max sequencer drift which is currently 2892s ==
-	// 48.2mins. Devops need about 7 mins to get the sequencer started after the
-	// migration script is run. We give them a 10 minute buffer in case of any
-	// issues, but if we are outside of this range we will fail here.
-	var maxSequencerDriftCelo uint64 = 2892 // Duplicate of the value defined at op-node/rollup.maxSequencerDriftCelo
-	if maxSequencerDriftCelo-(opts.migrationBlockTime-l1StartBlock.Time()) < 17*60 {
-		return fmt.Errorf(
-			"l1StartingBlock time (%v) is too far before L2 start block time (%v), too much chance that the first sequencer block will exceed max sequencer drift (%v)",
-			l1StartBlock.Time(), opts.migrationBlockTime, maxSequencerDriftCelo,
-		)
 	}
 
 	log.Info(fmt.Sprintf("Selected l1StartingBlock as block (%d), with hash (%v)", l1StartBlock.Number(), l1StartBlock.Hash()))

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -114,6 +114,16 @@ var (
 		Usage: "Fail fast on the first error encountered. If set, the db check will stop on the first error encountered, otherwise it will continue to check all blocks and print out all errors at the end.",
 		Value: false,
 	}
+	l1BeaconRPCFlag = &cli.StringFlag{
+		Name:     "l1-beacon-rpc",
+		Usage:    "RPC URL for a node of the L1 beacon chain",
+		Required: false,
+	}
+	l1BeaconchainURLFlag = &cli.StringFlag{
+		Name:     "l1-beaconcha.in-url",
+		Usage:    "API URL for beaconcha.in",
+		Required: false,
+	}
 
 	preMigrationFlags = []cli.Flag{
 		oldDBPathFlag,
@@ -158,6 +168,8 @@ type stateMigrationOptions struct {
 	outfileRollupConfig string
 	outfileGenesis      string
 	migrationBlockTime  uint64
+	l1BeaconRPC         string
+	l1BeaconchainURL    string
 }
 
 type fullMigrationOptions struct {
@@ -192,6 +204,8 @@ func parseStateMigrationOptions(ctx *cli.Context) stateMigrationOptions {
 		outfileRollupConfig: ctx.Path(outfileRollupConfigFlag.Name),
 		outfileGenesis:      ctx.Path(outfileGenesisFlag.Name),
 		migrationBlockTime:  ctx.Uint64(migrationBlockTimeFlag.Name),
+		l1BeaconRPC:         ctx.String(l1BeaconRPCFlag.Name),
+		l1BeaconchainURL:    ctx.String(l1BeaconchainURLFlag.Name),
 	}
 }
 
@@ -287,13 +301,20 @@ func runFullMigration(opts fullMigrationOptions) error {
 		return fmt.Errorf("old-db head block number not synced to the block immediately before the migration block number: %d != %d", head.Number.Uint64(), opts.migrationBlockNumber-1)
 	}
 
-	// Check that either both migration block time and l1StartingBlockTag are set or unset.
 	config, err := genesis.NewDeployConfig(opts.deployConfig)
 	if err != nil {
 		return err
 	}
-	if (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil) {
+	switch {
+	case (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil):
+		// Check that either both migration block time and l1StartingBlockTag are set or unset.
 		return fmt.Errorf("if the migration-block-time flag is specified, the l1StartingBlockTag in the deploy config must also be specified and vice versa")
+	case (opts.l1BeaconRPC != "") != (opts.l1BeaconchainURL != ""):
+		// Check that either both l1BeaconRPC and l1BeaconchainURL are set or unset.
+		return fmt.Errorf("if the l1-beacon-rpc flag is specified, the l1-beaconchain-url must also be specified and vice versa")
+	case (opts.migrationBlockTime == 0) != (opts.l1BeaconRPC == ""):
+		// Check that either the migration block time and l1StartingBlockTag pair or the l1BeaconRPC and l1BeaconchainURL pair is set but not both.
+		return fmt.Errorf("either (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) flags must be specified")
 	}
 
 	log.Info("Source db is synced to correct height", "head", head.Number.Uint64(), "migrationBlock", opts.migrationBlockNumber)

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -300,7 +298,7 @@ func runFullMigration(opts fullMigrationOptions) error {
 	if err = runNonAncientMigration(opts.newDBPath, strayAncientBlocks, opts.batchSize, numAncients); err != nil {
 		return fmt.Errorf("failed to run non-ancient migration: %w", err)
 	}
-	if err = runStateMigration(opts.newDBPath, opts.stateMigrationOptions); err != nil {
+	if err = runStateMigration(head, opts.newDBPath, opts.stateMigrationOptions); err != nil {
 		return fmt.Errorf("failed to run state migration: %w", err)
 	}
 
@@ -396,7 +394,7 @@ func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.Number
 	return nil
 }
 
-func runStateMigration(newDBPath string, opts stateMigrationOptions) error {
+func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMigrationOptions) error {
 	defer timer("state migration")()
 
 	log.Info("State Migration Started", "newDBPath", newDBPath, "deployConfig", opts.deployConfig, "l1Deployments", opts.l1Deployments, "l1RPC", opts.l1RPC, "l2AllocsPath", opts.l2AllocsPath, "outfileRollupConfig", opts.outfileRollupConfig)
@@ -421,39 +419,30 @@ func runStateMigration(newDBPath string, opts stateMigrationOptions) error {
 	}
 	config.SetDeployments(deployments)
 
-	// Get latest block information from L1
+	if config.L1StartingBlockTag != nil {
+		log.Info(fmt.Sprintf("Ignoring l1StartingBlockTag set to %v, the l1StartingBlockTag all be selected by the migration script", config.L1StartingBlockTag))
+	}
+
+	// Find the L1 starting block, make the L2 fork block occur 1 minute after the last celo L1 block.
+	l2ForkBlockTime := celoL1Head.Time + 60
+	// Wait for the L2 start time before we calculate the L1 starting block.
+	tillL2Start := int64(l2ForkBlockTime) - time.Now().Unix()
+	if tillL2Start >= 0 {
+		time.Sleep(time.Duration(tillL2Start+1) * time.Second)
+	}
+	l1StartingBlockHash, err := NewBeaconClient().MostRecentFinalizedL1BlockAtTime(l2ForkBlockTime)
 	var l1StartBlock *types.Block
 	client, err := ethclient.Dial(opts.l1RPC)
 	if err != nil {
 		return fmt.Errorf("cannot dial %s: %w", opts.l1RPC, err)
 	}
-
-	if config.L1StartingBlockTag == nil {
-		l1StartBlock, err = client.BlockByNumber(context.Background(), nil)
-		if err != nil {
-			return fmt.Errorf("cannot fetch latest block: %w", err)
-		}
-		tag := rpc.BlockNumberOrHashWithHash(l1StartBlock.Hash(), true)
-		config.L1StartingBlockTag = (*genesis.MarshalableRPCBlockNumberOrHash)(&tag)
-	} else if config.L1StartingBlockTag.BlockHash != nil {
-		l1StartBlock, err = client.BlockByHash(context.Background(), *config.L1StartingBlockTag.BlockHash)
-		if err != nil {
-			return fmt.Errorf("cannot fetch block by hash: %w", err)
-		}
-	} else if config.L1StartingBlockTag.BlockNumber != nil {
-		l1StartBlock, err = client.BlockByNumber(context.Background(), big.NewInt(config.L1StartingBlockTag.BlockNumber.Int64()))
-		if err != nil {
-			return fmt.Errorf("cannot fetch block by number: %w", err)
-		}
+	l1StartBlock, err = client.BlockByHash(context.Background(), l1StartingBlockHash)
+	if err != nil {
+		return fmt.Errorf("failed to fetch l1startingBlock by hash (%v): %w", l1StartingBlockHash, err)
 	}
+	log.Info(fmt.Sprintf("Selected l1StartingBlock as block (%d), with hash (%v)", l1StartBlock.Number(), l1StartBlock.Hash()))
 
-	// Ensure that there is a starting L1 block
-	if l1StartBlock == nil {
-		return fmt.Errorf("no starting L1 block")
-	}
-	l1startingBlockHash := l1StartBlock.Hash()
-	config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1startingBlockHash}
-
+	config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
 	// Sanity check the config. Do this after filling in the L1StartingBlockTag
 	// if it is not defined.
 	if err := config.Check(log.New()); err != nil {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -467,7 +467,7 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		if tillL2Start >= 0 {
 			time.Sleep(time.Duration(tillL2Start+1) * time.Second)
 		}
-		l1StartingBlockHash, err := NewBeaconClient().MostRecentFinalizedL1BlockAtTime(opts.migrationBlockTime)
+		l1StartingBlockHash, err := NewBeaconClient(opts.l1BeaconRPC, opts.l1BeaconchainURL).MostRecentFinalizedL1BlockAtTime(opts.migrationBlockTime)
 		if err != nil {
 			return fmt.Errorf("failed to fetch l1startingBlock by time (%v): %w", opts.migrationBlockTime, err)
 		}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -458,75 +456,10 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		opts.migrationBlockTime = celoL1Head.Time + 60
 		bc := NewBeaconClient(opts.l1BeaconRPC)
 
-		var l1StartBlockHash common.Hash
-		var l1StartBlockTime uint64
-
-		// This loop looks back for a finalized L1 block that is up to maxSequencerDrift before the L2 fork block.
-		for epoch := ContainingEpoch(opts.migrationBlockTime); ; epoch-- {
-			AwaitEpoch(epoch)
-			slot := FirstSlotOfEpoch(epoch)
-			finalityCheckpoints, err := bc.FindFinalityCheckpointsForSlot(slot, 10)
-			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
-					continue
-				}
-				return fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
-			}
-			justifiedEpoch := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch)
-			if !withinMaxSequencerDrift(opts.migrationBlockTime, EpochStartTime(justifiedEpoch)) {
-				// We've gone too far back and not found a suitable block, so break.
-				break
-			}
-
-			finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
-			l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(finalizedSlot, 10)
-			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
-					continue
-				}
-				return fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
-			}
-			if !withinMaxSequencerDrift(opts.migrationBlockTime, l1StartBlockTime) {
-				// This block is too old to use with the L2 fork block. Nullify the hash
-				// to signify that no suitable block was yet found.
-				l1StartBlockHash = common.Hash{}
-			} else {
-				log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
-			}
-			break
+		l1StartBlockHash, err := bc.MostRecentFinalizedBlockAtTime(opts.migrationBlockTime)
+		if err != nil {
+			return fmt.Errorf("failed to find finalized L1 starting block: %w", err)
 		}
-
-		// If no block found start looking to future epochs, failing if we
-		// cannot find a finalized block ocurring before the L2 fork block.
-		if l1StartBlockHash == (common.Hash{}) {
-			for epoch := ContainingEpoch(opts.migrationBlockTime) + 1; ; epoch++ {
-				slot := FirstSlotOfEpoch(epoch)
-				finalityCheckpoints, err := bc.FindFinalityCheckpointsForSlot(slot, 10)
-				if err != nil {
-					if errors.Is(err, ethereum.NotFound) {
-						continue
-					}
-					return fmt.Errorf("failed fetching finality checkpoints for slot %d: %w", slot, err)
-				}
-				justifiedEpoch := uint64(finalityCheckpoints.Data.CurrentJustified.Epoch)
-				finalizedSlot := FirstSlotOfEpoch(justifiedEpoch)
-				l1StartBlockHash, l1StartBlockTime, err = bc.FindBlockForSlot(finalizedSlot, 10)
-				if err != nil {
-					if errors.Is(err, ethereum.NotFound) {
-						continue
-					}
-					return fmt.Errorf("failed fetching L1 block for slot (%v): %w", finalizedSlot, err)
-				}
-				if l1StartBlockTime >= opts.migrationBlockTime {
-					// We've gone too far forward and not found a suitable block, so nullify the hash and break.
-					l1StartBlockHash = common.Hash{}
-				} else {
-					log.Info(fmt.Sprintf("Found finalized L1 slot at %d", finalizedSlot))
-				}
-				break
-			}
-		}
-
 		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartBlockHash}
 	}
 
@@ -585,13 +518,6 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 	log.Info("State Migration Completed")
 
 	return nil
-}
-
-func withinMaxSequencerDrift(l1StartingBlockTime, l2StartBlockTime uint64) bool {
-	// Used to check block validity, duplicate of the
-	// value defined at op-node/rollup.maxSequencerDriftCelo.
-	var maxSequencerDriftCelo uint64 = 2892
-	return l2StartBlockTime-l1StartingBlockTime <= maxSequencerDriftCelo
 }
 
 func runDBCheck(opts dbCheckOptions) (err error) {

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -469,9 +469,12 @@ func runStateMigration(celoL1Head *types.Header, newDBPath string, opts stateMig
 		if tillL2Start >= 0 {
 			time.Sleep(time.Duration(tillL2Start+1) * time.Second)
 		}
-		l1StartingBlockHash, err := NewBeaconClient(opts.l1BeaconRPC, opts.l1BeaconchainURL).MostRecentFinalizedL1BlockAtTime(opts.migrationBlockTime)
+		// MostRecentFinalizedL1BlockAtTime can a few seconds so we provide a suitably long context.
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		l1StartingBlockHash, err := NewBeaconClient(opts.l1BeaconRPC, opts.l1BeaconchainURL).MostRecentFinalizedL1BlockAtTime(ctx, opts.migrationBlockTime)
 		if err != nil {
-			return fmt.Errorf("failed to fetch l1startingBlock based on L2 starting block time time (%v): %w", opts.migrationBlockTime, err)
+			return fmt.Errorf("failed to fetch l1startingBlock based on L2 starting block time (%v): %w", opts.migrationBlockTime, err)
 		}
 		config.L1StartingBlockTag = &genesis.MarshalableRPCBlockNumberOrHash{BlockHash: &l1StartingBlockHash}
 	}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -305,6 +305,8 @@ func runFullMigration(opts fullMigrationOptions) error {
 	if err != nil {
 		return err
 	}
+
+	// Verify that (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) are set.
 	switch {
 	case (opts.migrationBlockTime != 0) != (config.L1StartingBlockTag != nil):
 		// Check that either both migration block time and l1StartingBlockTag are set or unset.
@@ -312,7 +314,7 @@ func runFullMigration(opts fullMigrationOptions) error {
 	case (opts.l1BeaconRPC != "") != (opts.l1BeaconchainURL != ""):
 		// Check that either both l1BeaconRPC and l1BeaconchainURL are set or unset.
 		return fmt.Errorf("if the l1-beacon-rpc flag is specified, the l1-beaconchain-url must also be specified and vice versa")
-	case (opts.migrationBlockTime == 0) != (opts.l1BeaconRPC == ""):
+	case (opts.migrationBlockTime == 0) == (opts.l1BeaconRPC == ""):
 		// Check that either the migration block time and l1StartingBlockTag pair or the l1BeaconRPC and l1BeaconchainURL pair is set but not both.
 		return fmt.Errorf("either (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) flags must be specified")
 	}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -303,6 +303,8 @@ func runFullMigration(opts fullMigrationOptions) error {
 		return fmt.Errorf("old-db head block number not synced to the block immediately before the migration block number: %d != %d", head.Number.Uint64(), opts.migrationBlockNumber-1)
 	}
 
+	log.Info("Source db is synced to correct height", "head", head.Number.Uint64(), "migrationBlock", opts.migrationBlockNumber)
+
 	config, err := genesis.NewDeployConfig(opts.deployConfig)
 	if err != nil {
 		return err
@@ -320,8 +322,6 @@ func runFullMigration(opts fullMigrationOptions) error {
 		// Check that either the migration block time and l1StartingBlockTag pair or the l1BeaconRPC and l1BeaconchainURL pair is set but not both.
 		return fmt.Errorf("either (migration-block-time and l1StartingBlockTag) or (l1-beacon-rpc and l1-beaconchain-url) flags must be specified")
 	}
-
-	log.Info("Source db is synced to correct height", "head", head.Number.Uint64(), "migrationBlock", opts.migrationBlockNumber)
 
 	var numAncients uint64
 	var strayAncientBlocks []*rawdb.NumberHash


### PR DESCRIPTION
Changes the way the migration script works so that it does not require the L2 fork block time as an input. This frees us from trying to predict a safe L2 fork block time that falls after the final Celo L1 block but not so far in the future that we end up with the L2 not producing blocks once started because it is waiting for that time.

Also changes the way we select the l1 starting block, previously we were selecting it to be the latest block of the L1 but this was not safe since that block would not have been finalized and it was also not deterministic, since the value depended on when the migration script was run. Now we select the most recent L1 block that was finalized at the time of the L2 fork block (or if there is none the closest we can find), which is deterministic because it is based on the L2 fork block time that is based on the last Celo L1 block time.

These changes allow us to provide all required config for a migration well in advance of the migration time and also allows partners to perform the migration in parallel with our migration, as opposed to having to wait for our migration to finish before they can start their migration.

A description of ethereum's finalization process can be found here - https://eth2book.info/capella/part2/consensus/casper_ffg/
and here - https://ethos.dev/beacon-chain

The approach we use here is to use the finality_checkpoints to find the most recent finalized slot for a given slot, the finality checkpoints don't change so we can easily historically find out what was the latest finalized slot at any point in the history of the chain.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/908

# Tested

 