### PR TITLE
Fix or skip failing acceptance tests

### DIFF
--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
+	// Skipped upstream: https://github.com/ethereum-optimism/optimism/commit/01a4115836dc37ffb267cc65cf0b5076a893ac7f
+	gt.Skip("Skipping test until upstream fixes nonce too high error: tx: 177 state: 176")
+
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
 	l := t.Logger()

--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -51,8 +51,8 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
 }
 
 func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sleep time.Duration) {
@@ -98,6 +98,6 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
 }

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -26,6 +26,7 @@ var (
 
 // TestFlashblocksStream checks we can connect to the flashblocks stream across multiple CL backends.
 func TestFlashblocksStream(gt *testing.T) {
+	gt.Skip("Not applicable to Celo: flashblocks block building is disrupted by missing fee currency registry contract")
 	t := devtest.SerialT(gt)
 	logger := t.Logger()
 	sys := presets.NewSingleChainWithFlashblocks(t)

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -31,6 +31,7 @@ type timedMessage struct {
 // - That Flashblock's time (in seconds) must be less than or equal to the Transaction's block time (in seconds). (Can't check the block time beyond the granularity of seconds)
 // - That Flashblock's time in nanoseconds must be before the approximated transaction confirmation time recorded previously.
 func TestFlashblocksTransfer(gt *testing.T) {
+	gt.Skip("Not applicable to Celo: flashblocks block building is disrupted by missing fee currency registry contract")
 	t := devtest.SerialT(gt)
 	logger := t.Logger()
 	tracer := t.Tracer()

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -216,6 +216,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 }
 
 func hfsExt(gt *testing.T, upgradeName forks.Name, l2CLSyncMode sync.Mode) {
+	gt.Skip("Not applicable to Celo: all pre-Holocene forks are active at genesis so there are no fork boundaries to sync across, and the test targets op-sepolia infrastructure")
 	t := devtest.ParallelT(gt)
 	l := t.Logger()
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1175,7 +1175,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *eth.BlockRef, l2GenesisBlockHa
 		ProtocolVersionsAddress: d.ProtocolVersionsProxy,
 		AltDAConfig:             altDA,
 		ChainOpConfig:           chainOpConfig,
-		Cel2Time:                d.RegolithTime(l1StartTime),
+		Cel2Time:                func() *uint64 { v := uint64(0); return &v }(),
 	}, nil
 }
 

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -78,7 +78,7 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *eth.BlockRef) (*core.Gene
 		JovianTime:              config.JovianTime(l1StartTime),
 		PragueTime:              config.IsthmusTime(l1StartTime),
 		InteropTime:             config.InteropTime(l1StartTime),
-		Cel2Time:                config.RegolithTime(l1StartTime),
+		Cel2Time:                u64ptr(0),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,
 			EIP1559Elasticity:        eip1559Elasticity,

--- a/op-devstack/dsl/fjord_fees.go
+++ b/op-devstack/dsl/fjord_fees.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -110,9 +111,19 @@ func (ff *FjordFees) ValidateTransaction(from *EOA, to *EOA, amount *big.Int) Fj
 	}
 }
 
+// baseFeeRecipientAddr returns the address that receives base fees.
+// On Celo (IsCel2), base fees are routed to the FeeHandler instead of BaseFeeVault.
+func (ff *FjordFees) baseFeeRecipientAddr() common.Address {
+	rc := ff.l2Network.inner.RollupConfig()
+	if rc.IsCel2(rc.Genesis.L2Time) {
+		return addresses.GetAddressesOrDefault(rc.L2ChainID, addresses.MainnetAddresses).FeeHandler
+	}
+	return predeploys.BaseFeeVaultAddr
+}
+
 // getVaultBalances gets the balances of the vaults
 func (ff *FjordFees) getVaultBalances(client apis.EthClient) VaultBalances {
-	baseFee := ff.getBalance(client, predeploys.BaseFeeVaultAddr)
+	baseFee := ff.getBalance(client, ff.baseFeeRecipientAddr())
 	l1Fee := ff.getBalance(client, predeploys.L1FeeVaultAddr)
 	sequencer := ff.getBalance(client, predeploys.SequencerFeeVaultAddr)
 	operator := ff.getBalance(client, predeploys.OperatorFeeVaultAddr)

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -727,7 +727,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 			IsthmusTime:             cfg.DeployConfig.IsthmusTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			JovianTime:              cfg.DeployConfig.JovianTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			InteropTime:             cfg.DeployConfig.InteropTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
-			Cel2Time:                cfg.DeployConfig.RegolithTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
+			Cel2Time:                func() *uint64 { v := uint64(0); return &v }(),
 			ProtocolVersionsAddress: cfg.L1Deployments.ProtocolVersionsProxy,
 			AltDAConfig:             rollupAltDAConfig,
 			ChainOpConfig: &params.OptimismConfig{


### PR DESCRIPTION
Make the acceptance tests work, mostly by skipping hard fork schedule tests, which are not really relevant to Celo, since most OP hard-forks happened before Celo L2. We can try to adapt and reenable some if we see and advantage. But let's start with a well defined set of green tests, so that we can start using the rebase and notice any new regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect fork scheduling (`Cel2Time`) and fee recipient assumptions, which can impact genesis/rollup behavior, but most other edits are test skips/timeout tweaks.
> 
> **Overview**
> Makes the acceptance test suite *Celo-compatible* by skipping several tests that are either currently failing upstream (`TestBatcherFullChannelsAfterDowntime`) or rely on OP-Sepolia-specific fork boundaries / flashblocks infrastructure (`TestFlashblocksStream`, `TestFlashblocksTransfer`, HFS external sync tests).
> 
> Stabilizes remaining acceptance coverage by increasing post-reconnect sync wait timeouts from 30s to 60s.
> 
> Adjusts Celo chain configuration to treat `Cel2Time` as active at genesis (set to `0`) across rollup/genesis setup paths, and updates Fjord fee validation to read base-fee accrual from Celo’s `FeeHandler` instead of `BaseFeeVault` when `IsCel2` is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f57a0f52cb97e4372c741a4dd3f249df1acc54a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->