### PR TITLE
op-node/derive: Gate BPO activation per L2 chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1124,7 +1124,7 @@ jobs:
           name: Run coverage tests
           command: |
             export ETH_RPC_URL="$MAINNET_RPC_URL"
-            just coverage-lcov-all
+            just coverage-lcov
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
             ETH_RPC_URL: https://ci-mainnet-l1-archive.optimism.io
@@ -2775,17 +2775,18 @@ workflows:
               features: *features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
+      # Upgrade tests fork OP mainnet and are not relevant for Celo.
+      # - contracts-bedrock-tests-upgrade:
+      #     name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
+      #     fork_op_chain: op
+      #     fork_base_chain: mainnet
+      #     fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+      #     features: <<matrix.features>>
+      #     matrix:
+      #       parameters:
+      #         features: *features_matrix
+      #     context:
+      #       - circleci-repo-readonly-authenticated-github-token
       # - contracts-bedrock-tests-upgrade:
       #     name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
       #     fork_op_chain: <<matrix.fork_op_chain>>

--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 )
 
 // Use this command to find the pseudoversion for an op-geth commit `go list -m github.com/celo-org/op-geth@<commit-hash>`
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260122170355-ed4697ae80d7
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260210105716-cac185e09e60
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
-github.com/celo-org/op-geth v1.101411.1-0.20260122170355-ed4697ae80d7 h1:NuZsEGpKMeQiaMnratCBMViA+WtApflyJXOITQpMUCY=
-github.com/celo-org/op-geth v1.101411.1-0.20260122170355-ed4697ae80d7/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
+github.com/celo-org/op-geth v1.101411.1-0.20260210105716-cac185e09e60 h1:9Y5Z3lAuYhcMmHETNusqka/vuApAoOyr3c6SdXyoPNY=
+github.com/celo-org/op-geth v1.101411.1-0.20260210105716-cac185e09e60/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -463,6 +463,42 @@ func isJovianButNotFirstBlock(rollupCfg *rollup.Config, l2Timestamp uint64) bool
 	return rollupCfg.IsJovian(l2Timestamp) && !rollupCfg.IsJovianActivationBlock(l2Timestamp)
 }
 
