### PR TITLE
Fix Test_ProgramAction_OperatorFeeConsistency tests

### DIFF
--- a/op-e2e/actions/proofs/celo_operator_fee_test_util.go
+++ b/op-e2e/actions/proofs/celo_operator_fee_test_util.go
@@ -1,0 +1,18 @@
+package proofs
+
+import (
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
+)
+
+// In the celo op-geth state transition function we issue the base fee to the fee handler
+// if running in a cel2 context, otherwise it is issued to the base fee vault.
+// We need to account for this here so that we can correctly account for all funds.
+func getBaseFeeRecipientAddress(env *helpers.L2FaultProofEnv) common.Address {
+	if env.Sd.L2Cfg.Config.IsCel2(env.Sequencer.L2Unsafe().Time) {
+		return addresses.GetAddressesOrDefault(env.Sd.RollupCfg.L2ChainID, addresses.MainnetAddresses).FeeHandler
+	}
+	return predeploys.BaseFeeVaultAddr
+}

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -84,7 +84,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 		getCurrentBalances := func() (alice *big.Int, l1FeeVault *big.Int, baseFeeVault *big.Int, sequencerFeeVault *big.Int, operatorFeeVault *big.Int) {
 			alice = balanceAt(env.Alice.Address())
 			l1FeeVault = balanceAt(predeploys.L1FeeVaultAddr)
-			baseFeeVault = balanceAt(predeploys.BaseFeeVaultAddr)
+			baseFeeVault = balanceAt(getBaseFeeRecipientAddress(env))
 			sequencerFeeVault = balanceAt(predeploys.SequencerFeeVaultAddr)
 			operatorFeeVault = balanceAt(predeploys.OperatorFeeVaultAddr)
 


### PR DESCRIPTION
These operator fee consistency tests perform a check at the end to ensure that
the total funds after a test match the total funds before the test.

We had modified the state transition function to direct baseFee payments to the
fee handler instead of optimism's OperatorFeeVault when in a cel2 context.

This caused the tests to fail because the tests were not including the balance
of the fee handler.

This change ensures that we do consider the fee handler balance when
calculating the total.