### PR TITLE
Audit fix: CGT vs Lockbox.

### DIFF
--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -262,6 +262,12 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = internalRequire(_sysCfg.operatorFeeConstant() == 0, "SYSCON-120", _errors);
         _errors = internalRequire(getProxyAdmin(address(_sysCfg)) == _admin, "SYSCON-130", _errors);
         _errors = internalRequire(_sysCfg.superchainConfig() == superchainConfig, "SYSCON-140", _errors);
+
+        // CGT prevents Lockbox
+        if (_sysCfg.isCustomGasToken()) {
+            _errors = internalRequire(!_sysCfg.isFeatureEnabled(Features.ETH_LOCKBOX), "SYSCON-150", _errors);
+        }
+
         return _errors;
     }
 
@@ -444,6 +450,8 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = internalRequire(getProxyAdmin(address(_lockbox)) == _admin, "LOCKBOX-30", _errors);
         _errors = internalRequire(_lockbox.systemConfig() == _sysCfg, "LOCKBOX-40", _errors);
         _errors = internalRequire(_lockbox.authorizedPortals(_portal), "LOCKBOX-50", _errors);
+        // Lockbox is not compatible with CGT
+        _errors = internalRequire(!_sysCfg.isCustomGasToken(), "LOCKBOX-60", _errors);
         return _errors;
     }
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -792,7 +792,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Checks if the ETHLockbox feature is enabled.
     /// @return bool True if the ETHLockbox feature is enabled.
     function _isUsingLockbox() internal view returns (bool) {
-        return systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(ethLockbox) != address(0);
+        // CGT prevents Lockbox
+        (address token,) = gasPayingToken();
+        return token == Constants.ETHER && systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(ethLockbox) != address(0);
     }
 
     /// @notice Asserts that the contract is not paused.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -15,7 +15,6 @@ import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -581,6 +581,11 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         // Features can only be set by the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
+        // Prevent Lockbox on CGT chains
+        if (_enabled && _feature == Features.ETH_LOCKBOX && isCustomGasToken()) {
+            revert SystemConfig_InvalidFeatureState();
+        }
+
         // As a sanity check, prevent users from enabling the feature if already enabled or
         // disabling the feature if already disabled. This helps to prevent accidental misuse.
         if (_enabled == isFeatureEnabled[_feature]) {

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -3373,3 +3373,26 @@ contract OptimismPortal2WithMockERC20_Test is OptimismPortal2_FinalizeWithdrawal
         optimismPortal2.depositERC20Transaction(address(0), 0, 0, 0, false, "");
     }
 }
+
+/// @title OptimismPortal2_CGTLockboxGuard_Test
+/// @notice Lockbox must stay inactive on CGT chains.
+contract OptimismPortal2_CGTLockboxGuard_Test is OptimismPortal2_TestInit {
+    /// @notice Deposit on a CGT chain never calls lockETH, even with lockbox force-enabled.
+    function test_deposit_customGasToken_skipsLockbox_succeeds() external {
+        forceEnableLockbox(address(ethLockbox));
+
+        // Mock CGT
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(systemConfig.gasPayingToken, ()),
+            abi.encode(address(42), uint8(18))
+        );
+
+        // lockETH must NOT be called
+        vm.expectCall(address(ethLockbox), abi.encodeCall(ethLockbox.lockETH, ()), 0);
+
+        // Deposit with msg.value = 0
+        vm.prank(alice, alice);
+        optimismPortal2.depositTransaction(address(0xbeef), 0, 100_000, false, "");
+    }
+}

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -1037,6 +1037,25 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     }
 }
 
+/// @title SystemConfig_SetFeature_CustomGasToken_Test
+/// @notice Validates that ETH_LOCKBOX cannot be enabled on a Custom Gas Token chain.
+contract SystemConfig_SetFeature_CustomGasToken_Test is SystemConfig_Init_CustomGasToken {
+    /// @notice Enabling ETH_LOCKBOX on a CGT chain must revert.
+    function test_setFeature_ethLockboxOnCGTChain_reverts() external {
+        vm.prank(address(systemConfig.proxyAdmin()));
+        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+    }
+
+    /// @notice Non-lockbox features remain unaffected on CGT chains.
+    function test_setFeature_nonLockboxFeatureOnCGTChain_succeeds() external {
+        bytes32 otherFeature = "OTHER_FEATURE";
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.setFeature(otherFeature, true);
+        assertTrue(systemConfig.isFeatureEnabled(otherFeature));
+    }
+}
+
 /// @title SystemConfig_IsFeatureEnabled_Test
 /// @notice Test contract for SystemConfig `isFeatureEnabled` function.
 contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {


### PR DESCRIPTION
Fixes `[M-01] OptimismPortal2#finalizeWithdrawalTransactionExternalProof - ETHLockbox Misaccounting With Custom Gas Token Withdrawals`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit/withdrawal lockbox gating and feature-flag behavior in core L1 contracts; incorrect assumptions about gas-paying token reporting or feature state could affect ETH handling on affected networks.
> 
> **Overview**
> Prevents ETHLockbox usage on Custom Gas Token (CGT) chains to address misaccounting risk: `OptimismPortal2._isUsingLockbox()` now requires the gas-paying token to be ETH, and `SystemConfig.setFeature()` reverts if `Features.ETH_LOCKBOX` is enabled while `isCustomGasToken()`.
> 
> Adds configuration/upgrade-time guardrails by extending `OPContractsManagerStandardValidator` to assert lockbox is disabled on CGT chains and to reject lockbox validation if CGT is detected, plus new tests covering the CGT lockbox skip behavior and the feature-flag enablement revert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc0261a91eccd87b415ae476310bfbe5f490d989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->