+// bpoActivationBlock returns the L2 block number at which BPO hardfork support
+// is enabled for the given L2 chain. Returns nil if BPO is not yet supported.
+func bpoActivationBlock(l2ChainID uint64) *uint64 {
+	switch l2ChainID {
+	case params.CeloMainnetChainID, params.CeloSepoliaChainID, params.CeloChaosChainID:
+		return nil // BPO disabled until Jovian hardfork
+	default:
+		return uint64ptr(0) // Enable BPO by default (upstream behavior)
+	}
+}
+
+// stripBPOActivations returns a copy of the L1 chain config with BPO and Osaka
+// activation times removed, so blob fee calculations use pre-BPO parameters.
+func stripBPOActivations(l1ChainConfig *params.ChainConfig) *params.ChainConfig {
+	cfg := *l1ChainConfig
+	cfg.OsakaTime = nil
+	cfg.BPO1Time = nil
+	cfg.BPO2Time = nil
+	cfg.BPO3Time = nil
+	cfg.BPO4Time = nil
+	cfg.BPO5Time = nil
+	if cfg.BlobScheduleConfig != nil {
+		bsc := *cfg.BlobScheduleConfig
+		bsc.Osaka = nil
+		bsc.BPO1 = nil
+		bsc.BPO2 = nil
+		bsc.BPO3 = nil
+		bsc.BPO4 = nil
+		bsc.BPO5 = nil
+		cfg.BlobScheduleConfig = &bsc
+	}
+	return &cfg
+}
+
+func uint64ptr(n uint64) *uint64 { return &n }
+
 // L1BlockInfoFromBytes is the inverse of L1InfoDeposit, to see where the L2 chain is derived from
 func L1BlockInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []byte) (*L1BlockInfo, error) {
 	var info L1BlockInfo
@@ -497,7 +533,13 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 
 	// 1. Set all fields according to active forks
 	if isEcotoneActivated {
-		l1BlockInfo.BlobBaseFee = block.BlobBaseFee(l1ChainConfig)
+		l1Cfg := l1ChainConfig
+		if rollupCfg.L2ChainID != nil && rollupCfg.L2ChainID.IsUint64() {
+			if bpoActivationBlock(rollupCfg.L2ChainID.Uint64()) == nil {
+				l1Cfg = stripBPOActivations(l1ChainConfig)
+			}
+		}
+		l1BlockInfo.BlobBaseFee = block.BlobBaseFee(l1Cfg)
 
 		// Apply Cancun blob base fee calculation if this chain needs the L1 Pectra
 		// blob schedule fix (mostly Holesky and Sepolia OP-Stack chains).

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"context"
 	crand "crypto/rand"
 	"math/big"
 	"math/rand"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
@@ -275,5 +277,122 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		require.False(t, depTx.IsSystemTransaction)
 		require.Equal(t, depTx.Gas, uint64(RegolithSystemTxGas))
 		require.Equal(t, L1InfoJovianLen, len(depTx.Data))
+	})
+}
+
+// TestBlobBaseFeeFromSepolia fetches a real Sepolia L1 block header via RPC and verifies
+// that the derived BlobBaseFee matches a known BlobBaseFee.
+func TestBlobBaseFeeFromSepolia(t *testing.T) {
+	rpcURL := "https://ethereum-sepolia-rpc.publicnode.com"
+
+	client, err := ethclient.Dial(rpcURL)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx := context.Background()
+	header, err := client.HeaderByNumber(ctx, big.NewInt(10253939)) // This block proved problematic when running jovian snap sync tests.
+	require.NoError(t, err)
+
+	blockInfo := eth.HeaderBlockInfo(header)
+	derivedBlobBaseFee := blockInfo.BlobBaseFee(params.SepoliaChainConfig)
+	expected, ok := new(big.Int).SetString("45441352348192177559", 10) // The blob base fee in the corresponding l2 block (17727223)
+	require.True(t, ok)
+	require.Equal(t, expected, derivedBlobBaseFee)
+}
+func TestBpoActivationBlock(t *testing.T) {
+	t.Run("celo mainnet returns nil", func(t *testing.T) {
+		assert.Nil(t, bpoActivationBlock(params.CeloMainnetChainID))
+	})
+	t.Run("celo sepolia returns nil", func(t *testing.T) {
+		assert.Nil(t, bpoActivationBlock(params.CeloSepoliaChainID))
+	})
+	t.Run("celo chaos returns nil", func(t *testing.T) {
+		assert.Nil(t, bpoActivationBlock(params.CeloChaosChainID))
+	})
+	t.Run("default chain returns zero", func(t *testing.T) {
+		result := bpoActivationBlock(999)
+		require.NotNil(t, result)
+		assert.Equal(t, uint64(0), *result)
+	})
+	t.Run("op mainnet returns zero", func(t *testing.T) {
+		result := bpoActivationBlock(10)
+		require.NotNil(t, result)
+		assert.Equal(t, uint64(0), *result)
+	})
+}
+
+func TestStripBPOActivations(t *testing.T) {
+	osakaTime := uint64(1000)
+	bpo1Time := uint64(2000)
+	bpo2Time := uint64(3000)
+	bpo3Time := uint64(4000)
+	bpo4Time := uint64(5000)
+	bpo5Time := uint64(6000)
+	pragueTime := uint64(500)
+
+	t.Run("strips osaka and bpo times", func(t *testing.T) {
+		cfg := &params.ChainConfig{
+			OsakaTime:  &osakaTime,
+			BPO1Time:   &bpo1Time,
+			BPO2Time:   &bpo2Time,
+			BPO3Time:   &bpo3Time,
+			BPO4Time:   &bpo4Time,
+			BPO5Time:   &bpo5Time,
+			PragueTime: &pragueTime,
+			BlobScheduleConfig: &params.BlobScheduleConfig{
+				Osaka:  &params.BlobConfig{Target: 6, Max: 9},
+				BPO1:   &params.BlobConfig{Target: 8, Max: 12},
+				BPO2:   &params.BlobConfig{Target: 10, Max: 15},
+				BPO3:   &params.BlobConfig{Target: 12, Max: 18},
+				BPO4:   &params.BlobConfig{Target: 14, Max: 21},
+				BPO5:   &params.BlobConfig{Target: 16, Max: 24},
+				Prague: &params.BlobConfig{Target: 3, Max: 6},
+			},
+		}
+
+		result := stripBPOActivations(cfg)
+
+		// BPO/Osaka times should be nil
+		assert.Nil(t, result.OsakaTime)
+		assert.Nil(t, result.BPO1Time)
+		assert.Nil(t, result.BPO2Time)
+		assert.Nil(t, result.BPO3Time)
+		assert.Nil(t, result.BPO4Time)
+		assert.Nil(t, result.BPO5Time)
+
+		// Other times should be preserved
+		require.NotNil(t, result.PragueTime)
+		assert.Equal(t, pragueTime, *result.PragueTime)
+
+		// BlobScheduleConfig BPO/Osaka entries should be nil
+		require.NotNil(t, result.BlobScheduleConfig)
+		assert.Nil(t, result.BlobScheduleConfig.Osaka)
+		assert.Nil(t, result.BlobScheduleConfig.BPO1)
+		assert.Nil(t, result.BlobScheduleConfig.BPO2)
+		assert.Nil(t, result.BlobScheduleConfig.BPO3)
+		assert.Nil(t, result.BlobScheduleConfig.BPO4)
+		assert.Nil(t, result.BlobScheduleConfig.BPO5)
+
+		// Other BlobScheduleConfig entries should be preserved
+		require.NotNil(t, result.BlobScheduleConfig.Prague)
+		assert.Equal(t, 3, result.BlobScheduleConfig.Prague.Target)
+
+		// Original should be unmodified
+		require.NotNil(t, cfg.OsakaTime)
+		assert.Equal(t, osakaTime, *cfg.OsakaTime)
+		require.NotNil(t, cfg.BlobScheduleConfig.Osaka)
+	})
+
+	t.Run("nil blob schedule config is safe", func(t *testing.T) {
+		cfg := &params.ChainConfig{
+			OsakaTime:          &osakaTime,
+			BPO1Time:           &bpo1Time,
+			BlobScheduleConfig: nil,
+		}
+
+		result := stripBPOActivations(cfg)
+		assert.Nil(t, result.OsakaTime)
+		assert.Nil(t, result.BPO1Time)
+		assert.Nil(t, result.BlobScheduleConfig)
 	})
 }

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -1,7 +1,6 @@
 package derive
 
 import (
-	"context"
 	crand "crypto/rand"
 	"math/big"
 	"math/rand"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
@@ -280,25 +278,29 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 	})
 }
 
