### PR TITLE
Add Prometheus metrics for AltDA failover in Batcher

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -66,6 +66,7 @@ func (c *channel) TxFailed(id string, failoverToEthDA bool) {
 		// TODO: figure out how to switch to blobs/auto instead. Might need to make
 		// batcherService.initChannelConfig function stateless so that we can reuse it.
 		c.cfg.DaType = DaTypeCalldata
+		c.metr.RecordFailoverToEthDA()
 	}
 	c.metr.RecordBatchTxFailed()
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -47,6 +47,7 @@ type txRef struct {
 	id       txID
 	isCancel bool
 	isBlob   bool
+	daType   DaType
 }
 
 func (r txRef) String() string {
@@ -863,7 +864,6 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 		}
 		// if Alt DA is enabled we post the txdata to the DA Provider and replace it with the commitment.
 		l.publishToAltDAAndL1(txdata, queue, receiptsCh, daGroup)
-		l.Metr.RecordBatchDaType(txdata.daType.Name())
 		// we return nil to allow publishStateToL1 to keep processing the next txdata
 		return nil
 	case DaTypeBlob:
@@ -885,7 +885,6 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 	}
 
 	l.sendTx(txdata, false, candidate, queue, receiptsCh)
-	l.Metr.RecordBatchDaType(txdata.daType.Name())
 	return nil
 }
 
@@ -912,7 +911,7 @@ func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.T
 		candidate.GasLimit = floorDataGas
 	}
 
-	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob}, *candidate, receiptsCh)
+	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob, daType: txdata.daType}, *candidate, receiptsCh)
 }
 
 // Copypaste from upstream geth
@@ -965,8 +964,8 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 		l.recordFailedTx(r.ID.id, r.Err)
 	} else if r.Receipt != nil {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
+		l.Metr.RecordBatchDaType(r.ID.daType.Name())
 	}
-	// Both r.Err and r.Receipt can be nil, in which case we do nothing.
 }
 
 func (l *BatchSubmitter) recordFailedDARequest(id txID, err error) {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -48,6 +48,7 @@ type txRef struct {
 	isCancel bool
 	isBlob   bool
 	daType   DaType
+	size     int
 }
 
 func (r txRef) String() string {
@@ -839,6 +840,7 @@ func (l *BatchSubmitter) publishToAltDAAndL1(txdata txData, queue *txmgr.Queue[t
 			return nil
 		}
 		l.Log.Info("Set altda input", "commitment", comm, "tx", txdata.ID())
+		l.Metr.RecordBatchDataSizeBytes(DaTypeAltDA.Name(), len(txdata.CallData()))
 		candidate := l.calldataTxCandidate(comm.TxData())
 		l.sendTx(txdata, false, candidate, queue, receiptsCh)
 		return nil
@@ -911,7 +913,7 @@ func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.T
 		candidate.GasLimit = floorDataGas
 	}
 
-	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob, daType: txdata.daType}, *candidate, receiptsCh)
+	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob, daType: txdata.daType, size: txdata.Len()}, *candidate, receiptsCh)
 }
 
 // Copypaste from upstream geth
@@ -965,6 +967,9 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 	} else if r.Receipt != nil {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
 		l.Metr.RecordBatchDaType(r.ID.daType.Name())
+		if r.ID.daType != DaTypeAltDA {
+			l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
+		}
 	}
 	// Both r.Err and r.Receipt can be nil, in which case we do nothing.
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -966,6 +966,7 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
 		l.Metr.RecordBatchDaType(r.ID.daType.Name())
 	}
