### PR TITLE
contracts: scripts for L2 token deployment/verification

### DIFF
--- a/packages/contracts-bedrock/scripts/celo/gen_l2_token_cmds.fish
+++ b/packages/contracts-bedrock/scripts/celo/gen_l2_token_cmds.fish
@@ -8,7 +8,7 @@ if [ -z "$argv" ];
 end
 
 echo
-echo "Commands to deploy L2 tokens for bridging from Ethereum. If tokens don't use 18 decimals, use createOptimismMintableERC20WithDecimals instead."
+echo "Commands to deploy L2 tokens for bridging from Ethereum:"
 echo
 
 set -x ETH_RPC_URL https://ethereum-rpc.publicnode.com
@@ -16,5 +16,6 @@ set -x ETH_RPC_URL https://ethereum-rpc.publicnode.com
 for address in $argv
 	set symbol (cast call $address "symbol() returns (string)" --json | jq -r '.[0]')
 	set name (cast call $address "name() returns (string)" --json | jq -r '.[0]')
-	echo cast send 0x4200000000000000000000000000000000000012 "\"createOptimismMintableERC20(address,string,string)\"" $address "\"$name (Celo native bridge)\"" \"$symbol\" --private-key \$PRIVKEY
+	set decimals (cast call $address "decimals() returns (uint256)" --json | jq -r '.[0]')
+	echo cast send 0x4200000000000000000000000000000000000012 "\"createOptimismMintableERC20WithDecimals(address,string,string,uint8)\"" $address "\"$name (Celo native bridge)\"" \"$symbol\" $decimals --private-key \$PRIVKEY
 end

--- a/packages/contracts-bedrock/scripts/celo/gen_l2_token_cmds.fish
+++ b/packages/contracts-bedrock/scripts/celo/gen_l2_token_cmds.fish
@@ -1,0 +1,20 @@
+#!/usr/bin/env fish
+
+if [ -z "$argv" ];
+  echo Create commands to deploy L2 tokens for bridging from Ethereum
+  echo
+  echo "Usage: $(status filename) <l1_token_address> [<l1_token_address> ...]"
+  return
+end
+
+echo
+echo "Commands to deploy L2 tokens for bridging from Ethereum. If tokens don't use 18 decimals, use createOptimismMintableERC20WithDecimals instead."
+echo
+
+set -x ETH_RPC_URL https://ethereum-rpc.publicnode.com
+
+for address in $argv
+	set symbol (cast call $address "symbol() returns (string)" --json | jq -r '.[0]')
+	set name (cast call $address "name() returns (string)" --json | jq -r '.[0]')
+	echo cast send 0x4200000000000000000000000000000000000012 "\"createOptimismMintableERC20(address,string,string)\"" $address "\"$name (Celo native bridge)\"" \"$symbol\" --private-key \$PRIVKEY
+end

--- a/packages/contracts-bedrock/scripts/celo/verify_token_blockscout.sh
+++ b/packages/contracts-bedrock/scripts/celo/verify_token_blockscout.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$*" ]; then
+  echo "Verify L2 bridged tokens on Blockscout"
+  echo
+  echo "Usage: $0 <token_address> [<token_address> ...]"
+  exit 1
+fi
+
+for BRIDGED_TOKEN in "$@"; do
+  forge verify-contract \
+    --verifier=blockscout \
+    --verifier-url=https://celo.blockscout.com/api/ \
+    "$BRIDGED_TOKEN" \
+    src/universal/OptimismMintableERC20.sol:OptimismMintableERC20
+done

--- a/packages/contracts-bedrock/scripts/celo/verify_token_celoscan.sh
+++ b/packages/contracts-bedrock/scripts/celo/verify_token_celoscan.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ -z "$*" ]; then
+  echo "Verify L2 bridged tokens on Celoscan"
+  echo
+  echo "Usage: $0 <token_address> [<token_address> ...]"
+  exit 1
+fi
+
+for BRIDGED_TOKEN in "$@"; do
+  # cast_call <address> <signature>
+  function cast_call() {
+    cast call --json --rpc-url https://forno.celo.org "$1" "$2" | jq -r ".[0]"
+  }
+
+  REMOTE_TOKEN=$(cast_call "$BRIDGED_TOKEN" "REMOTE_TOKEN()(address)")
+  NAME=$(cast_call "$BRIDGED_TOKEN" "name()(string)")
+  SYMBOL=$(cast_call "$BRIDGED_TOKEN" "symbol()(string)")
+  DECIMALS=$(cast_call "$BRIDGED_TOKEN" "decimals()(uint8)")
+
+  CONSTRUCTOR_ARGS=$(cast abi-encode "constructor(address,address,string,string,uint8)"  0x4200000000000000000000000000000000000010 "$REMOTE_TOKEN" "$NAME" "$SYMBOL" "$DECIMALS")
+  CONSTRUCTOR_ARGS=${CONSTRUCTOR_ARGS#0x}
+
+  forge verify-contract \
+    --verifier=etherscan \
+    --verifier-url=https://api.celoscan.io/api/ \
+    --constructor-args="$CONSTRUCTOR_ARGS" \
+    --skip-is-verified-check \
+    "$BRIDGED_TOKEN" \
+    src/universal/OptimismMintableERC20.sol:OptimismMintableERC20
+done


### PR DESCRIPTION
These can certainly be improved (e.g. all using bash instead of one fish script), but I wanted to keep them as close as possible to the commands actually executed to avoid introducing subtle differences. I wouldn't notice those since I probably won't run these commands again within the next days.

See https://github.com/celo-org/celo-blockchain-planning/issues/982