### PR TITLE
Fix token name

### DIFF
--- a/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
 contract CeloTokenL1 is ERC20Upgradeable {
-    string constant NAME = "Celo native asset";
+    string constant NAME = "Celo";
     string constant SYMBOL = "CELO";
     uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 

--- a/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
+++ b/packages/contracts-bedrock/src/celo/CeloTokenL1Permit.sol
@@ -5,7 +5,7 @@ import { ERC20Permit } from "@openzeppelin/contracts-v5/token/ERC20/extensions/E
 import { ERC20 } from "@openzeppelin/contracts-v5/token/ERC20/ERC20.sol";
 
 contract CeloTokenL1Permit is ERC20Permit {
-    string constant NAME = "Celo native asset";
+    string constant NAME = "Celo";
     string constant SYMBOL = "CELO";
     uint256 constant TOTAL_MARKET_CAP = 1000000000e18; // 1 billion CELO
 


### PR DESCRIPTION
Marketing suggested this new name. If we're redeploying then we should use this one, otherwise we should update on the next upgrade.