+	// Both r.Err and r.Receipt can be nil, in which case we do nothing.
 }
 
 func (l *BatchSubmitter) recordFailedDARequest(id txID, err error) {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -840,7 +840,7 @@ func (l *BatchSubmitter) publishToAltDAAndL1(txdata txData, queue *txmgr.Queue[t
 			return nil
 		}
 		l.Log.Info("Set altda input", "commitment", comm, "tx", txdata.ID())
-		l.Metr.RecordBatchDataSizeBytes(DaTypeAltDA.Name(), len(txdata.CallData()))
+		l.Metr.RecordBatchDataSizeBytes(DaTypeAltDA.Name(), txdata.Len())
 		candidate := l.calldataTxCandidate(comm.TxData())
 		l.sendTx(txdata, false, candidate, queue, receiptsCh)
 		return nil

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -966,9 +966,12 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 		l.recordFailedTx(r.ID.id, r.Err)
 	} else if r.Receipt != nil {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
-		l.Metr.RecordBatchDaType(r.ID.daType.Name())
-		if r.ID.daType != DaTypeAltDA {
-			l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
+
+		if !r.ID.isCancel {
+			l.Metr.RecordBatchDaType(r.ID.daType.Name())
+			if r.ID.daType != DaTypeAltDA {
+				l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
+			}
 		}
 	}
 	// Both r.Err and r.Receipt can be nil, in which case we do nothing.

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -840,7 +840,6 @@ func (l *BatchSubmitter) publishToAltDAAndL1(txdata txData, queue *txmgr.Queue[t
 			return nil
 		}
 		l.Log.Info("Set altda input", "commitment", comm, "tx", txdata.ID())
-		l.Metr.RecordBatchDataSizeBytes(DaTypeAltDA.Name(), txdata.Len())
 		candidate := l.calldataTxCandidate(comm.TxData())
 		l.sendTx(txdata, false, candidate, queue, receiptsCh)
 		return nil
@@ -966,12 +965,9 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 		l.recordFailedTx(r.ID.id, r.Err)
 	} else if r.Receipt != nil {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
-
 		if !r.ID.isCancel {
 			l.Metr.RecordBatchDaType(r.ID.daType.Name())
-			if r.ID.daType != DaTypeAltDA {
-				l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
-			}
+			l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
 		}
 	}
 	// Both r.Err and r.Receipt can be nil, in which case we do nothing.

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -863,6 +863,7 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 		}
 		// if Alt DA is enabled we post the txdata to the DA Provider and replace it with the commitment.
 		l.publishToAltDAAndL1(txdata, queue, receiptsCh, daGroup)
+		l.Metr.RecordBatchDaType(txdata.daType.Name())
 		// we return nil to allow publishStateToL1 to keep processing the next txdata
 		return nil
 	case DaTypeBlob:
@@ -884,6 +885,7 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 	}
 
 	l.sendTx(txdata, false, candidate, queue, receiptsCh)
+	l.Metr.RecordBatchDaType(txdata.daType.Name())
 	return nil
 }
 

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -21,6 +21,19 @@ const (
 	DaTypeAltDA
 )
 
+func (t DaType) Name() string {
+	switch t {
+	case DaTypeCalldata:
+		return "calldata"
+	case DaTypeBlob:
+		return "blob"
+	case DaTypeAltDA:
+		return "altda"
+	default:
+		return "unknown"
+	}
+}
+
 // txData represents the data for a single transaction.
 //
 // Note: The batcher currently sends exactly one frame per transaction. This

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -209,21 +209,21 @@ func NewMetrics(procName string) *Metrics {
 		batchSentDATypeTotal: *factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      "batch_sent_da_type_total",
-			Help:      "Total number of batches sent, categorized by DA type",
+			Help:      "Total number of batches successfully stored, categorized by DA type.",
 		},
 			[]string{"da_type"},
 		),
 		batchStoredDataSizeBytesTotal: *factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      "batch_stored_data_size_bytes_total",
-			Help:      "Total data size stored in each DA type (in bytes)",
+			Help:      "Total batch size stored in each DA type (in bytes).",
 		},
 			[]string{"da_type"},
 		),
 		altDaFailoverTotal: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      "alt_da_failover_total",
-			Help:      "Total number of batches that failed to send to AltDA and were instead sent to L1",
+			Help:      "Total number of batches that could not be stored in AltDA and were sent to L1 instead",
 		}),
 		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -213,11 +213,11 @@ func NewMetrics(procName string) *Metrics {
 		},
 			[]string{"da_type"},
 		),
-		batchStoredDataSizeBytesTotal: *factory.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "batch_stored_data_size_bytes_total",
-				Help: "Total data size stored in each DA type (in bytes)",
-			},
+		batchStoredDataSizeBytesTotal: *factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "batch_stored_data_size_bytes_total",
+			Help:      "Total data size stored in each DA type (in bytes)",
+		},
 			[]string{"da_type"},
 		),
 		altDaFailoverTotal: factory.NewCounter(prometheus.CounterOpts{

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -50,6 +50,9 @@ type Metricer interface {
 
 	RecordBlobUsedBytes(num int)
 
+	RecordBatchDaType(daType string)
+	RecordFailoverToEthDA()
+
 	Document() []opmetrics.DocumentedMetric
 
 	PendingDABytes() float64
@@ -88,6 +91,9 @@ type Metrics struct {
 	channelInputBytesTotal  prometheus.Counter
 	channelOutputBytesTotal prometheus.Counter
 	channelQueueLength      prometheus.Gauge
+
+	batchSentDATypeTotal prometheus.CounterVec
+	altDaFailoverTotal   prometheus.Counter
 
 	batcherTxEvs opmetrics.EventVec
 
@@ -197,6 +203,18 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "channel_queue_length",
 			Help:      "The number of channels currently in memory.",
+		}),
+		batchSentDATypeTotal: *factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "batch_sent_da_type_total",
+			Help:      "Total number of batches sent, categorized by DA type",
+		},
+			[]string{"da_type"},
+		),
+		altDaFailoverTotal: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "alt_da_failover_total",
+			Help:      "Total number of batches that failed to send to AltDA and were instead sent to L1",
 		}),
 		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,
