### PR TITLE
migration script: Add tests and fix edge case

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -60,6 +60,9 @@ func AwaitEpoch(chainID uint64, epoch uint64) {
 // for a finalized L1 block that is up to maxSequencerDrift before the L2 fork
 // block.
 func (c *BeaconClient) findL1StartingBlock(chainID uint64, unixTime uint64, epochIncrement int64) (common.Hash, error) {
+	if epochIncrement == 0 {
+		return common.Hash{}, fmt.Errorf("epoch increment must be non-zero")
+	}
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
 

--- a/op-chain-ops/cmd/celo-migrate/beacon.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon.go
@@ -63,13 +63,28 @@ func (c *BeaconClient) findL1StartingBlock(chainID uint64, unixTime uint64, epoc
 	var l1StartBlockHash common.Hash
 	var l1StartBlockTime uint64
 
-	epoch := int64(ContainingEpoch(chainID, unixTime))
+	containingEpoch := int64(ContainingEpoch(chainID, unixTime))
 	log.Info(fmt.Sprintf(
 		"Searching for finalized block at time %d, chain (%d) beacon genesis time %d, containing epoch %d, epoch start time %d",
-		unixTime, chainID, beaconChainGenesisTimesSeconds[chainID], epoch, EpochStartTime(chainID, uint64(epoch))))
+		unixTime, chainID, beaconChainGenesisTimesSeconds[chainID], containingEpoch, EpochStartTime(chainID, uint64(containingEpoch))))
 
-	for ; ; epoch += epochIncrement {
+	for epoch := containingEpoch; ; epoch += epochIncrement {
 		log.Info(fmt.Sprintf("Checking epoch %d", epoch))
+		if epochIncrement < 0 && !withinMaxSequencerDrift(EpochStartTime(chainID, uint64(epoch)), unixTime) {
+			// We've gone too far back and not found a suitable block, so break.
+			log.Info(fmt.Sprintf(
+				"Searched too far back, epoch %d with start time %d more than maxSequencerDrift before %d",
+				epoch, EpochStartTime(chainID, uint64(epoch)), unixTime,
+			))
+			break
+		} else if epochIncrement > 0 && epoch > containingEpoch+3 {
+			// We've looked too far forward we will never find a finalized block
+			log.Info(fmt.Sprintf(
+				"Searched too far forward, epoch %d could not finalize a block in epoch %d or earlier",
+				epoch, containingEpoch,
+			))
+			break
+		}
 		AwaitEpoch(chainID, uint64(epoch))
 		slot := FirstSlotOfEpoch(uint64(epoch))
 		finalityCheckpoints, err := c.FindFinalityCheckpointsForSlot(slot, 10)

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -2,18 +2,17 @@ package main
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFinalizedL1BlockSelection(t *testing.T) {
-
+	// Uncomment to see log output during tests
+	// log.SetDefault(log.NewLogger(log.NewTerminalHandler(os.Stdout, false)))
 	t.Run("DefaultTest", func(t *testing.T) {
 		bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
 		var chainID uint64 = Mainnet
@@ -61,7 +60,6 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		// celo l1 migraiton block 30819350
 		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
 		// Timestamp targetted by the migration script for l2 block start 1741771353  (last block of celo l1 + one minute)
-		log.SetDefault(log.NewLogger(log.NewTerminalHandler(os.Stdout, false)))
 		bc := NewBeaconClient("https://ethereum-holesky-beacon-api.publicnode.com")
 		var targetTime uint64 = 1741771353
 		var expectedSlot uint64 = 3822400
@@ -76,7 +74,6 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		// celo l1 migraiton block 30824250
 		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
 		// Timestamp targetted by the migration script for l2 block start 1741795853 (last block of celo l1 + one minute)
-		log.SetDefault(log.NewLogger(log.NewTerminalHandler(os.Stdout, false)))
 		bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
 		var targetTime uint64 = 1741795853
 		var expectedSlot uint64 = 11247584
@@ -84,8 +81,6 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		checkFinalizedL1BlockSelection(t, bc, Mainnet, targetTime, expectedSlot, expectedL1BlockHash)
 
 	})
-
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 }
 
 func checkFinalizedL1BlockSelection(t *testing.T, bc *BeaconClient, chainID, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -2,59 +2,96 @@ package main
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFinalizedL1BlockSelection(t *testing.T) {
-	bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
-	var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
-	var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
-	expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")
 
-	// We expect the same block to be chosen regardless of which slot in an
-	// epoch the target time falls in. The only thing that would change the
-	// chosen block would be if the target time fell in a different epoch.
+	t.Run("DefaultTest", func(t *testing.T) {
+		bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
+		var chainID uint64 = Mainnet
+		var targetTime uint64 = 1740759647 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
+		// var targetTime uint64 = 1741771358 // this is the timestamp of slot 11161302 https://beaconcha.in/slot/11161302
+		var expectedSlot uint64 = 11161216 // this is the beginning slot of the epoch 2 before https://beaconcha.in/slot/11161216
+		expectedL1BlockHash := common.HexToHash("0x6c71e110fc83faa393017681ab97b26621cda68d12e31d24917e210d169d7be5")
+		t.Run("MidEpochSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, targetTime, expectedSlot, expectedL1BlockHash)
+		})
 
-	t.Run("MidEpochSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, targetTime, expectedSlot, expectedL1BlockHash)
+		t.Run("MidEpochMidSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, targetTime+beaconChainSlotDurationSeconds/2, expectedSlot, expectedL1BlockHash)
+		})
+
+		epochFirstSlotTime := EpochStartTime(chainID, ContainingEpoch(chainID, targetTime))
+		t.Run("StartEpochSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, epochFirstSlotTime, expectedSlot, expectedL1BlockHash)
+		})
+
+		epochLastSlotTime := epochFirstSlotTime + beaconChainSlotDurationSeconds*(beaconSlotsPerEpoch-1)
+		t.Run("EndEpochSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, epochLastSlotTime, expectedSlot, expectedL1BlockHash)
+		})
+
+		// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161184
+		expectedL1BlockHashPrevEpoch := common.HexToHash("0xca6237f41190e1adfa52ba20fadb03ef14a7f57c516806edf7660f301b08de36")
+		t.Run("PriorEpochEndSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, epochFirstSlotTime-1, expectedSlot-beaconSlotsPerEpoch, expectedL1BlockHashPrevEpoch)
+		})
+
+		// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161248
+		expectedL1BlockHashNextEpoch := common.HexToHash("0x7892cbc14d57ab7036a722306bcae1fc07a202fc5907a227cce539b5f1ca41b3")
+		t.Run("NextEpochStartSlot", func(t *testing.T) {
+			checkFinalizedL1BlockSelection(t, bc, chainID, epochLastSlotTime+beaconChainSlotDurationSeconds, expectedSlot+beaconSlotsPerEpoch, expectedL1BlockHashNextEpoch)
+		})
 	})
 
-	t.Run("MidEpochMidSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, targetTime+beaconChainSlotDurationSeconds/2, expectedSlot, expectedL1BlockHash)
+	// This test seeks to recreate the conditions of our first celo mainnet
+	// migration dry run using holesky as the L1, in the end we chose not to use
+	// holesky, and also this test does not work because the holesky beacon rpc
+	// api does not support queries for old finality_checkpoints.
+	t.Run("CeloMainnetDryRun1Holesky", func(t *testing.T) {
+		t.Skip("Holesky public node does not support old historical queries for finality_checkpoints, so this test does not work any more")
+		// celo l1 migraiton block 30819350
+		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
+		// Timestamp targetted by the migration script for l2 block start 1741771353  (last block of celo l1 + one minute)
+		log.SetDefault(log.NewLogger(log.NewTerminalHandler(os.Stdout, false)))
+		bc := NewBeaconClient("https://ethereum-holesky-beacon-api.publicnode.com")
+		var targetTime uint64 = 1741771353
+		var expectedSlot uint64 = 3822400
+		var expectedL1BlockHash common.Hash = common.HexToHash("0xd85604da94ed6263239dc6e48bbc508c69445f084a8d2bde2e4de6c536876b61")
+		checkFinalizedL1BlockSelection(t, bc, Holesky, targetTime, expectedSlot, expectedL1BlockHash)
+
 	})
 
-	epochFirstSlotTime := EpochStartTime(Mainnet, ContainingEpoch(Mainnet, targetTime))
-	t.Run("StartEpochSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime, expectedSlot, expectedL1BlockHash)
+	// This test seeks to recreate the conditions of our first celo mainnet
+	// migration dry run using ethereum mainnet as the L1.
+	t.Run("CeloMainnetDryRun1Mainnet", func(t *testing.T) {
+		// celo l1 migraiton block 30824250
+		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
+		// Timestamp targetted by the migration script for l2 block start 1741795853 (last block of celo l1 + one minute)
+		log.SetDefault(log.NewLogger(log.NewTerminalHandler(os.Stdout, false)))
+		bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
+		var targetTime uint64 = 1741795853
+		var expectedSlot uint64 = 11247584
+		var expectedL1BlockHash common.Hash = common.HexToHash("0x4e2105c9e9d948efd49e611cbd6cfaee2053af2df20ed5c51880a6c310d0a360")
+		checkFinalizedL1BlockSelection(t, bc, Mainnet, targetTime, expectedSlot, expectedL1BlockHash)
+
 	})
 
-	epochLastSlotTime := epochFirstSlotTime + beaconChainSlotDurationSeconds*(beaconSlotsPerEpoch-1)
-	t.Run("EndEpochSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, epochLastSlotTime, expectedSlot, expectedL1BlockHash)
-	})
-
-	// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161184
-	expectedL1BlockHashPrevEpoch := common.HexToHash("0xca6237f41190e1adfa52ba20fadb03ef14a7f57c516806edf7660f301b08de36")
-	t.Run("PriorEpochEndSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, epochFirstSlotTime-1, expectedSlot-beaconSlotsPerEpoch, expectedL1BlockHashPrevEpoch)
-	})
-
-	// Execution payload block hash retrieved here - https://beaconcha.in/slot/11161248
-	expectedL1BlockHashNextEpoch := common.HexToHash("0x7892cbc14d57ab7036a722306bcae1fc07a202fc5907a227cce539b5f1ca41b3")
-	t.Run("NextEpochStartSlot", func(t *testing.T) {
-		checkFinalizedL1BlockSelection(t, bc, epochLastSlotTime+beaconChainSlotDurationSeconds, expectedSlot+beaconSlotsPerEpoch, expectedL1BlockHashNextEpoch)
-	})
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 }
 
