### PR TITLE
Add a new deploy entrypoint

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -310,8 +310,10 @@ contract Deploy is Deployer {
         save("SuperchainConfigProxy", _superchainConfigProxy);
 
         // The Celo system does not use a ProtocolVersions contract.
-        save("ProtocolVersions", address(0));
-        save("ProtocolVersionsProxy", address(0));
+        // Set to a non-0 dummy address such that `mustGetAddress` does not revert (e.g. when
+        // _proxies() is called).
+        save("ProtocolVersions", address(1));
+        save("ProtocolVersionsProxy", address(1));
 
         _run(false, false);
     }

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -298,6 +298,24 @@ contract Deploy is Deployer {
         _run(true, false);
     }
 
+    /// @notice Deploy L1 contracts for the Celo OP system.
+    /// @param _superchainConfigProxy The external SuperchainConfig address (Celo uses a custom
+    ///        CeloSuperchainConfig, which calls to the official SuperchainConfig).
+    function runCeloWithSuperchain(address payable _superchainConfigProxy) public {
+        require(_superchainConfigProxy != address(0), "must specify address for superchain config proxy");
+        console.log("Deploying a fresh OP Stack with existing SuperchainConfig");
+
+        Proxy scProxy = Proxy(_superchainConfigProxy);
+        save("SuperchainConfig", scProxy.implementation());
+        save("SuperchainConfigProxy", _superchainConfigProxy);
+
+        // The Celo system does not use a ProtocolVersions contract.
+        save("ProtocolVersions", address(0));
+        save("ProtocolVersionsProxy", address(0));
+
+        _run(false, false);
+    }
+
     /// @notice Deploy a new OP Chain using an existing SuperchainConfig and ProtocolVersions
     /// @param _superchainConfigProxy Address of the existing SuperchainConfig proxy
     /// @param _protocolVersionsProxy Address of the existing ProtocolVersions proxy


### PR DESCRIPTION
Adds an entrypoint, `runCeloWithSuperchain`, to the `Deploy.s.sol` script that:

* Takes an `address` argument that specifies the external SuperchainConfig deployment.
* Calls `_run` with
   * `_needsSuperchain = false`, since we want to use the provided SuperchainConfig, rather than deploying a new one
   * `_initializeFaultGames = false`, since that is what the previous `runCelo` entrypoint specified.