@@ -343,6 +361,14 @@ func (m *Metrics) RecordBatchTxFailed() {
 
 func (m *Metrics) RecordBlobUsedBytes(num int) {
 	m.blobUsedBytes.Observe(float64(num))
+}
+
+func (m *Metrics) RecordBatchDaType(daType string) {
+	m.batchSentDATypeTotal.With(prometheus.Labels{"da_type": daType}).Inc()
+}
+
+func (m *Metrics) RecordFailoverToEthDA() {
+	m.altDaFailoverTotal.Inc()
 }
 
 func (m *Metrics) RecordChannelQueueLength(len int) {

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -51,6 +51,7 @@ type Metricer interface {
 	RecordBlobUsedBytes(num int)
 
 	RecordBatchDaType(daType string)
+	RecordBatchDataSizeBytes(daType string, size int)
 	RecordFailoverToEthDA()
 
 	Document() []opmetrics.DocumentedMetric
@@ -92,8 +93,9 @@ type Metrics struct {
 	channelOutputBytesTotal prometheus.Counter
 	channelQueueLength      prometheus.Gauge
 
-	batchSentDATypeTotal prometheus.CounterVec
-	altDaFailoverTotal   prometheus.Counter
+	batchSentDATypeTotal          prometheus.CounterVec
+	batchStoredDataSizeBytesTotal prometheus.CounterVec
+	altDaFailoverTotal            prometheus.Counter
 
 	batcherTxEvs opmetrics.EventVec
 
@@ -209,6 +211,13 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "batch_sent_da_type_total",
 			Help:      "Total number of batches sent, categorized by DA type",
 		},
+			[]string{"da_type"},
+		),
+		batchStoredDataSizeBytesTotal: *factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "batch_stored_data_size_bytes_total",
+				Help: "Total data size stored in each DA type (in bytes)",
+			},
 			[]string{"da_type"},
 		),
 		altDaFailoverTotal: factory.NewCounter(prometheus.CounterOpts{
@@ -365,6 +374,10 @@ func (m *Metrics) RecordBlobUsedBytes(num int) {
 
 func (m *Metrics) RecordBatchDaType(daType string) {
 	m.batchSentDATypeTotal.With(prometheus.Labels{"da_type": daType}).Inc()
+}
+
+func (m *Metrics) RecordBatchDataSizeBytes(daType string, size int) {
+	m.batchStoredDataSizeBytesTotal.WithLabelValues(daType).Add(float64(size))
 }
 
 func (m *Metrics) RecordFailoverToEthDA() {

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -46,8 +46,9 @@ func (*noopMetrics) RecordBatchTxSuccess()   {}
 func (*noopMetrics) RecordBatchTxFailed()    {}
 func (*noopMetrics) RecordBlobUsedBytes(int) {}
 
-func (*noopMetrics) RecordBatchDaType(string) {}
-func (*noopMetrics) RecordFailoverToEthDA()   {}
+func (*noopMetrics) RecordBatchDaType(string)             {}
+func (*noopMetrics) RecordBatchDataSizeBytes(string, int) {}
+func (*noopMetrics) RecordFailoverToEthDA()               {}
 
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -45,6 +45,10 @@ func (*noopMetrics) RecordBatchTxSubmitted() {}
 func (*noopMetrics) RecordBatchTxSuccess()   {}
 func (*noopMetrics) RecordBatchTxFailed()    {}
 func (*noopMetrics) RecordBlobUsedBytes(int) {}
+
+func (*noopMetrics) RecordBatchDaType(string) {}
+func (*noopMetrics) RecordFailoverToEthDA()   {}
+
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }


### PR DESCRIPTION
Closes https://github.com/celo-org/optimism/issues/321

Add the following types of metrics for AltDA failover feature
- Total count of failover occurrences
- Total number of batches posted for each DA type