### PR TITLE
op-node: Delay BPO hardforks until Jovian for Celo chains

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -499,6 +500,12 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 	if isEcotoneActivated {
 		l1BlockInfo.BlobBaseFee = block.BlobBaseFee(l1ChainConfig)
 
+		// Fusaka blob schedule fix: for Celo chains, use Prague blob params
+		// until Jovian activates, to gate BPO activation on Jovian.
+		if needsFusakaBlobScheduleFix(rollupCfg.L2ChainID) && !rollupCfg.IsJovian(l2Timestamp) {
+			l1BlockInfo.BlobBaseFee = calcBlobFeePrague(*block.ExcessBlobGas())
+		}
+
 		// Apply Cancun blob base fee calculation if this chain needs the L1 Pectra
 		// blob schedule fix (mostly Holesky and Sepolia OP-Stack chains).
 		if t := rollupCfg.PectraBlobScheduleTime; t != nil && block.Time() < *t {
@@ -583,6 +590,31 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 		out.Gas = RegolithSystemTxGas
 	}
 	return out, nil
+}
+
+// calcBlobFeePrague calculates the blob fee using the Prague blob schedule.
+// This is only used to gate BPO activation on Jovian for Celo chains.
+func calcBlobFeePrague(excessBlobGas uint64) *big.Int {
+	pragueHeader := &types.Header{ExcessBlobGas: &excessBlobGas}
+	dummyChainCfg := &params.ChainConfig{
+		LondonBlock:        common.Big0,
+		CancunTime:         func() *uint64 { v := uint64(0); return &v }(),
+		PragueTime:         func() *uint64 { v := uint64(0); return &v }(),
+		BlobScheduleConfig: params.DefaultBlobSchedule,
+	}
+	return eip4844.CalcBlobFee(dummyChainCfg, pragueHeader)
+}
+
+// needsFusakaBlobScheduleFix returns true if the given L2 chain ID is a Celo chain
+// that delays Fusaka BPO blob parameter change.
+func needsFusakaBlobScheduleFix(chainID *big.Int) bool {
+	if chainID == nil {
+		return false
+	}
+	id := chainID.Uint64()
+	return id == params.CeloMainnetChainID ||
+		id == params.CeloSepoliaChainID ||
+		id == 11162320 // Celo Chaos testnet
 }
 
 // L1InfoDepositBytes returns a serialized L1-info attributes transaction.


### PR DESCRIPTION
When Ethereum L1 activates Fusaka, the BPO blob schedule changes the blob base fee calculation. For Celo chains, we missed that and now have to keep using the Prague blob parameters until Jovian activates on L2.

This matches https://github.com/celo-org/celo-kona/pull/121.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/1301

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 attribute derivation for `BlobBaseFee` on specific networks, which can affect fee accounting and block validity if miscomputed, but is narrowly gated to Celo chain IDs and pre-Jovian timing.
> 
> **Overview**
> Adjusts `L1InfoDeposit` blob base fee computation for Ecotone-era blocks on Celo L2s to **keep using Prague blob schedule parameters until Jovian activates**, avoiding premature Fusaka/BPO fee parameter changes.
> 
> Adds chain-ID gating via `needsFusakaBlobScheduleFix` (Celo mainnet/sepolia/chaos) and a helper `calcBlobFeePrague` (using `eip4844.CalcBlobFee` with a Prague-configured dummy chain config) to override `BlobBaseFee` when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d477277b5c5d2bce1ec4e6f04efef3219575726f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->