### PR TITLE
Add ProxyAdmin owner verification to deploy/genesis scripts

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -910,6 +910,9 @@ type DeployConfig struct {
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
+
+	// Used to validate the ProxyAdmin owner address.
+	ProxyAdminOwnerIsMultisig bool `json:"proxyAdminOwnerIsMultisig"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -72,5 +72,6 @@
   "daChallengeWindow": 16,
   "daResolveWindow": 16,
   "daBondSize": 1000000,
-  "daResolverRefundPercentage": 0
+  "daResolverRefundPercentage": 0,
+  "proxyAdminOwnerIsMultisig": false
 }

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -62,5 +62,6 @@
   "daChallengeWindow": 100,
   "daResolveWindow": 100,
   "daBondSize": 1000,
-  "daResolverRefundPercentage": 50
+  "daResolverRefundPercentage": 50,
+  "l2ProxyAdminOwnerVerification": "equal"
 }

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -63,5 +63,5 @@
   "daResolveWindow": 100,
   "daBondSize": 1000,
   "daResolverRefundPercentage": 50,
-  "l2ProxyAdminOwnerVerification": "equal"
+  "proxyAdminOwnerIsMultisig": false
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -96,7 +96,7 @@ contract DeployConfig is Script {
 
     bool public deployCeloContracts;
 
-    string public l2ProxyAdminOwnerVerification;
+    bool public proxyAdminOwnerIsMultisig;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -186,38 +186,33 @@ contract DeployConfig is Script {
 
         deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
 
-        l2ProxyAdminOwnerVerification = stdJson.readString(_json, "$.l2ProxyAdminOwnerVerification");
+        proxyAdminOwnerIsMultisig = stdJson.readBool(_json, "$.proxyAdminOwnerIsMultisig");
 
         verifyProxyAdminOwners();
     }
 
 
     /// @notice Performs a check on the ProxyAdmin owner addresses accross L1 and L2, based on the
-    /// `l2ProxyAdminOwnerVerification` parameter of the config.
+    /// `proxyAdminOwnerIsMultisig` parameter of the config.
     /// Specifically:
     /// - `finalSystemOwner` is the L1 ProxyAdmin owner address (used in Deploy.s.sol).
     /// - `proxyAdminOwner` is the L2 ProxyAdmin owner address (used in L2Genesis.s.sol).
-    /// - `l2ProxyAdminOwnerVerification` can have one of three values:
-    ///   - `"no-check"`: No verification is performed, the addresses are taken as they are.
-    ///   - `"aliased"`: Verify that the L2 address is the aliased version of the L1 address. This
-    ///   should be used when both the L1 and L2 systems are owned by the same L1 contract address.
-    ///   - `"equal"`: Verify that both the addresses are equal. This should be used when both
-    ///   systems are owned by the same EOA address.
+    /// - If `proxyAdminOwnerIsMultisig` is true, assumes that both systems are owned by the same L1
+    ///   smart contract multisig, so the L2 owner should be the aliased verision of the L1 owner
+    ///   address.
+    /// - If `proxyAdminOwnerIsMultisig` is false, assumes that both systems are owned by the same
+    ///   EOA, so both owner addresses should be equal.
     ///   See the following docs for details on address aliasing:
     ///   https://docs.optimism.io/stack/differences#address-aliasing
-    function verifyProxyAdminOwners() public  {
-        if (LibString.eq(l2ProxyAdminOwnerVerification, "equal")) {
+    function verifyProxyAdminOwners() public view {
+        if (proxyAdminOwnerIsMultisig) {
+            address expectedAlias = AddressAliasHelper.applyL1ToL2Alias(finalSystemOwner);
+            require(expectedAlias == proxyAdminOwner, "Expected proxyAdminOwner to be aliased finalSystemOwner");
+        } else {
             require(
                 finalSystemOwner == proxyAdminOwner,
                 "Expected finalSystemOwner and proxyAdminOwner to be equal"
             );
-        } else if (LibString.eq(l2ProxyAdminOwnerVerification, "aliased")) {
-            address expectedAlias = AddressAliasHelper.applyL1ToL2Alias(finalSystemOwner);
-            require(expectedAlias == proxyAdminOwner, "Expected aliased address");
-        } else if (LibString.eq(l2ProxyAdminOwnerVerification, "no-check")) {
-            // no-op
-        } else {
-            require(false, "Incorrect value for l2ProxyAdminOwnerVerification");
         }
     }
 
@@ -296,10 +291,10 @@ contract DeployConfig is Script {
 
     /// @notice Allow the ProxyAdmin owner configs (`finalSystemOwner`, `proxyAdminOwner`, and
     /// `l2ProxyAdminOwnerVerification`) to be overriden in testing environments.
-    function setProxyAdminOwnerSettings(address l1Owner, address l2Owner, string calldata verification) public {
+    function setProxyAdminOwnerSettings(address l1Owner, address l2Owner, bool isMultisig) public {
         finalSystemOwner = l1Owner;
         proxyAdminOwner = l2Owner;
-        l2ProxyAdminOwnerVerification = verification;
+        proxyAdminOwnerIsMultisig = isMultisig;
     }
 
     function latestGenesisFork() internal view returns (Fork) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 import { stdJson } from "forge-std/StdJson.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 import { Executables } from "scripts/libraries/Executables.sol";
 import { Process } from "scripts/libraries/Process.sol";
 import { Config, Fork, ForkUtils } from "scripts/libraries/Config.sol";
@@ -94,6 +96,8 @@ contract DeployConfig is Script {
 
     bool public deployCeloContracts;
 
+    string public l2ProxyAdminOwnerVerification;
+
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
         try vm.readFile(_path) returns (string memory data_) {
@@ -181,6 +185,40 @@ contract DeployConfig is Script {
         useInterop = _readOr(_json, "$.useInterop", false);
 
         deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
+
+        l2ProxyAdminOwnerVerification = stdJson.readString(_json, "$.l2ProxyAdminOwnerVerification");
+
+        verifyProxyAdminOwners();
+    }
+
+
+    /// @notice Performs a check on the ProxyAdmin owner addresses accross L1 and L2, based on the
+    /// `l2ProxyAdminOwnerVerification` parameter of the config.
+    /// Specifically:
+    /// - `finalSystemOwner` is the L1 ProxyAdmin owner address (used in Deploy.s.sol).
+    /// - `proxyAdminOwner` is the L2 ProxyAdmin owner address (used in L2Genesis.s.sol).
+    /// - `l2ProxyAdminOwnerVerification` can have one of three values:
+    ///   - `"no-check"`: No verification is performed, the addresses are taken as they are.
+    ///   - `"aliased"`: Verify that the L2 address is the aliased version of the L1 address. This
+    ///   should be used when both the L1 and L2 systems are owned by the same L1 contract address.
+    ///   - `"equal"`: Verify that both the addresses are equal. This should be used when both
+    ///   systems are owned by the same EOA address.
+    ///   See the following docs for details on address aliasing:
+    ///   https://docs.optimism.io/stack/differences#address-aliasing
+    function verifyProxyAdminOwners() public  {
+        if (LibString.eq(l2ProxyAdminOwnerVerification, "equal")) {
+            require(
+                finalSystemOwner == proxyAdminOwner,
+                "Expected finalSystemOwner and proxyAdminOwner to be equal"
+            );
+        } else if (LibString.eq(l2ProxyAdminOwnerVerification, "aliased")) {
+            address expectedAlias = AddressAliasHelper.applyL1ToL2Alias(finalSystemOwner);
+            require(expectedAlias == proxyAdminOwner, "Expected aliased address");
+        } else if (LibString.eq(l2ProxyAdminOwnerVerification, "no-check")) {
+            // no-op
+        } else {
+            require(false, "Incorrect value for l2ProxyAdminOwnerVerification");
+        }
     }
 
     function fork() public view returns (Fork fork_) {
@@ -254,6 +292,14 @@ contract DeployConfig is Script {
     function setUseCustomGasToken(address _token) public {
         useCustomGasToken = true;
         customGasTokenAddress = _token;
+    }
+
+    /// @notice Allow the ProxyAdmin owner configs (`finalSystemOwner`, `proxyAdminOwner`, and
+    /// `l2ProxyAdminOwnerVerification`) to be overriden in testing environments.
+    function setProxyAdminOwnerSettings(address l1Owner, address l2Owner, string calldata verification) public {
+        finalSystemOwner = l1Owner;
+        proxyAdminOwner = l2Owner;
+        l2ProxyAdminOwnerVerification = verification;
     }
 
     function latestGenesisFork() internal view returns (Fork) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -191,7 +191,6 @@ contract DeployConfig is Script {
         verifyProxyAdminOwners();
     }
 
-
     /// @notice Performs a check on the ProxyAdmin owner addresses accross L1 and L2, based on the
     /// `proxyAdminOwnerIsMultisig` parameter of the config.
     /// Specifically:
@@ -209,10 +208,7 @@ contract DeployConfig is Script {
             address expectedAlias = AddressAliasHelper.applyL1ToL2Alias(finalSystemOwner);
             require(expectedAlias == proxyAdminOwner, "Expected proxyAdminOwner to be aliased finalSystemOwner");
         } else {
-            require(
-                finalSystemOwner == proxyAdminOwner,
-                "Expected finalSystemOwner and proxyAdminOwner to be equal"
-            );
+            require(finalSystemOwner == proxyAdminOwner, "Expected finalSystemOwner and proxyAdminOwner to be equal");
         }
     }
 

--- a/packages/contracts-bedrock/test/setup/L2ProxyAdminOwnerVerification.t.sol
+++ b/packages/contracts-bedrock/test/setup/L2ProxyAdminOwnerVerification.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+
+// Testing utilities
+import { CommonTest } from "test/setup/CommonTest.sol";
+
+contract L2ProxyAdminOwnerVerification_Test is CommonTest {
+    address constant anOwner = 0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe;
+    address constant anotherOwner = 0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef;
+    address constant aliasedOwner = 0xDc0FCafeCAFecAfeCafecAfecaFecAFeCAfEdc0F;
+
+    DeployConfig cfg;
+
+    function setUp() public override {
+        super.setUp();
+        cfg = deploy.cfg();
+    }
+
+    function test_noCheck_succeeds() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, anotherOwner, "no-check");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_aliased_succeeds() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, "aliased");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_equal_succeeds() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "equal");
+        cfg.verifyProxyAdminOwners();
+    }
+}
+
+contract L2ProxyAdminOwnerVerification_TestFail is CommonTest {
+    address constant anOwner = 0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe;
+    address constant anotherOwner = 0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef;
+    address constant aliasedOwner = 0xDc0FCafeCAFecAfeCafecAfecaFecAFeCAfEdc0F;
+    address constant offByOneOwner = 0xcAFeCAfEcAFECaFecaFECAFeCAfEcAFecAFECAff;
+
+    DeployConfig cfg;
+
+    function setUp() public override {
+        super.setUp();
+        cfg = deploy.cfg();
+    }
+
+    function test_aliased_whenSameAddress_fails() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "aliased");
+        vm.expectRevert("Expected aliased address");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_aliased_whenIncorrectAlias_fails() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, "aliased");
+        vm.expectRevert("Expected aliased address");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_equal_whenAliased_fails() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, "equal");
+        vm.expectRevert("Expected finalSystemOwner and proxyAdminOwner to be equal");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_equal_whenOffBy1_fails() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, "equal");
+        vm.expectRevert("Expected finalSystemOwner and proxyAdminOwner to be equal");
+        cfg.verifyProxyAdminOwners();
+    }
+
+    function test_badConfig_fails() public {
+        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "bad-option");
+        vm.expectRevert("Incorrect value for l2ProxyAdminOwnerVerification");
+        cfg.verifyProxyAdminOwners();
+    }
+}

--- a/packages/contracts-bedrock/test/setup/L2ProxyAdminOwnerVerification.t.sol
+++ b/packages/contracts-bedrock/test/setup/L2ProxyAdminOwnerVerification.t.sol
@@ -18,18 +18,13 @@ contract L2ProxyAdminOwnerVerification_Test is CommonTest {
         cfg = deploy.cfg();
     }
 
-    function test_noCheck_succeeds() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, anotherOwner, "no-check");
-        cfg.verifyProxyAdminOwners();
-    }
-
     function test_aliased_succeeds() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, "aliased");
+        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, true);
         cfg.verifyProxyAdminOwners();
     }
 
     function test_equal_succeeds() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "equal");
+        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, false);
         cfg.verifyProxyAdminOwners();
     }
 }
@@ -48,32 +43,26 @@ contract L2ProxyAdminOwnerVerification_TestFail is CommonTest {
     }
 
     function test_aliased_whenSameAddress_fails() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "aliased");
-        vm.expectRevert("Expected aliased address");
+        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, true);
+        vm.expectRevert("Expected proxyAdminOwner to be aliased finalSystemOwner");
         cfg.verifyProxyAdminOwners();
     }
 
     function test_aliased_whenIncorrectAlias_fails() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, "aliased");
-        vm.expectRevert("Expected aliased address");
+        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, true);
+        vm.expectRevert("Expected proxyAdminOwner to be aliased finalSystemOwner");
         cfg.verifyProxyAdminOwners();
     }
 
     function test_equal_whenAliased_fails() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, "equal");
+        cfg.setProxyAdminOwnerSettings(anOwner, aliasedOwner, false);
         vm.expectRevert("Expected finalSystemOwner and proxyAdminOwner to be equal");
         cfg.verifyProxyAdminOwners();
     }
 
     function test_equal_whenOffBy1_fails() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, "equal");
+        cfg.setProxyAdminOwnerSettings(anOwner, offByOneOwner, false);
         vm.expectRevert("Expected finalSystemOwner and proxyAdminOwner to be equal");
-        cfg.verifyProxyAdminOwners();
-    }
-
-    function test_badConfig_fails() public {
-        cfg.setProxyAdminOwnerSettings(anOwner, anOwner, "bad-option");
-        vm.expectRevert("Incorrect value for l2ProxyAdminOwnerVerification");
         cfg.verifyProxyAdminOwners();
     }
 }


### PR DESCRIPTION
This PR adds a config validation step to ensure that the L1/L2 ProxyAdmin owner addresses are set correctly in the deployment config.

There is a new config variable, `l2ProxyAdminOwnerVerification`, that needs to be explicitly set to one of three values: `no-check`, `aliased`, or `equal`. After the JSON config is read, the `finalSystemOwner` (which defines the L1 ProxyAdmin owner) and `proxyAdminOwner` (which defines the L2 ProxyAdmin owner) will be validated according to the verification method specified:
- `no-check`: no check is performed
- `aliased`: verifies that `proxyAdminOwner` is the aliased version of `finalSystemOwner`. This is the method expected to be used for the production deployment, where both systems are owned by the same L1 multisig.
- `equal`: verifies that `proxyAdminOwner` and `finalSystemOwner` are equal. This can be used for testing environments where both systems are just owned by the same EOA.

This check happens in both the L1 deployment script and the L2 genesis script.