### PR TITLE
Add Mainnet CeloUnreleasedTreasury address to migration script

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/state.go
+++ b/op-chain-ops/cmd/celo-migrate/state.go
@@ -89,6 +89,7 @@ var (
 	unreleasedTreasuryAddressMap = map[uint64]common.Address{
 		AlfajoresNetworkID: common.HexToAddress("0x07bf0b2461A0cb608D5CF9a82ba97dAbA850F79F"),
 		BaklavaNetworkID:   common.HexToAddress("0x022c5d5837E177B6d145761feb4C5574e5b48F5e"),
+		MainnetNetworkID:   common.HexToAddress("0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f"),
 	}
 )
 


### PR DESCRIPTION
One-liner to add the CeloUnreleasedTreasury address for mainnet to a mapping. Addresses https://github.com/celo-org/celo-blockchain-planning/issues/619

It looks like the balance is set based on information read from the [celoAddresses.CeloToken](https://github.com/celo-org/optimism/blob/ca0b801cb728c247de0653d87d0320085d031d12/op-chain-ops/cmd/celo-migrate/state.go#L388) contract, so it doesn't need to be configured here. 