### PR TITLE
Use upstream batcher metrics PR

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -78,7 +78,6 @@ func (c *channel) rewindAltDAFrameCursor(txData txData) {
 // It rewinds the channelBuilder's frameCursor to the first frame of the failed txData,
 // so that the frames can be resubmitted. failoverToEthDA should be set to true when using altDA
 // and altDA is down. This will switch the channel to submit frames to ethDA instead.
-// TODO: add a metric for altDA submission failures.
 func (c *channel) AltDASubmissionFailed(id string, failoverToEthDA bool) {
 	// We coopt TxFailed to rewind the frame cursor.
 	// This will force a resubmit of all the following frames as well,
@@ -96,6 +95,7 @@ func (c *channel) AltDASubmissionFailed(id string, failoverToEthDA bool) {
 		// TODO: figure out how to switch to blobs/auto instead. Might need to make
 		// batcherService.initChannelConfig function stateless so that we can reuse it.
 		c.cfg.DaType = DaTypeCalldata
+		c.metr.RecordFailoverToEthDA()
 	}
 }
 
@@ -120,13 +120,13 @@ func (c *channel) TxFailed(id string) {
 	} else {
 		c.log.Warn("unknown transaction marked as failed", "id", id)
 	}
-	c.metr.RecordBatchTxFailed()
+	c.metr.RecordBatchTxFailed(c.cfg.DaType.String())
 }
 
 // TxConfirmed marks a transaction as confirmed on L1. Returns a bool indicating
 // whether the channel timed out on chain.
 func (c *channel) TxConfirmed(id string, inclusionBlock eth.BlockID) bool {
-	c.metr.RecordBatchTxSuccess()
+	c.metr.RecordBatchTxSuccess(c.cfg.DaType.String())
 	c.log.Debug("marked transaction as confirmed", "id", id, "block", inclusionBlock)
 	if _, ok := c.pendingTransactions[id]; !ok {
 		c.log.Warn("unknown transaction marked as confirmed", "id", id, "block", inclusionBlock)

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -96,7 +96,6 @@ func (c *channel) AltDASubmissionFailed(id string, failoverToEthDA bool) {
 		// TODO: figure out how to switch to blobs/auto instead. Might need to make
 		// batcherService.initChannelConfig function stateless so that we can reuse it.
 		c.cfg.DaType = DaTypeCalldata
-		c.metr.RecordFailoverToEthDA()
 	}
 }
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -146,16 +146,18 @@ func (s *channelManager) TxFailed(_id txID) {
 // the channelManager's state is modified.
 func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 	id := _id.String()
+	daType := DaTypeCalldata
 	if channel, ok := s.txChannels[id]; ok {
 		delete(s.txChannels, id)
 		if timedOut := channel.TxConfirmed(id, inclusionBlock); timedOut {
 			s.log.Warn("channel timed out on chain", "channel_id", channel.ID(), "tx_id", id)
 			s.handleChannelInvalidated(channel)
 		}
+		daType = channel.cfg.DaType
 	} else {
 		s.log.Warn("transaction from unknown channel marked as confirmed", "id", id)
 	}
-	s.metr.RecordBatchTxSubmitted()
+	s.metr.RecordBatchTxSubmitted(daType.String())
 	s.log.Debug("marked transaction as confirmed", "id", id, "block", inclusionBlock)
 }
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -47,8 +47,6 @@ type txRef struct {
 	id       txID
 	isCancel bool
 	isBlob   bool
-	daType   DaType
-	size     int
 }
 
 func (r txRef) String() string {
@@ -1037,7 +1035,7 @@ func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.T
 		candidate.GasLimit = floorDataGas
 	}
 
-	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob, daType: txdata.daType, size: txdata.Len()}, *candidate, receiptsCh)
+	queue.Send(txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob}, *candidate, receiptsCh)
 }
 
 func (l *BatchSubmitter) blobTxCandidate(data txData) (*txmgr.TxCandidate, error) {
@@ -1070,10 +1068,6 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 		l.recordFailedTx(r.ID.id, r.Err)
 	} else if r.Receipt != nil {
 		l.recordConfirmedTx(r.ID.id, r.Receipt)
-		if !r.ID.isCancel {
-			l.Metr.RecordBatchDaType(r.ID.daType.Name())
-			l.Metr.RecordBatchDataSizeBytes(r.ID.daType.Name(), r.ID.size)
-		}
 	}
 	// Both r.Err and r.Receipt can be nil, in which case we do nothing.
 }

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -22,6 +22,19 @@ const (
 	DaTypeAltDA
 )
 
