### PR TITLE
Update op-deployer and foundry scripts for Kurtosis devnet on celo-rebase-13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "packages/contracts-bedrock/lib/safe-contracts"]
 	path = packages/contracts-bedrock/lib/safe-contracts
 	url = https://github.com/celo-org/safe-smart-account
-	branch = mc01/v1.4.0
+	branch = mc01/v1.3.0
 [submodule "packages/contracts-bedrock/lib/kontrol-cheatcodes"]
 	path = packages/contracts-bedrock/lib/kontrol-cheatcodes
 	url = https://github.com/runtimeverification/kontrol-cheatcodes

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -657,6 +657,16 @@ func (d *AltDADeployConfig) Check(log log.Logger) error {
 	return nil
 }
 
+type CeloDeployConfig struct {
+	DeployCeloContracts bool `json:"deployCeloContracts" toml:"deployCeloContracts"`
+}
+
+var _ ConfigChecker = (*CeloDeployConfig)(nil)
+
+func (d *CeloDeployConfig) Check(log log.Logger) error {
+	return nil
+}
+
 // L2InitializationConfig represents all L2 configuration
 // data that can be configured before the deployment of any L1 contracts.
 type L2InitializationConfig struct {
@@ -672,6 +682,7 @@ type L2InitializationConfig struct {
 	UpgradeScheduleDeployConfig
 	L2CoreDeployConfig
 	AltDADeployConfig
+	CeloDeployConfig
 }
 
 func (d *L2InitializationConfig) Check(log log.Logger) error {

--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -23,6 +23,8 @@ type DeployImplementationsInput struct {
 	SuperchainProxyAdmin  common.Address
 	UpgradeController     common.Address
 	UseInterop            bool // if true, deploy Interop implementations
+	// For Celo Kurtosis Devent
+	UseDevCeloTokenL1 bool // Deploy DevCeloTokenL1 instead of CeloTokenL1
 }
 
 func (input *DeployImplementationsInput) InputSet() bool {

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -44,6 +44,11 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 		return fmt.Errorf("error merging proof params from overrides: %w", err)
 	}
 
+	var useDevCeloTokenL1 bool
+	if shouldDeployDevCeloTokenL1, ok := intent.GlobalDeployOverrides["useDevCeloTokenL1"].(bool); ok {
+		useDevCeloTokenL1 = shouldDeployDevCeloTokenL1
+	}
+
 	dio, err := opcm.DeployImplementations(
 		env.L1ScriptHost,
 		opcm.DeployImplementationsInput{
@@ -59,6 +64,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			SuperchainProxyAdmin:            st.SuperchainDeployment.ProxyAdminAddress,
 			UpgradeController:               intent.SuperchainRoles.ProxyAdminOwner,
 			UseInterop:                      intent.UseInterop,
+			UseDevCeloTokenL1:               useDevCeloTokenL1,
 		},
 	)
 	if err != nil {

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -27,6 +27,11 @@ forge-build-dev *ARGS:
 build-source:
   forge build --skip "/**/test/**" --skip "/**/scripts/**"
 
+# Builds source contracts and scripts, skipping tests.
+build-no-tests:
+  forge build --skip "/**/test/**" --libraries \
+  "src/celo/common/linkedlists/AddressSortedLinkedListWithMedian.sol:AddressSortedLinkedListWithMedian:0xED477A99035d0c1e11369F1D7A4e587893cc002B"
+
 # Builds the contracts.
 build *ARGS: lint-fix-no-fail
   just forge-build {{ARGS}}

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -33,6 +33,19 @@ import { IL2CrossDomainMessenger } from "interfaces/L2/IL2CrossDomainMessenger.s
 import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 
+// Celo Specific Contracts
+import { GoldToken } from "src/celo/GoldToken.sol";
+import { CeloPredeploys } from "src/celo/CeloPredeploys.sol";
+import { CeloRegistry } from "src/celo/CeloRegistry.sol";
+import { FeeHandler } from "src/celo/FeeHandler.sol";
+import { MentoFeeHandlerSeller } from "src/celo/MentoFeeHandlerSeller.sol";
+import { UniswapFeeHandlerSeller } from "src/celo/UniswapFeeHandlerSeller.sol";
+import { SortedOracles } from "src/celo/stability/SortedOracles.sol";
+import { FeeCurrencyDirectory } from "src/celo/FeeCurrencyDirectory.sol";
+import { FeeCurrency } from "src/celo/testing/FeeCurrency.sol";
+import { StableTokenV2 } from "src/celo/StableTokenV2.sol";
+import { AddressSortedLinkedListWithMedian } from "src/celo/common/linkedlists/AddressSortedLinkedListWithMedian.sol";
+
 struct L1Dependencies {
     address payable l1CrossDomainMessengerProxy;
     address payable l1StandardBridgeProxy;
@@ -53,6 +66,10 @@ contract L2Genesis is Deployer {
     uint256 public constant PRECOMPILE_COUNT = 256;
 
     uint80 internal constant DEV_ACCOUNT_FUND_AMT = 10_000 ether;
+
+    // Define here to use mainnet fee currency directory address
+    // (CeloPredeploy's fee currency directory address is for Alfajores)
+    address internal constant FEE_CURRENCY_DIRECTORY = 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276;
 
     /// @notice Default Anvil dev accounts. Only funded if `cfg.fundDevAccounts == true`.
     /// Also known as "test test test test test test test test test test test junk" mnemonic accounts,
@@ -157,6 +174,9 @@ contract L2Genesis is Deployer {
         setPreinstalls();
         if (cfg.fundDevAccounts()) {
             fundDevAccounts();
+        }
+        if (cfg.deployCeloContracts()) {
+            setCeloPredeploys();
         }
         vm.stopPrank();
 
@@ -674,5 +694,185 @@ contract L2Genesis is Deployer {
             console.log("Funding dev account %s with %s ETH", devAccounts[i], DEV_ACCOUNT_FUND_AMT / 1e18);
             vm.deal(devAccounts[i], DEV_ACCOUNT_FUND_AMT);
         }
+    }
+
+    ///@notice Sets all proxies and implementations for Celo contracts
+    function setCeloPredeploys() internal {
+        console.log("Deploying Celo contracts");
+
+        setCeloRegistry();
+        setCeloGoldToken();
+        setCeloFeeHandler();
+        setCeloMentoFeeHandlerSeller();
+        setCeloUniswapFeeHandlerSeller();
+        setCeloAddressSortedLinkedListWithMedian();
+        setCeloSortedOracles();
+        setCeloFeeCurrency();
+        setFeeCurrencyDirectory();
+
+        address[] memory initialBalanceAddresses = new address[](2);
+        initialBalanceAddresses[0] = devAccounts[0];
+        initialBalanceAddresses[1] = CeloPredeploys.FEE_HANDLER; // Seed the FeeHandler with a tiny balance to avoid the 20 000-gas “cold” SSTORE on its first transfer
+
+        uint256[] memory initialBalances = new uint256[](2);
+        initialBalances[0] = 100_000 ether;
+        initialBalances[1] = 1;
+        deploycUSD(initialBalanceAddresses, initialBalances, 2);
+    }
+
+    /// @notice Sets up a proxy for the given impl address
+    function _setupProxy(address addr, address impl) internal returns (address) {
+        bytes memory code = vm.getDeployedCode("Proxy.sol:Proxy");
+        vm.etch(addr, code);
+        EIP1967Helper.setAdmin(addr, Predeploys.PROXY_ADMIN);
+
+        console.log("Setting proxy %s with implementation: %s", addr, impl);
+        EIP1967Helper.setImplementation(addr, impl);
+
+        return addr;
+    }
+
+    function setCeloRegistry() internal {
+        CeloRegistry kontract = new CeloRegistry({ test: false });
+
+        address precompile = CeloPredeploys.CELO_REGISTRY;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setCeloGoldToken() internal {
+        GoldToken kontract = new GoldToken({ test: false });
+
+        address precompile = CeloPredeploys.GOLD_TOKEN;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setCeloFeeHandler() internal {
+        FeeHandler kontract = new FeeHandler({ test: false });
+
+        address precompile = CeloPredeploys.FEE_HANDLER;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setCeloMentoFeeHandlerSeller() internal {
+        MentoFeeHandlerSeller kontract = new MentoFeeHandlerSeller({ test: false });
+
+        address precompile = CeloPredeploys.MENTO_FEE_HANDLER_SELLER;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setCeloUniswapFeeHandlerSeller() internal {
+        UniswapFeeHandlerSeller kontract = new UniswapFeeHandlerSeller({ test: false });
+
+        address precompile = CeloPredeploys.UNISWAP_FEE_HANDLER_SELLER;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setCeloSortedOracles() internal {
+        SortedOracles kontract = new SortedOracles({ test: false });
+
+        address precompile = CeloPredeploys.SORTED_ORACLES;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function setFeeCurrencyDirectory() internal {
+        FeeCurrencyDirectory feeCurrencyDirectory = new FeeCurrencyDirectory({ test: false });
+
+        address precompile = FEE_CURRENCY_DIRECTORY;
+        string memory cname = CeloPredeploys.getName(CeloPredeploys.FEE_CURRENCY_DIRECTORY);
+        console.log("Deploying %s implementation at: %s", cname, address(feeCurrencyDirectory));
+
+        vm.resetNonce(address(feeCurrencyDirectory));
+        _setupProxy(precompile, address(feeCurrencyDirectory));
+
+        vm.startPrank(devAccounts[0]);
+        FeeCurrencyDirectory(precompile).initialize();
+        vm.stopPrank();
+    }
+
+    function setCeloAddressSortedLinkedListWithMedian() internal {
+        address precompile = CeloPredeploys.ADDRESS_SORTED_LINKED_LIST_WITH_MEDIAN;
+        string memory cname = CeloPredeploys.getName(precompile);
+
+        console.log("Deploying %s (library) at: %s", cname, precompile);
+
+        bytes memory runtimeCode = type(AddressSortedLinkedListWithMedian).runtimeCode;
+        vm.etch(precompile, runtimeCode);
+    }
+
+    function setCeloFeeCurrency() internal {
+        FeeCurrency kontract = new FeeCurrency({ name_: "Test", symbol_: "TST" });
+        address precompile = CeloPredeploys.FEE_CURRENCY;
+        string memory cname = CeloPredeploys.getName(precompile);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+        vm.resetNonce(address(kontract));
+        _setupProxy(precompile, address(kontract));
+    }
+
+    function deploycUSD(
+        address[] memory initialBalanceAddresses,
+        uint256[] memory initialBalanceValues,
+        uint256 celoPrice
+    )
+        public
+    {
+        StableTokenV2 kontract = new StableTokenV2({ disable: false });
+        address cusdProxyAddress = CeloPredeploys.cUSD;
+        string memory cname = CeloPredeploys.getName(cusdProxyAddress);
+        console.log("Deploying %s implementation at: %s", cname, address(kontract));
+        vm.resetNonce(address(kontract));
+
+        _setupProxy(cusdProxyAddress, address(kontract));
+
+        StableTokenV2(cusdProxyAddress).initialize("Celo Dollar", "cUSD", initialBalanceAddresses, initialBalanceValues);
+
+        SortedOracles sortedOracles = SortedOracles(CeloPredeploys.SORTED_ORACLES);
+
+        console.log("beofre add oracle");
+
+        vm.startPrank(sortedOracles.owner());
+        sortedOracles.addOracle(cusdProxyAddress, deployer);
+        vm.stopPrank();
+        vm.startPrank(deployer);
+
+        if (celoPrice != 0) {
+            sortedOracles.report(cusdProxyAddress, celoPrice * 1e24, address(0), address(0)); // TODO use fixidity
+        }
+
+        /*
+    Arbitrary intrinsic gas number take from existing `FeeCurrencyDirectory.t.sol` tests
+        Source:
+        https://github.com/celo-org/celo-monorepo/blob/2cec07d43328cf4216c62491a35eacc4960fffb6/packages/protocol/test-sol/common/FeeCurrencyDirectory.t.sol#L27
+        */
+        uint256 mockIntrinsicGas = 21000;
+
+        FeeCurrencyDirectory feeCurrencyDirectory = FeeCurrencyDirectory(FEE_CURRENCY_DIRECTORY);
+        vm.startPrank(feeCurrencyDirectory.owner());
+        feeCurrencyDirectory.setCurrencyConfig(cusdProxyAddress, address(sortedOracles), mockIntrinsicGas);
+        vm.stopPrank();
+        vm.startPrank(deployer);
     }
 }

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -69,7 +69,7 @@ contract L2Genesis is Deployer {
 
     // Define here to use mainnet fee currency directory address
     // (CeloPredeploy's fee currency directory address is for Alfajores)
-    address internal constant FEE_CURRENCY_DIRECTORY = 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276;
+    // address internal constant FEE_CURRENCY_DIRECTORY = 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276;
 
     /// @notice Default Anvil dev accounts. Only funded if `cfg.fundDevAccounts == true`.
     /// Also known as "test test test test test test test test test test test junk" mnemonic accounts,
@@ -801,8 +801,8 @@ contract L2Genesis is Deployer {
     function setFeeCurrencyDirectory() internal {
         FeeCurrencyDirectory feeCurrencyDirectory = new FeeCurrencyDirectory({ test: false });
 
-        address precompile = FEE_CURRENCY_DIRECTORY;
-        string memory cname = CeloPredeploys.getName(CeloPredeploys.FEE_CURRENCY_DIRECTORY);
+        address precompile = CeloPredeploys.FEE_CURRENCY_DIRECTORY;
+        string memory cname = CeloPredeploys.getName(precompile);
         console.log("Deploying %s implementation at: %s", cname, address(feeCurrencyDirectory));
 
         vm.resetNonce(address(feeCurrencyDirectory));
@@ -869,7 +869,7 @@ contract L2Genesis is Deployer {
         */
         uint256 mockIntrinsicGas = 21000;
 
-        FeeCurrencyDirectory feeCurrencyDirectory = FeeCurrencyDirectory(FEE_CURRENCY_DIRECTORY);
+        FeeCurrencyDirectory feeCurrencyDirectory = FeeCurrencyDirectory(CeloPredeploys.FEE_CURRENCY_DIRECTORY);
         vm.startPrank(feeCurrencyDirectory.owner());
         feeCurrencyDirectory.setCurrencyConfig(cusdProxyAddress, address(sortedOracles), mockIntrinsicGas);
         vm.stopPrank();

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -69,7 +69,7 @@ contract L2Genesis is Deployer {
 
     // Define here to use mainnet fee currency directory address
     // (CeloPredeploy's fee currency directory address is for Alfajores)
-    // address internal constant FEE_CURRENCY_DIRECTORY = 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276;
+    address internal constant FEE_CURRENCY_DIRECTORY = 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276;
 
     /// @notice Default Anvil dev accounts. Only funded if `cfg.fundDevAccounts == true`.
     /// Also known as "test test test test test test test test test test test junk" mnemonic accounts,
@@ -801,8 +801,8 @@ contract L2Genesis is Deployer {
     function setFeeCurrencyDirectory() internal {
         FeeCurrencyDirectory feeCurrencyDirectory = new FeeCurrencyDirectory({ test: false });
 
-        address precompile = CeloPredeploys.FEE_CURRENCY_DIRECTORY;
-        string memory cname = CeloPredeploys.getName(precompile);
+        address precompile = FEE_CURRENCY_DIRECTORY;
+        string memory cname = CeloPredeploys.getName(CeloPredeploys.FEE_CURRENCY_DIRECTORY);
         console.log("Deploying %s implementation at: %s", cname, address(feeCurrencyDirectory));
 
         vm.resetNonce(address(feeCurrencyDirectory));
@@ -869,7 +869,7 @@ contract L2Genesis is Deployer {
         */
         uint256 mockIntrinsicGas = 21000;
 
-        FeeCurrencyDirectory feeCurrencyDirectory = FeeCurrencyDirectory(CeloPredeploys.FEE_CURRENCY_DIRECTORY);
+        FeeCurrencyDirectory feeCurrencyDirectory = FeeCurrencyDirectory(FEE_CURRENCY_DIRECTORY);
         vm.startPrank(feeCurrencyDirectory.owner());
         feeCurrencyDirectory.setCurrencyConfig(cusdProxyAddress, address(sortedOracles), mockIntrinsicGas);
         vm.stopPrank();

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -93,6 +93,8 @@ contract DeployConfig is Script {
     bool public useInterop;
     bool public useUpgradedFork;
 
+    bool public deployCeloContracts;
+
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
         try vm.readFile(_path) returns (string memory data_) {
@@ -180,6 +182,8 @@ contract DeployConfig is Script {
 
         useInterop = _readOr(_json, "$.useInterop", false);
         useUpgradedFork;
+
+        deployCeloContracts = _readOr(_json, "$.deployCeloContracts", false);
     }
 
     function fork() public view returns (Fork fork_) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -56,6 +56,8 @@ contract DeployImplementationsInput is BaseDeployIO {
     IProxyAdmin internal _superchainProxyAdmin;
     address internal _upgradeController;
 
+    bool internal _useDevCeloTokenL1;
+
     function set(bytes4 _sel, uint256 _value) public {
         require(_value != 0, "DeployImplementationsInput: cannot set zero value");
 
@@ -89,6 +91,11 @@ contract DeployImplementationsInput is BaseDeployIO {
         else if (_sel == this.protocolVersionsProxy.selector) _protocolVersionsProxy = IProtocolVersions(_addr);
         else if (_sel == this.superchainProxyAdmin.selector) _superchainProxyAdmin = IProxyAdmin(_addr);
         else if (_sel == this.upgradeController.selector) _upgradeController = _addr;
+        else revert("DeployImplementationsInput: unknown selector");
+    }
+
+    function set(bytes4 _sel, bool _value) public {
+        if (_sel == this.useDevCeloTokenL1.selector) _useDevCeloTokenL1 = _value;
         else revert("DeployImplementationsInput: unknown selector");
     }
 
@@ -148,6 +155,10 @@ contract DeployImplementationsInput is BaseDeployIO {
     function upgradeController() public view returns (address) {
         require(address(_upgradeController) != address(0), "DeployImplementationsInput: not set");
         return _upgradeController;
+    }
+
+    function useDevCeloTokenL1() public view returns (bool) {
+        return _useDevCeloTokenL1;
     }
 }
 
@@ -581,7 +592,13 @@ contract DeployImplementations is Script {
         require(checkAddress == address(0), "OPCM-40");
         (blueprints.resolvedDelegateProxy, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("ResolvedDelegateProxy"), _salt);
         require(checkAddress == address(0), "OPCM-50");
-        (blueprints.celoTokenL1, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("CeloTokenL1"), _salt);
+
+        string memory celoTokenL1Contract = "CeloTokenL1";
+        if (_dii.useDevCeloTokenL1()) {
+            celoTokenL1Contract = "DevCeloTokenL1";
+        }
+
+        (blueprints.celoTokenL1, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode(celoTokenL1Contract), _salt);
         require(checkAddress == address(0), "CELO_50");
         // The max initcode/runtimecode size is 48KB/24KB.
         // But for Blueprint, the initcode is stored as runtime code, that's why it's necessary to split into 2 parts.

--- a/packages/contracts-bedrock/src/celo/DevCeloTokenL1.sol
+++ b/packages/contracts-bedrock/src/celo/DevCeloTokenL1.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+contract DevCeloTokenL1 is ERC20Upgradeable {
+    string constant NAME = "Celo";
+    string constant SYMBOL = "CELO";
+    uint256 constant L2_INITIAL_MARKET_CAP = 1000000000e18;
+    uint256 constant L1_INITIAL_AMOUNT_PER_ACOUNT = 1000e18;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _portalProxyAddress) external initializer {
+        // m/44'/60'/0'/0/i
+        address[21] memory devAccountsCelo = [
+            0x8943545177806ED17B9F23F0a21ee5948eCaa776,
+            0xE25583099BA105D9ec0A67f5Ae86D90e50036425,
+            0x3e95dFbBaF6B348396E6674C7871546dCC568e56,
+            0x5918b2e647464d4743601a865753e64C8059Dc4F,
+            0x589A698b7b7dA0Bec545177D3963A2741105C7C9,
+            0x4d1CB4eB7969f8806E2CaAc0cbbB71f88C8ec413,
+            0xF5504cE2BcC52614F121aff9b93b2001d92715CA,
+            0xF61E98E7D47aB884C244E39E031978E33162ff4b,
+            0xf1424826861ffbbD25405F5145B5E50d0F1bFc90,
+            0xfDCe42116f541fc8f7b0776e2B30832bD5621C85,
+            0xD9211042f35968820A3407ac3d80C725f8F75c14,
+            0xD8F3183DEF51A987222D845be228e0Bbb932C222,
+            0x614561D2d143621E126e87831AEF287678B442b8,
+            0xafF0CA253b97e54440965855cec0A8a2E2399896,
+            0xf93Ee4Cf8c6c40b329b0c0626F28333c132CF241,
+            0x802dCbE1B1A97554B4F50DB5119E37E8e7336417,
+            0xAe95d8DA9244C37CaC0a3e16BA966a8e852Bb6D6,
+            0x2c57d1CFC6d5f8E4182a56b4cf75421472eBAEa4,
+            0x741bFE4802cE1C4b5b00F9Df2F5f179A1C89171A,
+            0xc3913d4D8bAb4914328651C2EAE817C8b78E1f4c,
+            0x65D08a056c17Ae13370565B04cF77D2AfA1cB9FA
+        ];
+
+        __ERC20_init(NAME, SYMBOL);
+        _mint(_portalProxyAddress, L2_INITIAL_MARKET_CAP);
+        for (uint256 i = 0; i < devAccountsCelo.length; i++) {
+            _mint(devAccountsCelo[i], L1_INITIAL_AMOUNT_PER_ACOUNT);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds optional intents to deploy Celo custom gas token on L1 and CELO-specific L2 contracts, enabling Kurtosis devnet to run on celo-rebase-13

These flags are enabled through the intent shown in the following code:
https://github.com/celo-org/optimism-package/blob/3d50e7f2503b26f782c134aaa1c649088a83511a/src/contracts/contract_deployer.star#L201-L206

Address https://github.com/celo-org/celo-blockchain-planning/issues/893, https://github.com/celo-org/celo-blockchain-planning/issues/894
