### PR TITLE
Remove `--checksum` from migration script

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -85,6 +85,9 @@ func checkForPrevFullMigration(newDBPath string) (bool, error) {
 
 	newDB, err := openDBWithoutFreezer(newDBPath, true)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to open new database: %w", err)
 	}
 	defer newDB.Close()

--- a/op-chain-ops/cmd/celo-migrate/db.go
+++ b/op-chain-ops/cmd/celo-migrate/db.go
@@ -17,8 +17,9 @@ import (
 
 // Constants for the database
 const (
-	DBCache   = 1024 // size of the cache in MB
-	DBHandles = 60   // number of handles
+	DBCache                 = 1024                      // size of the cache in MB
+	DBHandles               = 60                        // number of handles
+	CeloFullMigrationMarker = "celoFullMigrationMarker" // Marker to indicate whether a previous full migration attempt has modified the database
 )
 
 var (
@@ -66,6 +67,30 @@ func blockBodyKey(number uint64, hash common.Hash) []byte {
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+}
+
+// readFullMigrationMarker reads a marker indicating whether a previous full migration attempt has modified the database
+func readFullMigrationMarker(db ethdb.KeyValueReader) ([]byte, error) {
+	return db.Get([]byte(CeloFullMigrationMarker))
+}
+
+// writeFullMigrationMarker writes a marker indicating that a full migration has been attempted on the database
+func writeFullMigrationMarker(db ethdb.KeyValueWriter) error {
+	return db.Put([]byte(CeloFullMigrationMarker), []byte{1})
+}
+
+// checkForPrevFullMigration checks if a previous full migration has already been attempted on the database
+func checkForPrevFullMigration(newDBPath string) (bool, error) {
+	defer timer("checkForPrevFullMigration")()
+
+	newDB, err := openDBWithoutFreezer(newDBPath, true)
+	if err != nil {
+		return false, fmt.Errorf("failed to open new database: %w", err)
+	}
+	defer newDB.Close()
+
+	marker, _ := readFullMigrationMarker(newDB)
+	return len(marker) > 0, nil
 }
 
 // Opens a database without access to AncientsDb

--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -360,12 +360,6 @@ func runPreMigration(opts preMigrationOptions) ([]*rawdb.NumberHash, uint64, err
 		return nil, 0, fmt.Errorf("failed to create new db path: %w", err)
 	}
 
-	if opts.resetNonAncients {
-		if err = cleanupNonAncientDb(opts.newDBPath); err != nil {
-			return nil, 0, fmt.Errorf("failed to cleanup non-ancient db: %w", err)
-		}
-	}
-
 	if !opts.skipDbCheck {
 		err = runDBCheckFromLastMigrated(opts)
 		if err != nil {
@@ -391,7 +385,26 @@ func runPreMigration(opts preMigrationOptions) ([]*rawdb.NumberHash, uint64, err
 		return nil
 	})
 	g.Go(func() error {
-		// By doing this once during the premigration, we get a speedup when we run it again in a full migration.
+		// Check if we should reset the non-ancient db. This is necessary if a full migration has been run before.
+		// The script can also be forced to reset non-ancients by passing the --reset flag.
+		shouldReset := opts.resetNonAncients
+		if !shouldReset {
+			prevFullMigration, err := checkForPrevFullMigration(opts.newDBPath)
+			if err != nil {
+				return fmt.Errorf("failed to check for previous full migration: %w", err)
+			}
+			if prevFullMigration {
+				log.Info("Previous full migration detected", "process", "pre-migration")
+			}
+			shouldReset = prevFullMigration
+		}
+		if shouldReset {
+			log.Info("Resetting non-ancient db", "process", "pre-migration")
+			if err := cleanupNonAncientDb(opts.newDBPath); err != nil {
+				return fmt.Errorf("failed to cleanup non-ancient db: %w", err)
+			}
+		}
+		// By doing this copy once during the premigration, we get a speedup when we run it again in a full migration.
 		return copyDbExceptAncients(opts.oldDBPath, opts.newDBPath)
 	})
 
@@ -421,6 +434,11 @@ func runNonAncientMigration(newDBPath string, strayAncientBlocks []*rawdb.Number
 	lastAncient := numAncients - 1
 
 	log.Info("Non-Ancient Block Migration Started", "process", "non-ancients", "newDBPath", newDBPath, "batchSize", batchSize, "startBlock", numAncients, "endBlock", lastBlock, "count", lastBlock-lastAncient, "lastAncientBlock", lastAncient)
+
+	log.Info("Writing full migration marker", "process", "non-ancients")
+	if err := writeFullMigrationMarker(newDB); err != nil {
+		return fmt.Errorf("failed to write full migration marker: %w", err)
+	}
 
 	var numNonAncients uint64
 	if numNonAncients, err = migrateNonAncientsDb(newDB, lastBlock, numAncients, batchSize); err != nil {

--- a/op-chain-ops/cmd/celo-migrate/non-ancients.go
+++ b/op-chain-ops/cmd/celo-migrate/non-ancients.go
@@ -29,7 +29,7 @@ func copyDbExceptAncients(oldDbPath, newDbPath string) error {
 	// Convert output to string
 	outputStr := string(output)
 
-	opts := []string{"-v", "-a", "--exclude=ancient", "--checksum", "--delete"}
+	opts := []string{"-v", "-a", "--exclude=ancient", "--delete"}
 
 	// Check for supported options
 	// Prefer --info=progress2 over --progress
@@ -50,10 +50,8 @@ func copyDbExceptAncients(oldDbPath, newDbPath string) error {
 	// '-a' archive mode; equals -rlptgoD. It is a quick way of saying you want recursion and want to preserve almost everything, including timestamps, ownerships, permissions, etc.
 	// Timestamps are important here because they are used to determine which files are newer and should be copied over.
 	//
-	// '--whole-file' This is the default when both the source and destination are specified as local paths, which they are here (oldDbPath and newDbPath).
+	// (default) '--whole-file' This is the default when both the source and destination are specified as local paths, which they are here (oldDbPath and newDbPath).
 	// This option disables rsync’s delta-transfer algorithm, which causes all transferred files to be sent whole. The delta-transfer algorithm is normally used when the destination is a remote system.
-	//
-	// '--checksum' This forces rsync to compare the checksums of all files to determine if they are the same. This is slows down the transfer but ensures that source and destination directories end up with the same contents (excluding /ancients).
 
 	log.Info("Running rsync command", "command", cmd.String())
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
The `--checksum` flag in the rsync command allowed us to treat the full migration script as an idempotent operation. Unfortunately, it has proven too inefficient to use on mainnet data, as the quantity of data that must be checksummed is much greater and causes the `rsync` command to take multiple hours even after a pre-migration. 
This PR removes the `--checksum` flag and adds code to write a marker to the db during a full migration so that subsequent runs will automatically delete the non-ancient portion of the destination datadir before performing the `rsync` command. This is necessary because there are changes that will occur on the source db in between the pre-migration and the full migration, and the full migration modifies data in the destination db. These changes will modify timestamps and file sizes in both dbs and prevent `rsync` from accurately determining which data should be transferred. 
Because the pre-migration just copies non-ancient data over but does not modify it, the pre-migration command can still be run multiple times even without the checksum flag or a db reset. 