-func checkFinalizedL1BlockSelection(t *testing.T, bc *BeaconClient, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+func checkFinalizedL1BlockSelection(t *testing.T, bc *BeaconClient, chainID, targetTime, expectedSlot uint64, expectedBlockHash common.Hash) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Second)
 	t.Cleanup(cancel)
-	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(Mainnet, targetTime)
+	calculatedHash, err := bc.MostRecentFinalizedBlockAtTime(chainID, targetTime)
 	require.NoError(t, err)
 	assert.Equal(t, expectedBlockHash, calculatedHash)
 	// Double check that we are targeting the correct slot

--- a/op-chain-ops/cmd/celo-migrate/beacon_test.go
+++ b/op-chain-ops/cmd/celo-migrate/beacon_test.go
@@ -59,7 +59,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 		t.Skip("Holesky public node does not support old historical queries for finality_checkpoints, so this test does not work any more")
 		// celo l1 migraiton block 30819350
 		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
-		// Timestamp targetted by the migration script for l2 block start 1741771353  (last block of celo l1 + one minute)
+		// Timestamp targeted by the migration script for l2 block start 1741771353  (last block of celo l1 + one minute)
 		bc := NewBeaconClient("https://ethereum-holesky-beacon-api.publicnode.com")
 		var targetTime uint64 = 1741771353
 		var expectedSlot uint64 = 3822400
@@ -73,7 +73,7 @@ func TestFinalizedL1BlockSelection(t *testing.T) {
 	t.Run("CeloMainnetDryRun1Mainnet", func(t *testing.T) {
 		// celo l1 migraiton block 30824250
 		// Timestamp for the last block of the l1 (one prior to the migration block) 1741771293
-		// Timestamp targetted by the migration script for l2 block start 1741795853 (last block of celo l1 + one minute)
+		// Timestamp targeted by the migration script for l2 block start 1741795853 (last block of celo l1 + one minute)
 		bc := NewBeaconClient("https://ethereum-beacon-api.publicnode.com")
 		var targetTime uint64 = 1741795853
 		var expectedSlot uint64 = 11247584


### PR DESCRIPTION
The search for an L1 starting block could get stuck if no finality checkpoints could be found, which happens when using the publicnode beacon rpc url since it only serves recent finality checkpoints.

Added an extra check to bound the search for an l1Starting block.

Also adds a test that recreates the results from our dry run yesterday.