+func (d DaType) String() string {
+	switch d {
+	case DaTypeCalldata:
+		return "calldata"
+	case DaTypeBlob:
+		return "blob"
+	case DaTypeAltDA:
+		return "alt_da"
+	default:
+		return fmt.Sprintf("unknown_da_type_%d", d)
+	}
+}
+
 // txData represents the data for a single transaction.
 //
 // Note: The batcher currently sends exactly one frame per transaction. This

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -22,19 +22,6 @@ const (
 	DaTypeAltDA
 )
 
-func (t DaType) Name() string {
-	switch t {
-	case DaTypeCalldata:
-		return "calldata"
-	case DaTypeBlob:
-		return "blob"
-	case DaTypeAltDA:
-		return "altda"
-	default:
-		return "unknown"
-	}
-}
-
 // txData represents the data for a single transaction.
 //
 // Note: The batcher currently sends exactly one frame per transaction. This

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -59,15 +59,17 @@ type Metricer interface {
 	// It should be called when clearing the ChannelManager state.
 	ClearAllStateMetrics()
 
-	RecordBatchTxSubmitted()
-	RecordBatchTxSuccess()
-	RecordBatchTxFailed()
+	RecordBatchTxSubmitted(daType string)
+	RecordBatchTxSuccess(daType string)
+	RecordBatchTxFailed(daType string)
 
 	RecordBlobUsedBytes(num int)
 
 	Document() []opmetrics.DocumentedMetric
 
 	PendingDABytes() float64
+
+	RecordFailoverToEthDA()
 }
 
 type Metrics struct {
@@ -122,6 +124,8 @@ type Metrics struct {
 	pidControllerIntegral   prometheus.Gauge
 	pidControllerDerivative prometheus.Gauge
 	pidResponseTime         prometheus.Histogram
+
+	eigenDAFailoverToEthDA prometheus.Counter
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -235,7 +239,7 @@ func NewMetrics(procName string) *Metrics {
 			Buckets:   prometheus.LinearBuckets(0.0, eth.MaxBlobDataSize/13, 14),
 		}),
 
-		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),
+		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage", "datype"}),
 
 		throttleIntensity: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -297,6 +301,11 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "unsafe_da_bytes",
 			Help:      "The estimated number of unsafe DA bytes",
