### PR TITLE
Improve `check-db` memory use

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -118,12 +118,15 @@ func loadAncientRange(freezer *rawdb.Freezer, start, count uint64, loadAllData b
 	log.Info("Loading ancient block range", "start", start, "end", start+count-1, "count", count)
 
 	blockRange := &RLPBlockRange{
-		start:    start,
-		hashes:   make([][]byte, count),
-		headers:  make([][]byte, count),
-		bodies:   make([][]byte, count),
-		receipts: make([][]byte, count),
-		tds:      make([][]byte, count),
+		start:   start,
+		hashes:  make([][]byte, count),
+		headers: make([][]byte, count),
+	}
+
+	if loadAllData {
+		blockRange.bodies = make([][]byte, count)
+		blockRange.receipts = make([][]byte, count)
+		blockRange.tds = make([][]byte, count)
 	}
 
 	var err error
@@ -173,6 +176,9 @@ func transformBlocks(ctx context.Context, in <-chan RLPBlockRange, out chan<- RL
 	defer close(out)
 
 	for blockRange := range in {
+		if blockRange.bodies == nil || blockRange.receipts == nil || blockRange.tds == nil || blockRange.headers == nil || blockRange.hashes == nil {
+			return fmt.Errorf("block range is missing data")
+		}
 		for i := range blockRange.hashes {
 			blockNumber := blockRange.start + uint64(i)
 

--- a/op-chain-ops/cmd/celo-migrate/ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/ancients.go
@@ -98,7 +98,7 @@ func readAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, startBlock, 
 		count := min(batchSize, endBlock-i)
 		start := i
 
-		blockRange, err := loadAncientRange(freezer, start, count)
+		blockRange, err := loadAncientRange(freezer, start, count, true)
 		if err != nil {
 			return fmt.Errorf("Failed to load ancient block range: %w", err)
 		}
@@ -114,7 +114,7 @@ func readAncientBlocks(ctx context.Context, freezer *rawdb.Freezer, startBlock, 
 	return nil
 }
 
-func loadAncientRange(freezer *rawdb.Freezer, start, count uint64) (*RLPBlockRange, error) {
+func loadAncientRange(freezer *rawdb.Freezer, start, count uint64, loadAllData bool) (*RLPBlockRange, error) {
 	log.Info("Loading ancient block range", "start", start, "end", start+count-1, "count", count)
 
 	blockRange := &RLPBlockRange{
@@ -135,17 +135,34 @@ func loadAncientRange(freezer *rawdb.Freezer, start, count uint64) (*RLPBlockRan
 	if err != nil {
 		return nil, fmt.Errorf("failed to read headers from freezer: %w", err)
 	}
-	blockRange.bodies, err = freezer.AncientRange(rawdb.ChainFreezerBodiesTable, start, count, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read bodies from freezer: %w", err)
-	}
-	blockRange.receipts, err = freezer.AncientRange(rawdb.ChainFreezerReceiptTable, start, count, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read receipts from freezer: %w", err)
-	}
-	blockRange.tds, err = freezer.AncientRange(rawdb.ChainFreezerDifficultyTable, start, count, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read tds from freezer: %w", err)
+	if loadAllData {
+		blockRange.bodies, err = freezer.AncientRange(rawdb.ChainFreezerBodiesTable, start, count, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read bodies from freezer: %w", err)
+		}
+		blockRange.receipts, err = freezer.AncientRange(rawdb.ChainFreezerReceiptTable, start, count, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read receipts from freezer: %w", err)
+		}
+		blockRange.tds, err = freezer.AncientRange(rawdb.ChainFreezerDifficultyTable, start, count, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tds from freezer: %w", err)
+		}
+	} else {
+		for i := start; i < start+count; i++ {
+			bodyExists, err := freezer.HasAncient(rawdb.ChainFreezerBodiesTable, i)
+			if err != nil || !bodyExists {
+				return nil, fmt.Errorf("failed to read bodies from freezer")
+			}
+			receiptExists, err := freezer.HasAncient(rawdb.ChainFreezerReceiptTable, i)
+			if err != nil || !receiptExists {
+				return nil, fmt.Errorf("failed to read receipts from freezer")
+			}
+			tdExists, err := freezer.HasAncient(rawdb.ChainFreezerDifficultyTable, i)
+			if err != nil || !tdExists {
+				return nil, fmt.Errorf("failed to read tds from freezer")
+			}
+		}
 	}
 
 	return blockRange, nil
@@ -245,7 +262,7 @@ func loadLastAncient(freezer *rawdb.Freezer) (*RLPBlockElement, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get number of ancients in freezer: %w", err)
 	}
-	blockRange, err := loadAncientRange(freezer, numAncients-1, 1)
+	blockRange, err := loadAncientRange(freezer, numAncients-1, 1, false)
 	if err != nil {
 		return nil, err
 	}

--- a/op-chain-ops/cmd/celo-migrate/continuity.go
+++ b/op-chain-ops/cmd/celo-migrate/continuity.go
@@ -53,20 +53,48 @@ func (e *RLPBlockElement) Number() uint64 {
 	return e.Header().Number.Uint64()
 }
 
+func (e *RLPBlockElement) Body() ([]byte, error) {
+	if e.body == nil {
+		return nil, fmt.Errorf("block element body is nil for block %d", e.Number())
+	}
+	return e.body, nil
+}
+
+func (e *RLPBlockElement) Receipts() ([]byte, error) {
+	if e.receipts == nil {
+		return nil, fmt.Errorf("block element receipts are nil for block %d", e.Number())
+	}
+	return e.receipts, nil
+}
+
+func (e *RLPBlockElement) TD() ([]byte, error) {
+	if e.td == nil {
+		return nil, fmt.Errorf("block element total difficulty is nil for block %d", e.Number())
+	}
+	return e.td, nil
+}
+
 func (r *RLPBlockRange) Element(i uint64) (*RLPBlockElement, error) {
 	header := types.Header{}
 	err := rlp.DecodeBytes(r.headers[i], &header)
 	if err != nil {
 		return nil, fmt.Errorf("can't decode header: %w", err)
 	}
-	return &RLPBlockElement{
+	element := &RLPBlockElement{
 		decodedHeader: &header,
 		hash:          r.hashes[i],
 		header:        r.headers[i],
-		body:          r.bodies[i],
-		receipts:      r.receipts[i],
-		td:            r.tds[i],
-	}, nil
+	}
+	if r.bodies != nil {
+		element.body = r.bodies[i]
+	}
+	if r.receipts != nil {
+		element.receipts = r.receipts[i]
+	}
+	if r.tds != nil {
+		element.td = r.tds[i]
+	}
+	return element, nil
 }
 
 // CheckContinuity checks if the block data in the range is continuous
@@ -115,16 +143,16 @@ func (r *RLPBlockRange) CheckLengths(expectedLength uint64) error {
 	if uint64(len(r.hashes)) != expectedLength {
 		err = fmt.Errorf("Unexpected number of hashes for block range: expected %d, actual %d", expectedLength, len(r.hashes))
 	}
-	if uint64(len(r.bodies)) != expectedLength {
-		err = errors.Join(err, fmt.Errorf("Unexpected number of bodies for block range: expected %d, actual %d", expectedLength, len(r.bodies)))
-	}
 	if uint64(len(r.headers)) != expectedLength {
 		err = errors.Join(err, fmt.Errorf("Unexpected number of headers for block range: expected %d, actual %d", expectedLength, len(r.headers)))
 	}
-	if uint64(len(r.receipts)) != expectedLength {
+	if r.bodies != nil && uint64(len(r.bodies)) != expectedLength {
+		err = errors.Join(err, fmt.Errorf("Unexpected number of bodies for block range: expected %d, actual %d", expectedLength, len(r.bodies)))
+	}
+	if r.receipts != nil && uint64(len(r.receipts)) != expectedLength {
 		err = errors.Join(err, fmt.Errorf("Unexpected number of receipts for block range: expected %d, actual %d", expectedLength, len(r.receipts)))
 	}
-	if uint64(len(r.tds)) != expectedLength {
+	if r.tds != nil && uint64(len(r.tds)) != expectedLength {
 		err = errors.Join(err, fmt.Errorf("Unexpected number of total difficulties for block range: expected %d, actual %d", expectedLength, len(r.tds)))
 	}
 	return err

--- a/op-chain-ops/cmd/celo-migrate/continuity_test.go
+++ b/op-chain-ops/cmd/celo-migrate/continuity_test.go
@@ -69,7 +69,7 @@ func TestCheckContinuity(t *testing.T) {
 			blockRange:     makeRange(1, bodies[1:], receipts[1:], tds[1:], hashes[1:], headers[1:]),
 			prevElement:    &RLPBlockElement{decodedHeader: decodedHeaders[0], hash: hashes[0]},
 			expectedLength: 4,
-			expectErrorMsg: "Unexpected number of hashes for block range: expected 4, actual 3\nUnexpected number of bodies for block range: expected 4, actual 3\nUnexpected number of headers for block range: expected 4, actual 3\nUnexpected number of receipts for block range: expected 4, actual 3\nUnexpected number of total difficulties for block range: expected 4, actual 3",
+			expectErrorMsg: "Unexpected number of hashes for block range: expected 4, actual 3\nUnexpected number of headers for block range: expected 4, actual 3\nUnexpected number of bodies for block range: expected 4, actual 3\nUnexpected number of receipts for block range: expected 4, actual 3\nUnexpected number of total difficulties for block range: expected 4, actual 3",
 		},
 		{
 			name:           "Length mismatch in hashes",

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -567,7 +567,7 @@ func runDBCheck(opts dbCheckOptions) (err error) {
 	// First, check continuity between ancients and non-ancients.
 	// Gaps in data will often halt the freezing process, so attempting to load the first non-ancient block
 	// will most likely fail if there is a gap.
-	firstNonAncientRange, err := loadNonAncientRange(nonAncientDB, lastAncientNumber+1, 1)
+	firstNonAncientRange, err := loadNonAncientRange(nonAncientDB, lastAncientNumber+1, 1, false)
 	if err != nil {
 		if opts.failFast {
 			return fmt.Errorf("failed to load first non-ancient block: %w", err)
@@ -644,13 +644,13 @@ func runDBCheck(opts dbCheckOptions) (err error) {
 
 	log.Info("Checking continuity of ancient blocks", "start", opts.start, "end", lastAncientNumber, "count", lastAncientNumber-opts.start+1)
 	if err := checkContinuity(opts.start, lastAncientNumber, func(start, count uint64) (*RLPBlockRange, error) {
-		return loadAncientRange(ancientDB, start, count)
+		return loadAncientRange(ancientDB, start, count, false)
 	}); err != nil {
 		return err
 	}
 	log.Info("Checking continuity of non-ancient blocks", "start", lastAncientNumber+1, "end", lastBlockNumber, "count", lastBlockNumber-lastAncientNumber)
 	if err := checkContinuity(lastAncientNumber+1, lastBlockNumber, func(start, count uint64) (*RLPBlockRange, error) {
-		return loadNonAncientRange(nonAncientDB, start, count)
+		return loadNonAncientRange(nonAncientDB, start, count, false)
 	}); err != nil {
 		return err
 	}

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -120,6 +120,11 @@ var (
 		Usage: "Fail fast on the first error encountered. If set, the db check will stop on the first error encountered, otherwise it will continue to check all blocks and print out all errors at the end.",
 		Value: false,
 	}
+	skipDbCheck = &cli.BoolFlag{
+		Name:  "skip-db-check",
+		Usage: "Skip the db continuity check.",
+		Value: false,
+	}
 
 	preMigrationFlags = []cli.Flag{
 		oldDBPathFlag,
@@ -128,6 +133,7 @@ var (
 		bufferSizeFlag,
 		memoryLimitFlag,
 		reset,
+		skipDbCheck,
 	}
 	fullMigrationFlags = append(
 		preMigrationFlags,
@@ -144,6 +150,7 @@ var (
 		dbCheckPathFlag,
 		batchSizeFlag,
 		dbCheckFailFastFlag,
+		dbCheckStartFlag,
 	}
 )
 
@@ -154,6 +161,7 @@ type preMigrationOptions struct {
 	bufferSize       uint64
 	memoryLimit      int64
 	resetNonAncients bool
+	skipDbCheck      bool
 }
 
 type stateMigrationOptions struct {
@@ -187,6 +195,7 @@ func parsePreMigrationOptions(ctx *cli.Context) preMigrationOptions {
 		bufferSize:       ctx.Uint64(bufferSizeFlag.Name),
 		memoryLimit:      ctx.Int64(memoryLimitFlag.Name),
 		resetNonAncients: ctx.Bool(reset.Name),
+		skipDbCheck:      ctx.Bool(skipDbCheck.Name),
 	}
 }
 
@@ -340,9 +349,13 @@ func runPreMigration(opts preMigrationOptions) ([]*rawdb.NumberHash, uint64, err
 		}
 	}
 
-	err = runDBCheckFromLastMigrated(opts)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to run db check from last migrated block: %w", err)
+	if !opts.skipDbCheck {
+		err = runDBCheckFromLastMigrated(opts)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to run db check from last migrated block: %w", err)
+		}
+	} else {
+		log.Info("Skipping db continuity check")
 	}
 
 	var numAncientsNewBefore uint64

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -130,13 +130,17 @@ func migrateNonAncientBlock(number uint64, hash common.Hash, newDB ethdb.Databas
 
 func loadNonAncientRange(db ethdb.Database, start, count uint64, loadAllData bool) (*RLPBlockRange, error) {
 	blockRange := &RLPBlockRange{
-		start:    start,
-		hashes:   make([][]byte, count),
-		headers:  make([][]byte, count),
-		bodies:   make([][]byte, count),
-		receipts: make([][]byte, count),
-		tds:      make([][]byte, count),
+		start:   start,
+		hashes:  make([][]byte, count),
+		headers: make([][]byte, count),
 	}
+
+	if loadAllData {
+		blockRange.bodies = make([][]byte, count)
+		blockRange.receipts = make([][]byte, count)
+		blockRange.tds = make([][]byte, count)
+	}
+
 	end := start + count - 1
 	log.Info("Loading non-ancient block range", "start", start, "end", end, "count", count)
 	numberHashes := rawdb.ReadAllHashesInRange(db, start, end)

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -128,7 +128,7 @@ func migrateNonAncientBlock(number uint64, hash common.Hash, newDB ethdb.Databas
 	return nil
 }
 
-func loadNonAncientRange(db ethdb.Database, start, count uint64) (*RLPBlockRange, error) {
+func loadNonAncientRange(db ethdb.Database, start, count uint64, loadAllData bool) (*RLPBlockRange, error) {
 	blockRange := &RLPBlockRange{
 		start:    start,
 		hashes:   make([][]byte, count),
@@ -156,17 +156,32 @@ func loadNonAncientRange(db ethdb.Database, start, count uint64) (*RLPBlockRange
 		if err != nil {
 			combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find header in db for non-ancient block %d - %x: %w", number, hash, err))
 		}
-		blockRange.bodies[i], err = db.Get(blockBodyKey(number, hash))
-		if err != nil {
-			combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find body in db for non-ancient block %d - %x: %w", number, hash, err))
-		}
-		blockRange.receipts[i], err = db.Get(blockReceiptsKey(number, hash))
-		if err != nil {
-			combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find receipts in db for non-ancient block %d - %x: %w", number, hash, err))
-		}
-		blockRange.tds[i], err = db.Get(headerTDKey(number, hash))
-		if err != nil {
-			combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find total difficulty in db for non-ancient block %d - %x: %w", number, hash, err))
+		if loadAllData {
+			blockRange.bodies[i], err = db.Get(blockBodyKey(number, hash))
+			if err != nil {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find body in db for non-ancient block %d - %x: %w", number, hash, err))
+			}
+			blockRange.receipts[i], err = db.Get(blockReceiptsKey(number, hash))
+			if err != nil {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find receipts in db for non-ancient block %d - %x: %w", number, hash, err))
+			}
+			blockRange.tds[i], err = db.Get(headerTDKey(number, hash))
+			if err != nil {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find total difficulty in db for non-ancient block %d - %x: %w", number, hash, err))
+			}
+		} else {
+			bodyExists, err := db.Has(blockBodyKey(number, hash))
+			if err != nil || !bodyExists {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find body in db for non-ancient block %d - %x", number, hash))
+			}
+			receiptExists, err := db.Has(blockReceiptsKey(number, hash))
+			if err != nil || !receiptExists {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find receipts in db for non-ancient block %d - %x", number, hash))
+			}
+			tdExists, err := db.Has(headerTDKey(number, hash))
+			if err != nil || !tdExists {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("failed to find total difficulty in db for non-ancient block %d - %x", number, hash))
+			}
 		}
 	}
 


### PR DESCRIPTION
When running the continuity on mainnet data the node ran out of memory. This is because mainnet block bodies and receipts are much larger than for alfajores or baklava. We do not need block bodies, receipts or total difficulty in memory in order to verify continuity -- we just need to check that the data exists in the db. By not loading everything into memory, the script is able to run on mainnet data without running out of memory. 

Also adds flag to skip the db continuity check, which otherwise will run automatically during the pre-migration step

Tested locally on baklava data with gaps, and with mainnet data in K8s