### PR TITLE
Initialize L1 Safe and Finalized head in SyncStatus at OpNode startup

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -568,6 +568,31 @@ func (n *OpNode) Start(ctx context.Context) error {
 		return err
 	}
 	log.Info("Rollup node started")
+
+	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer cannot retrieve non-finalized L1 blocks.
+	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (13 minutes),
+	// but immediately after startup, these values are not yet available.
+	// In some cases, this can cause the sequencer to get stuck.
+	// To prevent this, here is to fetch and initialize the latest safe and finalized L1 block references at startup
+	reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
+	defer reqCancel()
+
+	safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
+	if err != nil {
+		return fmt.Errorf("failed to fetch L1 safe head: %w", err)
+	}
+	if safeRef != (eth.L1BlockRef{}) {
+		n.OnNewL1Safe(reqCtx, safeRef)
+	}
+
+	finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
+	if err != nil {
+		return fmt.Errorf("failed to fetch L1 finalized head: %w", err)
+	}
+	if finalizedRef != (eth.L1BlockRef{}) {
+		n.OnNewL1Finalized(reqCtx, finalizedRef)
+	}
+
 	return nil
 }
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -555,6 +555,30 @@ func (n *OpNode) initP2PSigner(ctx context.Context, cfg *Config) (err error) {
 }
 
 func (n *OpNode) Start(ctx context.Context) error {
+	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer does not use non-finalized L1 blocks as L1 origin
+	// The OpNode periodically fetches the latest safe and finalized L1 block heights (1 epoch ≒ 6.4 minutes by default),
+	// but these values are not available immediately after startup until the first polling occurs.
+	// In some cases, this can cause the sequencer to get stuck because it fails to retrieve the next L1 block.
+	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup.
+	if n.cfg.Driver.SequencerUseFinalized {
+		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
+		defer reqCancel()
+
+		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
+		if err != nil {
+			log.Warn("failed to fetch L1 block", "label", eth.Finalized, "err", err)
+		} else if finalizedRef != (eth.L1BlockRef{}) {
+			n.OnNewL1Finalized(reqCtx, finalizedRef)
+		}
+
+		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
+		if err != nil {
+			log.Warn("failed to fetch L1 block", "label", eth.Safe, "err", err)
+		} else if safeRef != (eth.L1BlockRef{}) {
+			n.OnNewL1Safe(reqCtx, safeRef)
+		}
+	}
+
 	if n.interopSys != nil {
 		if err := n.interopSys.Start(ctx); err != nil {
 			n.log.Error("Could not start interop sub system", "err", err)
@@ -568,32 +592,6 @@ func (n *OpNode) Start(ctx context.Context) error {
 		return err
 	}
 	log.Info("Rollup node started")
-
-	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer does not use non-finalized L1 blocks as L1 origin
-	// The OpNode periodically fetches the latest safe and finalized L1 block heights (1 epoch ≒ 6.4 minutes by default),
-	// but these values are not available immediately after startup until the first polling occurs.
-	// In some cases, this can cause the sequencer to get stuck because it fails to retrieve the next L1 block.
-	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup.
-	if n.cfg.Driver.SequencerUseFinalized {
-		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
-		defer reqCancel()
-
-		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
-		if err != nil {
-			log.Warn("failed to fetch L1 block", "label", eth.Finalized, "err", err)
-		}
-		if finalizedRef != (eth.L1BlockRef{}) {
-			n.OnNewL1Finalized(reqCtx, finalizedRef)
-		}
-
-		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
-		if err != nil {
-			log.Warn("failed to fetch L1 block", "label", eth.Safe, "err", err)
-		}
-		if safeRef != (eth.L1BlockRef{}) {
-			n.OnNewL1Safe(reqCtx, safeRef)
-		}
-	}
 
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -572,8 +572,8 @@ func (n *OpNode) Start(ctx context.Context) error {
 	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer cannot retrieve non-finalized L1 blocks.
 	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (13 minutes),
 	// but immediately after startup, these values are not yet available.
-	// In some cases, this can cause the sequencer to get stuck when n.cfg.Driver.SequencerUseFinalized is true
-	// To prevent this, here is to fetch and initialize the latest safe and finalized L1 block references at startup
+	// In some cases, this can cause the sequencer to get stuck because sequencer fails to retrieve next L1 block
+	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup
 	if n.cfg.Driver.SequencerUseFinalized {
 		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
 		defer reqCancel()

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -580,7 +580,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 
 		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
 		if err != nil {
-			log.Warn("failed to poll L1 block", "label", eth.Safe, "err", err)
+			log.Warn("failed to fetch L1 block", "label", eth.Safe, "err", err)
 		}
 		if safeRef != (eth.L1BlockRef{}) {
 			n.OnNewL1Safe(reqCtx, safeRef)
@@ -588,7 +588,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 
 		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
 		if err != nil {
-			log.Warn("failed to poll L1 block", "label", eth.Finalized, "err", err)
+			log.Warn("failed to fetch L1 block", "label", eth.Finalized, "err", err)
 		}
 		if finalizedRef != (eth.L1BlockRef{}) {
 			n.OnNewL1Finalized(reqCtx, finalizedRef)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -570,7 +570,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 	log.Info("Rollup node started")
 
 	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer cannot retrieve non-finalized L1 blocks.
-	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (13 minutes),
+	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (6.4 minutes),
 	// but immediately after startup, these values are not yet available.
 	// In some cases, this can cause the sequencer to get stuck because sequencer fails to retrieve next L1 block
 	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -578,20 +578,20 @@ func (n *OpNode) Start(ctx context.Context) error {
 		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
 		defer reqCancel()
 
-		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
-		if err != nil {
-			log.Warn("failed to fetch L1 block", "label", eth.Safe, "err", err)
-		}
-		if safeRef != (eth.L1BlockRef{}) {
-			n.OnNewL1Safe(reqCtx, safeRef)
-		}
-
 		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
 		if err != nil {
 			log.Warn("failed to fetch L1 block", "label", eth.Finalized, "err", err)
 		}
 		if finalizedRef != (eth.L1BlockRef{}) {
 			n.OnNewL1Finalized(reqCtx, finalizedRef)
+		}
+
+		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
+		if err != nil {
+			log.Warn("failed to fetch L1 block", "label", eth.Safe, "err", err)
+		}
+		if safeRef != (eth.L1BlockRef{}) {
+			n.OnNewL1Safe(reqCtx, safeRef)
 		}
 	}
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -569,11 +569,11 @@ func (n *OpNode) Start(ctx context.Context) error {
 	}
 	log.Info("Rollup node started")
 
-	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer cannot retrieve non-finalized L1 blocks.
-	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (6.4 minutes),
-	// but immediately after startup, these values are not yet available.
-	// In some cases, this can cause the sequencer to get stuck because sequencer fails to retrieve next L1 block
-	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup
+	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer does not fetch non-finalized L1 blocks.
+	// The OpNode periodically fetches the latest safe and finalized L1 block heights (1 epoch ≒ 6.4 minutes by default),
+	// but these values are not available immediately after startup until the first polling occurs.
+	// In some cases, this can cause the sequencer to get stuck because it fails to retrieve the next L1 block.
+	// To prevent this, fetch and initialize the latest safe and finalized L1 block references at startup.
 	if n.cfg.Driver.SequencerUseFinalized {
 		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
 		defer reqCancel()

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -569,7 +569,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 	}
 	log.Info("Rollup node started")
 
-	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer does not fetch non-finalized L1 blocks.
+	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer does not use non-finalized L1 blocks as L1 origin
 	// The OpNode periodically fetches the latest safe and finalized L1 block heights (1 epoch ≒ 6.4 minutes by default),
 	// but these values are not available immediately after startup until the first polling occurs.
 	// In some cases, this can cause the sequencer to get stuck because it fails to retrieve the next L1 block.
@@ -580,7 +580,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 
 		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
 		if err != nil {
-			return fmt.Errorf("failed to fetch L1 safe head: %w", err)
+			log.Warn("failed to poll L1 block", "label", eth.Safe, "err", err)
 		}
 		if safeRef != (eth.L1BlockRef{}) {
 			n.OnNewL1Safe(reqCtx, safeRef)
@@ -588,7 +588,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 
 		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
 		if err != nil {
-			return fmt.Errorf("failed to fetch L1 finalized head: %w", err)
+			log.Warn("failed to poll L1 block", "label", eth.Finalized, "err", err)
 		}
 		if finalizedRef != (eth.L1BlockRef{}) {
 			n.OnNewL1Finalized(reqCtx, finalizedRef)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -592,7 +592,6 @@ func (n *OpNode) Start(ctx context.Context) error {
 		return err
 	}
 	log.Info("Rollup node started")
-
 	return nil
 }
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -572,25 +572,27 @@ func (n *OpNode) Start(ctx context.Context) error {
 	// If n.cfg.Driver.SequencerUseFinalized is true, sequencer cannot retrieve non-finalized L1 blocks.
 	// OpNode periodically fetches the latest safe and finalized L1 blocks every epoch (13 minutes),
 	// but immediately after startup, these values are not yet available.
-	// In some cases, this can cause the sequencer to get stuck.
+	// In some cases, this can cause the sequencer to get stuck when n.cfg.Driver.SequencerUseFinalized is true
 	// To prevent this, here is to fetch and initialize the latest safe and finalized L1 block references at startup
-	reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
-	defer reqCancel()
+	if n.cfg.Driver.SequencerUseFinalized {
+		reqCtx, reqCancel := context.WithTimeout(ctx, time.Second*20)
+		defer reqCancel()
 
-	safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
-	if err != nil {
-		return fmt.Errorf("failed to fetch L1 safe head: %w", err)
-	}
-	if safeRef != (eth.L1BlockRef{}) {
-		n.OnNewL1Safe(reqCtx, safeRef)
-	}
+		safeRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Safe)
+		if err != nil {
+			return fmt.Errorf("failed to fetch L1 safe head: %w", err)
+		}
+		if safeRef != (eth.L1BlockRef{}) {
+			n.OnNewL1Safe(reqCtx, safeRef)
+		}
 
-	finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
-	if err != nil {
-		return fmt.Errorf("failed to fetch L1 finalized head: %w", err)
-	}
-	if finalizedRef != (eth.L1BlockRef{}) {
-		n.OnNewL1Finalized(reqCtx, finalizedRef)
+		finalizedRef, err := n.l1Source.L1BlockRefByLabel(reqCtx, eth.Finalized)
+		if err != nil {
+			return fmt.Errorf("failed to fetch L1 finalized head: %w", err)
+		}
+		if finalizedRef != (eth.L1BlockRef{}) {
+			n.OnNewL1Finalized(reqCtx, finalizedRef)
+		}
 	}
 
 	return nil

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -240,7 +240,7 @@ func NewDriver(
 		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 		var seqL1Blocks sequencing.L1Blocks
 		if driverCfg.SequencerUseFinalized {
-			seqL1Blocks = finalized.NewFinalized(statusTracker.L1Finalized, l1)
+			seqL1Blocks = finalized.NewFinalized(statusTracker.L1Finalized, l1, log)
 		} else {
 			seqL1Blocks = confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
 		}

--- a/op-node/rollup/finalized/finalized.go
+++ b/op-node/rollup/finalized/finalized.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -12,10 +13,11 @@ import (
 type finalized struct {
 	derive.L1Fetcher
 	l1Finalized func() eth.L1BlockRef
+	log         log.Logger
 }
 
-func NewFinalized(l1Finalized func() eth.L1BlockRef, fetcher derive.L1Fetcher) *finalized {
-	return &finalized{L1Fetcher: fetcher, l1Finalized: l1Finalized}
+func NewFinalized(l1Finalized func() eth.L1BlockRef, fetcher derive.L1Fetcher, log log.Logger) *finalized {
+	return &finalized{L1Fetcher: fetcher, l1Finalized: l1Finalized, log: log}
 }
 
 func (f *finalized) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
@@ -23,6 +25,7 @@ func (f *finalized) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1B
 	if num == 0 || num <= l1Finalized.Number {
 		return f.L1Fetcher.L1BlockRefByNumber(ctx, num)
 	}
+	f.log.Warn("requested L1 block is beyond local finalized height", "requested_block", num, "finalized_block", l1Finalized.Number)
 	return eth.L1BlockRef{}, ethereum.NotFound
 }
 

--- a/op-node/rollup/finalized/finalized_test.go
+++ b/op-node/rollup/finalized/finalized_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -27,7 +28,7 @@ func (ft *finalizedTest) Run(t *testing.T) {
 	l1Finalized := eth.L1BlockRef{Number: ft.final, Hash: ft.hash}
 	l1FinalizedGetter := func() eth.L1BlockRef { return l1Finalized }
 
-	f := NewFinalized(l1FinalizedGetter, l1Fetcher)
+	f := NewFinalized(l1FinalizedGetter, l1Fetcher, log.New())
 
 	if ft.pass {
 		// no calls to the l1Fetcher are made if the block number is not finalized yet


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/940

This PR adds code to retrieve and initialize L1 Safe and Finalized head in `SyncStatus` when `OpNode` starts, preventing Sequencer from failing to fetch the next L1 finalized block if `--sequencer.use-finalized` is enabled.