### PR TITLE
Provide external SuperchainConfig in deploy config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -911,6 +911,9 @@ type DeployConfig struct {
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
 	DeployCeloContracts bool `json:"deployCeloContracts"`
 
+	// Address of the external SuperchainConfig that CeloSuperchainConfig should point to.
+	ExternalSuperchainConfig common.Address `json:"externalSuperchainConfig"`
+
 	// Used to validate the ProxyAdmin owner address.
 	ProxyAdminOwnerIsMultisig bool `json:"proxyAdminOwnerIsMultisig"`
 }

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -73,5 +73,6 @@
   "daResolveWindow": 16,
   "daBondSize": 1000000,
   "daResolverRefundPercentage": 0,
-  "proxyAdminOwnerIsMultisig": false
+  "proxyAdminOwnerIsMultisig": false,
+  "externalSuperchainConfig": "0x0000000000000000000000000000000000000000"
 }

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -289,13 +289,22 @@ contract Deploy is Deployer {
 
     /// @notice Deploy all of the L1 contracts necessary for a full Superchain with a single Op Chain.
     ///         The two parameters correspond to:
-    ///         1. Whether or not the Superchain contracts need to be deployed. Set to deploy a new Superchain contracts
+    ///         1. Whether or not the Superchain contracts need to be deployed. We do not deploy a
+    ///            SuperchainConfig, instead the address of the external one should be provided in
+    ///            the deployment config.
     ///         2. Whether or not the fault games need to be initialized. Set to false, and execute latter
     /// `setupFaultGames()` to initialize
     ///            when the config `faultGameGenesisOutputRoot` is known
     function runCelo() public {
-        console.log("Deploying a fresh OP Stack including SuperchainConfig");
-        _run(true, false);
+        console.log(
+            "Deploying a fresh OP Stack, without SuperchainConfig (address should be provided in `externalSuperchainConfig` parameter of the deploy JSON)"
+        );
+        _run(false, false);
+    }
+
+    /// @notice For testing purposes.
+    function run(bool _needsSuperchain) public {
+        _run(_needsSuperchain);
     }
 
     /// @notice Deploy a new OP Chain using an existing SuperchainConfig and ProtocolVersions
@@ -369,6 +378,18 @@ contract Deploy is Deployer {
         if (_needsSuperchain) {
             setupSuperchain();
             console.log("set up superchain!");
+        } else {
+            require(
+                cfg.externalSuperchainConfig() != address(0), "Need to provide the external SuperchainConfig address!"
+            );
+            // Inject the external SuperchainConfig address into Artifacts, so it can be retrieved
+            // by contracts that depend on it (e.g. CeloSuperchainConfig).
+            save("SuperchainConfigProxy", cfg.externalSuperchainConfig());
+
+            // Still need a ProtocolVersions deployment.
+            deployERC1967Proxy("ProtocolVersionsProxy");
+            deployProtocolVersions();
+            initializeProtocolVersions();
         }
 
         setupCeloSuperchainConfig();

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -95,6 +95,7 @@ contract DeployConfig is Script {
     bool public useInterop;
 
     bool public deployCeloContracts;
+    address public externalSuperchainConfig;
 
     bool public proxyAdminOwnerIsMultisig;
 
@@ -185,6 +186,7 @@ contract DeployConfig is Script {
         useInterop = _readOr(_json, "$.useInterop", false);
 
         deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
+        externalSuperchainConfig = _readOr(_json, "$.externalSuperchainConfig", address(0));
 
         proxyAdminOwnerIsMultisig = stdJson.readBool(_json, "$.proxyAdminOwnerIsMultisig");
 
@@ -283,6 +285,11 @@ contract DeployConfig is Script {
     function setUseCustomGasToken(address _token) public {
         useCustomGasToken = true;
         customGasTokenAddress = _token;
+    }
+
+    /// @notice Allow the `externalSuperchainConfig` config to be overridden in testing environments
+    function setExternalSuperchainConfig(address _externalSuperchainConfig) public {
+        externalSuperchainConfig = _externalSuperchainConfig;
     }
 
     /// @notice Allow the ProxyAdmin owner configs (`finalSystemOwner`, `proxyAdminOwner`, and

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -22,6 +22,7 @@ contract CommonTest is Test, Setup, Events {
     bool useLegacyContracts;
     address customGasToken;
     bool useInteropOverride;
+    address externalSuperchainConfig;
 
     function setUp() public virtual override {
         alice = makeAddr("alice");
@@ -44,6 +45,9 @@ contract CommonTest is Test, Setup, Events {
         }
         if (useInteropOverride) {
             deploy.cfg().setUseInterop(true);
+        }
+        if (externalSuperchainConfig != address(0)) {
+            deploy.cfg().setExternalSuperchainConfig(externalSuperchainConfig);
         }
 
         vm.etch(address(ffi), vm.getDeployedCode("FFIInterface.sol:FFIInterface"));
@@ -149,5 +153,16 @@ contract CommonTest is Test, Setup, Events {
         }
 
         useInteropOverride = true;
+    }
+
+    function enableExternalSuperchainConfig(address _externalSuperchainConfig) public {
+        // Check if the system has already been deployed, based off of the heuristic that alice and bob have not been
+        // set by the `setUp` function yet.
+        if (!(alice == address(0) && bob == address(0))) {
+            revert("CommonTest: Cannot enable interop after deployment. Consider overriding `setUp`.");
+        }
+
+        externalSuperchainConfig = _externalSuperchainConfig;
+        super.withoutSuperchain();
     }
 }

--- a/packages/contracts-bedrock/test/setup/ExternalSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/setup/ExternalSuperchainConfig.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { console } from "forge-std/console.sol";
+
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
+
+// Testing utilities
+import { CommonTest } from "test/setup/CommonTest.sol";
+
+contract ExternalSuperchainConfig_Test is CommonTest {
+    address anAddress;
+
+    function setUp() public override {
+        anAddress = address(new SuperchainConfig());
+        super.enableExternalSuperchainConfig(anAddress);
+        super.setUp();
+    }
+
+    function test_setsSuperchainConfigCorrectly() public {
+        assertEq(address(superchainConfig), anAddress);
+    }
+}
+
+contract ExternalSuperchainConfig_TestFail is CommonTest {
+    function setUp() public override { }
+
+    function test_address0_fails() public {
+        // With the below `expectRevert` uncommented, the test fails with "next call did not revert
+        // as expected", even though, when commented, instead the test fails with the expected error
+        // message.
+        vm.skip(true);
+        super.enableExternalSuperchainConfig(address(0));
+        //vm.expectRevert("Need to provide the external SuperchainConfig address!");
+        super.setUp();
+    }
+}

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -114,6 +114,8 @@ contract Setup {
     IOptimismSuperchainERC20Factory l2OptimismSuperchainERC20Factory =
         IOptimismSuperchainERC20Factory(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
 
+    bool needsSuperchain = true;
+
     /// @dev Deploys the Deploy contract without including its bytecode in the bytecode
     ///      of this contract by fetching the bytecode dynamically using `vm.getCode()`.
     ///      If the Deploy bytecode is included in this contract, then it will double
@@ -143,7 +145,7 @@ contract Setup {
             hex"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
         );
 
-        deploy.run();
+        deploy.run(needsSuperchain);
         console.log("Setup: completed L1 deployment, registering addresses now");
 
         optimismPortal = IOptimismPortal(deploy.mustGetAddress("OptimismPortalProxy"));
@@ -268,5 +270,9 @@ contract Setup {
 
     function labelPreinstall(address _addr) internal {
         vm.label(_addr, Preinstalls.getName(_addr));
+    }
+
+    function withoutSuperchain() internal {
+        needsSuperchain = false;
     }
 }


### PR DESCRIPTION
* Adds a new deploy config field, `externalSuperchainConfig`, which should be the address pointing to the official OP SuperchainConfig contract. This will be used in CeloSuperchainConfig to pause the Celo system whenever Superchain pauses.
* Modifies the `runCelo` entrypoint of Deploy.s.sol to run with `needsSuperchain = false`, i.e. without deploying a fresh SuperchainConfig contract.
* With `needsSuperchain = false`, now the deploy script:
  * As described above, sources the SuperchainConfig address from the new config field.
  * Still deploys a ProtocolVersions contract.

### Testing

Added two unit tests to test the new config field. For some reason, the failing path required a `vm.skip`. `vm.expectRevert` appeared to short-circuit, failing with "next call did not revert as expected", even though the call *does* revert as expected when `vm.expectRevert` is not used.