### PR TITLE
Change update-geth base-branch to 'celo-rebase-13'

### DIFF
--- a/.github/workflows/update-geth.yaml
+++ b/.github/workflows/update-geth.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  OP_GETH_BASE_BRANCH: "celo-rebase-12"
+  OP_GETH_BASE_BRANCH: "celo-rebase-13"
 
 jobs:
   job_id:


### PR DESCRIPTION
This changes the op-geth base-branch used to update the go dependencies in the update-geth CI run to 
the matching rebase.