### PR TITLE
Cherry pick upstream PR #14062

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -491,6 +491,8 @@ func (d *Sequencer) startBuildingBlock() {
 	// Figure out which L1 origin block we're going to be building on top of.
 	l1Origin, err := d.l1OriginSelector.FindL1Origin(ctx, l2Head)
 	if err != nil {
+		d.nextAction = d.timeNow().Add(time.Second)
+		d.nextActionOK = d.active.Load()
 		d.log.Error("Error finding next L1 Origin", "err", err)
 		d.emitter.Emit(rollup.L1TemporaryErrorEvent{Err: err})
 		return


### PR DESCRIPTION
Fixes https://github.com/celo-org/celo-blockchain-planning/issues/940

This PR cherry picks an upstream PR https://github.com/ethereum-optimism/optimism/pull/14062 in order to resolve the sequencer's stuck issue. This code adds re-trigger sequencing process after sequencer fails to next L1 origin.