-// TestBlobBaseFeeFromSepolia fetches a real Sepolia L1 block header via RPC and verifies
-// that the derived BlobBaseFee matches a known BlobBaseFee.
-func TestBlobBaseFeeFromSepolia(t *testing.T) {
-	rpcURL := "https://ethereum-sepolia-rpc.publicnode.com"
+// TestStripBPOBlobBaseFee verifies that stripBPOActivations produces the BlobBaseFee
+// matching the actual Celo Sepolia L2 block (derived before BPO was known).
+// Uses data from Sepolia L1 block 10253939 / Celo Sepolia L2 block 17727223.
+func TestStripBPOBlobBaseFee(t *testing.T) {
+	// Sepolia L1 block 10253939 header data (post-BPO2 activation).
+	excessBlobGas := uint64(226664020)
+	blockTime := uint64(1771010016)
 
-	client, err := ethclient.Dial(rpcURL)
-	require.NoError(t, err)
-	defer client.Close()
+	blockInfo := eth.HeaderBlockInfo(&types.Header{
+		Time:          blockTime,
+		ExcessBlobGas: &excessBlobGas,
+	})
 
-	ctx := context.Background()
-	header, err := client.HeaderByNumber(ctx, big.NewInt(10253939)) // This block proved problematic when running jovian snap sync tests.
-	require.NoError(t, err)
-
-	blockInfo := eth.HeaderBlockInfo(header)
-	derivedBlobBaseFee := blockInfo.BlobBaseFee(params.SepoliaChainConfig)
-	expected, ok := new(big.Int).SetString("45441352348192177559", 10) // The blob base fee in the corresponding l2 block (17727223)
+	// With BPO-stripped config, the blob base fee should match the value in the
+	// corresponding Celo Sepolia L2 block (17727223), which was derived using
+	// Prague blob parameters (before BPO was activated on the L2).
+	strippedCfg := stripBPOActivations(params.SepoliaChainConfig)
+	derivedBlobBaseFee := blockInfo.BlobBaseFee(strippedCfg)
+	expected, ok := new(big.Int).SetString("45441352348192177559", 10)
 	require.True(t, ok)
 	require.Equal(t, expected, derivedBlobBaseFee)
 }
+
 func TestBpoActivationBlock(t *testing.T) {
 	t.Run("celo mainnet returns nil", func(t *testing.T) {
 		assert.Nil(t, bpoActivationBlock(params.CeloMainnetChainID))


### PR DESCRIPTION
## Summary

- Gate BPO/Osaka blob fee formula in `L1InfoDeposit` per L2 chain, matching [celo-kona PR #121](https://github.com/celo-org/celo-kona/pull/121)
- Disable BPO for Celo chains (mainnet, sepolia, chaos) so blob base fee uses pre-BPO parameters until Jovian hardfork
- Preserve default upstream behavior (BPO enabled) for all other chains

Closes https://github.com/celo-org/celo-blockchain-planning/issues/1301
Closes https://github.com/celo-org/celo-blockchain-planning/issues/1343