+		}),
+		eigenDAFailoverToEthDA: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "eigenda_failover_total",
+			Help:      "Total number of failovers to EthDA",
 		}),
 	}
 	m.pendingDABytesGaugeFunc = factory.NewGaugeFunc(prometheus.GaugeOpts{
@@ -428,16 +437,16 @@ func (m *Metrics) RecordChannelTimedOut(id derive.ChannelID) {
 	m.channelEvs.Record(StageTimedOut)
 }
 
-func (m *Metrics) RecordBatchTxSubmitted() {
-	m.batcherTxEvs.Record(TxStageSubmitted)
+func (m *Metrics) RecordBatchTxSubmitted(daType string) {
+	m.batcherTxEvs.Record(TxStageSubmitted, daType)
 }
 
-func (m *Metrics) RecordBatchTxSuccess() {
-	m.batcherTxEvs.Record(TxStageSuccess)
+func (m *Metrics) RecordBatchTxSuccess(daType string) {
+	m.batcherTxEvs.Record(TxStageSuccess, daType)
 }
 
-func (m *Metrics) RecordBatchTxFailed() {
-	m.batcherTxEvs.Record(TxStageFailed)
+func (m *Metrics) RecordBatchTxFailed(daType string) {
+	m.batcherTxEvs.Record(TxStageFailed, daType)
 }
 
 func (m *Metrics) RecordBlobUsedBytes(num int) {
@@ -510,4 +519,9 @@ func (m *Metrics) RecordThrottleControllerState(error, integral, derivative floa
 // RecordThrottleResponseTime records the response time of the PID controller
 func (m *Metrics) RecordThrottleResponseTime(duration time.Duration) {
 	m.pidResponseTime.Observe(duration.Seconds())
+}
+
+// RecordFailoverToEthDA records when the system fails over to EthDA
+func (m *Metrics) RecordFailoverToEthDA() {
+	m.eigenDAFailoverToEthDA.Inc()
 }

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -65,10 +65,6 @@ type Metricer interface {
 
 	RecordBlobUsedBytes(num int)
 
-	RecordBatchDaType(daType string)
-	RecordBatchDataSizeBytes(daType string, size int)
-	RecordFailoverToEthDA()
-
 	Document() []opmetrics.DocumentedMetric
 
 	PendingDABytes() float64
@@ -109,10 +105,6 @@ type Metrics struct {
 	channelInputBytesTotal  prometheus.Counter
 	channelOutputBytesTotal prometheus.Counter
 	channelQueueLength      prometheus.Gauge
-
-	batchSentDATypeTotal          prometheus.CounterVec
-	batchStoredDataSizeBytesTotal prometheus.CounterVec
-	altDaFailoverTotal            prometheus.Counter
 
 	batcherTxEvs opmetrics.EventVec
 
@@ -235,25 +227,6 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "channel_queue_length",
 			Help:      "The number of channels currently in memory.",
-		}),
-		batchSentDATypeTotal: *factory.NewCounterVec(prometheus.CounterOpts{
-			Namespace: ns,
-			Name:      "batch_sent_da_type_total",
-			Help:      "Total number of batches successfully stored, categorized by DA type.",
-		},
-			[]string{"da_type"},
-		),
-		batchStoredDataSizeBytesTotal: *factory.NewCounterVec(prometheus.CounterOpts{
-			Namespace: ns,
-			Name:      "batch_stored_data_size_bytes_total",
-			Help:      "Total batch size stored in each DA type (in bytes).",
-		},
-			[]string{"da_type"},
-		),
-		altDaFailoverTotal: factory.NewCounter(prometheus.CounterOpts{
-			Namespace: ns,
-			Name:      "alt_da_failover_total",
-			Help:      "Total number of batches that could not be stored in AltDA and were sent to L1 instead",
 		}),
 		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,
@@ -469,18 +442,6 @@ func (m *Metrics) RecordBatchTxFailed() {
 
 func (m *Metrics) RecordBlobUsedBytes(num int) {
 	m.blobUsedBytes.Observe(float64(num))
-}
-
-func (m *Metrics) RecordBatchDaType(daType string) {
-	m.batchSentDATypeTotal.With(prometheus.Labels{"da_type": daType}).Inc()
-}
-
-func (m *Metrics) RecordBatchDataSizeBytes(daType string, size int) {
-	m.batchStoredDataSizeBytesTotal.WithLabelValues(daType).Add(float64(size))
-}
-
-func (m *Metrics) RecordFailoverToEthDA() {
-	m.altDaFailoverTotal.Inc()
 }
 
 func (m *Metrics) RecordChannelQueueLength(len int) {

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -56,10 +56,10 @@ func (*noopMetrics) RecordUnsafeDABytes(int64) {}
 func (*noopMetrics) RecordThrottleControllerState(error, integral, derivative float64) {}
 func (*noopMetrics) RecordThrottleResponseTime(duration time.Duration)                 {}
 
-func (*noopMetrics) RecordBatchTxSubmitted() {}
-func (*noopMetrics) RecordBatchTxSuccess()   {}
-func (*noopMetrics) RecordBatchTxFailed()    {}
-func (*noopMetrics) RecordBlobUsedBytes(int) {}
+func (*noopMetrics) RecordBatchTxSubmitted(string) {}
+func (*noopMetrics) RecordBatchTxSuccess(string)   {}
+func (*noopMetrics) RecordBatchTxFailed(string)    {}
+func (*noopMetrics) RecordBlobUsedBytes(int)       {}
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }
@@ -78,3 +78,5 @@ func (nm *ThrottlingMetrics) PendingDABytes() float64 {
 }
 
 func (*noopMetrics) ClearAllStateMetrics() {}
+
+func (*noopMetrics) RecordFailoverToEthDA() {}

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -60,11 +60,6 @@ func (*noopMetrics) RecordBatchTxSubmitted() {}
 func (*noopMetrics) RecordBatchTxSuccess()   {}
 func (*noopMetrics) RecordBatchTxFailed()    {}
 func (*noopMetrics) RecordBlobUsedBytes(int) {}
-
-func (*noopMetrics) RecordBatchDaType(string)             {}
-func (*noopMetrics) RecordBatchDataSizeBytes(string, int) {}
-func (*noopMetrics) RecordFailoverToEthDA()               {}
-
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }


### PR DESCRIPTION
So far we used https://github.com/celo-org/optimism/commit/ea52d8570c930dce2b30a610a99f79e992428616 to add some metrics to the batcher.

There's a upstream EigenDA patch adding the same thing, in a slightly different way.

I have no strong opinion, I think either way is fine. @ezdac what do you think?