### PR TITLE
Build op-node using docker-bake and push to devopsre/celo-blockchain-public registry

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -1,0 +1,55 @@
+name: "[cLabs] Publish Docker Image For Release"
+on:
+  workflow_dispatch:
+  release:
+    types: [published]  # Trigger the workflow only when a release is published
+
+jobs:
+  Set-Tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set tags
+        id: set_tags
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == *"rc"* || "${{ github.event.release.tag_name }}" == *"beta"* || "${{ github.event.release.tag_name }}" == *"alpha"* ]]; then
+            echo "::set-output name=tags::${{ github.event.release.tag_name }}"
+          else
+            echo "::set-output name=tags::${{ github.event.release.tag_name }},stable,latest"
+          fi
+    outputs:
+      tags: ${{ steps.set_tags.outputs.tags }}
+
+  # Build op-node using docker-bake and push to devopsre/celo-blockchain-public registry
+  build-op-stack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    needs: Set-Tags
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    env:
+      GIT_COMMIT: ${{ github.sha }}
+      GIT_DATE: ${{ github.event.release.created_at }}
+      IMAGE_TAGS: ${{ needs.set-tags.outputs.tags }}
+      REGISTRY: us-west1-docker.pkg.dev
+      REPOSITORY: devopsre/celo-blockchain-public
+      PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login at GCP Artifact Registry
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0
+        with:
+          workload-id-provider: 'projects/1094498259535/locations/global/workloadIdentityPools/gh-optimism/providers/github-by-repos'
+          service-account: 'celo-optimism-gh@devopsre.iam.gserviceaccount.com'
+          docker-gcp-registries: us-west1-docker.pkg.dev
+      # We need a custom steps as it's using docker bake
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/bake-action@v5
+        with:
+          push: true
+          source: .
+          files: docker-bake.hcl
+          targets: op-node

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -31,7 +31,7 @@ jobs:
     env:
       GIT_COMMIT: ${{ github.sha }}
       GIT_DATE: ${{ github.event.release.created_at }}
-      IMAGE_TAGS: ${{ needs.set-tags.outputs.tags }}
+      IMAGE_TAGS: ${{ needs.Set-Tags.outputs.tags }}
       REGISTRY: us-west1-docker.pkg.dev
       REPOSITORY: devopsre/celo-blockchain-public
       PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
Build op-node using docker-bake and push to devopsre/celo-blockchain-public registry