### PR TITLE
Add optional Celo fields for strict deploy-config parsing

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -919,7 +919,8 @@ type DeployConfig struct {
 	LegacyDeployConfig `evm:"-"`
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
-	DeployCeloContracts       bool            `json:"deployCeloContracts"`
+	DeployCeloContracts bool `json:"deployCeloContracts"`
+	// Unused, added to make strict config parsing possible
 	ProxyAdminOwnerIsMultiSig *bool           `json:"proxyAdminOwnerIsMultisig,omitempty"`
 	ExternalSuperchainConfig  *common.Address `json:"externalSuperchainConfig,omitempty"`
 }

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -919,7 +919,9 @@ type DeployConfig struct {
 	LegacyDeployConfig `evm:"-"`
 
 	// DeployCeloContracts indicates whether to deploy Celo contracts.
-	DeployCeloContracts bool `json:"deployCeloContracts"`
+	DeployCeloContracts       bool            `json:"deployCeloContracts"`
+	ProxyAdminOwnerIsMultiSig *bool           `json:"proxyAdminOwnerIsMultisig,omitempty"`
+	ExternalSuperchainConfig  *common.Address `json:"externalSuperchainConfig,omitempty"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy


### PR DESCRIPTION
This fixes the error we got during the dry-run, where our two added deploy-config fields 
caused the strict json parsing of the `DeployConfig` to fail, because the fields where not defined in the struct.

The fields are not used currently in our go-code, so they are mainly added to make the strict parsing pass.