### PR TITLE
Lower default batch size in migration script

### DIFF
--- a/op-chain-ops/cmd/celo-migrate/main.go
+++ b/op-chain-ops/cmd/celo-migrate/main.go
@@ -82,7 +82,7 @@ var (
 	batchSizeFlag = &cli.Uint64Flag{
 		Name:  "batch-size",
 		Usage: "Batch size to use for block migration, larger batch sizes can speed up migration but require more memory. If increasing the batch size consider also increasing the memory-limit",
-		Value: 50000,
+		Value: 5000,
 	}
 	bufferSizeFlag = &cli.Uint64Flag{
 		Name:  "buffer-size",


### PR DESCRIPTION
The previous default batch size of 50k worked well for alfajores and baklava, but for mainnet blocks it is probably too big. We have a default soft memory limit of 7500 MiB, and a recommended RAM of 16GB listed in our docs. For the testnet migrations and dry-runs, we've been using flags to set --batchSize=20000 and --memoryLimit=20000, which seems to be working well on a machine with 32GB of RAM. In any case, it seem that 50k batchSize is probably far too large to be optimal for mainnet blocks, especially with a lower default memory limit and recommended RAM. 

Open to other suggestions on how we should set these values and also the recommended RAM in the docs. Just want to get the conversation started.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/469