### PR TITLE
Refactor bpo hardfork gating

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -465,7 +465,7 @@ func isJovianButNotFirstBlock(rollupCfg *rollup.Config, l2Timestamp uint64) bool
 
 // bpoActivationBlock returns the L2 block number at which BPO hardfork support
 // is enabled for the given L2 chain. Returns nil if BPO is not yet supported.
-func isPreJovialCeloChain(rollupCfg *rollup.Config, l2BlockTimestamp uint64) bool {
+func isPreJovianCeloChain(rollupCfg *rollup.Config, l2BlockTimestamp uint64) bool {
 	if rollupCfg.L2ChainID == nil || !rollupCfg.L2ChainID.IsUint64() {
 		return false
 	}
@@ -477,8 +477,8 @@ func isPreJovialCeloChain(rollupCfg *rollup.Config, l2BlockTimestamp uint64) boo
 	}
 }
 
-// stripPreJovialBPOActivations strips the BPO activations from the given chain config.
-func stripPreJovialBPOActivations(l1Cfg *params.ChainConfig) *params.ChainConfig {
+// stripPreJovianBPOActivations strips the BPO activations from the given chain config.
+func stripPreJovianBPOActivations(l1Cfg *params.ChainConfig) *params.ChainConfig {
 	cfg := *l1Cfg
 	cfg.OsakaTime = nil
 	cfg.BPO1Time = nil
@@ -538,8 +538,8 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 		// blob schedules and timestamps that op-node ignored at the time.
 		// bpo3+ are intentionally omitted since Jovian is expected to activate on all Celo chains
 		// before bpo3 is scheduled on any L1 network.
-		if isPreJovialCeloChain(rollupCfg, l2Timestamp) {
-			l1Cfg = stripPreJovialBPOActivations(l1Cfg)
+		if isPreJovianCeloChain(rollupCfg, l2Timestamp) {
+			l1Cfg = stripPreJovianBPOActivations(l1Cfg)
 		}
 		l1BlockInfo.BlobBaseFee = block.BlobBaseFee(l1Cfg)
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -465,33 +465,29 @@ func isJovianButNotFirstBlock(rollupCfg *rollup.Config, l2Timestamp uint64) bool
 
 // bpoActivationBlock returns the L2 block number at which BPO hardfork support
 // is enabled for the given L2 chain. Returns nil if BPO is not yet supported.
-func bpoActivationBlock(l2ChainID uint64) *uint64 {
-	switch l2ChainID {
+func isPreJovialCeloChain(rollupCfg *rollup.Config, l2BlockTimestamp uint64) bool {
+	if rollupCfg.L2ChainID == nil || !rollupCfg.L2ChainID.IsUint64() {
+		return false
+	}
+	switch rollupCfg.L2ChainID.Uint64() {
 	case params.CeloMainnetChainID, params.CeloSepoliaChainID, params.CeloChaosChainID:
-		return nil // BPO disabled until Jovian hardfork
+		return !rollupCfg.IsJovian(l2BlockTimestamp)
 	default:
-		return uint64ptr(0) // Enable BPO by default (upstream behavior)
+		return false
 	}
 }
 
-// stripBPOActivations returns a copy of the L1 chain config with BPO and Osaka
-// activation times removed, so blob fee calculations use pre-BPO parameters.
-func stripBPOActivations(l1ChainConfig *params.ChainConfig) *params.ChainConfig {
-	cfg := *l1ChainConfig
+// stripPreJovialBPOActivations strips the BPO activations from the given chain config.
+func stripPreJovialBPOActivations(l1Cfg *params.ChainConfig) *params.ChainConfig {
+	cfg := *l1Cfg
 	cfg.OsakaTime = nil
 	cfg.BPO1Time = nil
 	cfg.BPO2Time = nil
-	cfg.BPO3Time = nil
-	cfg.BPO4Time = nil
-	cfg.BPO5Time = nil
 	if cfg.BlobScheduleConfig != nil {
 		bsc := *cfg.BlobScheduleConfig
 		bsc.Osaka = nil
 		bsc.BPO1 = nil
 		bsc.BPO2 = nil
-		bsc.BPO3 = nil
-		bsc.BPO4 = nil
-		bsc.BPO5 = nil
 		cfg.BlobScheduleConfig = &bsc
 	}
 	return &cfg
@@ -534,10 +530,16 @@ func L1InfoDeposit(rollupCfg *rollup.Config, l1ChainConfig *params.ChainConfig, 
 	// 1. Set all fields according to active forks
 	if isEcotoneActivated {
 		l1Cfg := l1ChainConfig
-		if rollupCfg.L2ChainID != nil && rollupCfg.L2ChainID.IsUint64() {
-			if bpoActivationBlock(rollupCfg.L2ChainID.Uint64()) == nil {
-				l1Cfg = stripBPOActivations(l1ChainConfig)
-			}
+
+		// BPO (Blob Parameter Only) hardforks introduce changes to blob gas pricing that require
+		// corresponding support in op-node. For Celo chains, BPO must be disabled until the Jovian
+		// hardfork is activated, because Celo's op-node did not support these L1 hardfork changes
+		// early enough. Enabling BPO prematurely would cause the derivation pipeline to use
+		// blob schedules and timestamps that op-node ignored at the time.
+		// bpo3+ are intentionally omitted since Jovian is expected to activate on all Celo chains
+		// before bpo3 is scheduled on any L1 network.
+		if isPreJovialCeloChain(rollupCfg, l2Timestamp) {
+			l1Cfg = stripPreJovialBPOActivations(l1Cfg)
 		}
 		l1BlockInfo.BlobBaseFee = block.BlobBaseFee(l1Cfg)
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -493,8 +493,6 @@ func stripPreJovianBPOActivations(l1Cfg *params.ChainConfig) *params.ChainConfig
 	return &cfg
 }
 
-func uint64ptr(n uint64) *uint64 { return &n }
-
 // L1BlockInfoFromBytes is the inverse of L1InfoDeposit, to see where the L2 chain is derived from
 func L1BlockInfoFromBytes(rollupCfg *rollup.Config, l2BlockTime uint64, data []byte) (*L1BlockInfo, error) {
 	var info L1BlockInfo

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -294,32 +294,32 @@ func TestStripBPOBlobBaseFee(t *testing.T) {
 	// With BPO-stripped config, the blob base fee should match the value in the
 	// corresponding Celo Sepolia L2 block (17727223), which was derived using
 	// Prague blob parameters (before BPO was activated on the L2).
-	strippedCfg := stripPreJovialBPOActivations(params.SepoliaChainConfig)
+	strippedCfg := stripPreJovianBPOActivations(params.SepoliaChainConfig)
 	derivedBlobBaseFee := blockInfo.BlobBaseFee(strippedCfg)
 	expected, ok := new(big.Int).SetString("45441352348192177559", 10)
 	require.True(t, ok)
 	require.Equal(t, expected, derivedBlobBaseFee)
 }
 
-func TestIsPreJovialCeloChain(t *testing.T) {
+func TestIsPreJovianCeloChain(t *testing.T) {
 	t.Run("celo mainnet returns true at block 0", func(t *testing.T) {
-		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloMainnetChainID)}, 0))
+		assert.True(t, isPreJovianCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloMainnetChainID)}, 0))
 	})
 	t.Run("celo sepolia returns true at block 0", func(t *testing.T) {
-		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloSepoliaChainID)}, 0))
+		assert.True(t, isPreJovianCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloSepoliaChainID)}, 0))
 	})
 	t.Run("celo chaos returns true at block 0", func(t *testing.T) {
-		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloChaosChainID)}, 0))
+		assert.True(t, isPreJovianCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloChaosChainID)}, 0))
 	})
 	t.Run("default chain returns false at block 0", func(t *testing.T) {
-		assert.False(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(999)}, 0))
+		assert.False(t, isPreJovianCeloChain(&rollup.Config{L2ChainID: big.NewInt(999)}, 0))
 	})
 	t.Run("op mainnet returns false at block 0", func(t *testing.T) {
-		assert.False(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(10)}, 0))
+		assert.False(t, isPreJovianCeloChain(&rollup.Config{L2ChainID: big.NewInt(10)}, 0))
 	})
 }
 
-func TestStripPreJovialBPOActivations(t *testing.T) {
+func TestStripPreJovianBPOActivations(t *testing.T) {
 	osakaTime := uint64(1000)
 	bpo1Time := uint64(2000)
 	bpo2Time := uint64(3000)
@@ -347,7 +347,7 @@ func TestStripPreJovialBPOActivations(t *testing.T) {
 				Prague: &params.BlobConfig{Target: 3, Max: 6},
 			},
 		}
-		stripped := stripPreJovialBPOActivations(cfg)
+		stripped := stripPreJovianBPOActivations(cfg)
 
 		// BPO/Osaka times should be nil
 		assert.Nil(t, stripped.OsakaTime)
@@ -389,7 +389,7 @@ func TestStripPreJovialBPOActivations(t *testing.T) {
 			BlobScheduleConfig: nil,
 		}
 
-		stripped := stripPreJovialBPOActivations(cfg)
+		stripped := stripPreJovianBPOActivations(cfg)
 		assert.Nil(t, stripped.OsakaTime)
 		assert.Nil(t, stripped.BPO1Time)
 		assert.Nil(t, stripped.BlobScheduleConfig)

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -294,36 +294,32 @@ func TestStripBPOBlobBaseFee(t *testing.T) {
 	// With BPO-stripped config, the blob base fee should match the value in the
 	// corresponding Celo Sepolia L2 block (17727223), which was derived using
 	// Prague blob parameters (before BPO was activated on the L2).
-	strippedCfg := stripBPOActivations(params.SepoliaChainConfig)
+	strippedCfg := stripPreJovialBPOActivations(params.SepoliaChainConfig)
 	derivedBlobBaseFee := blockInfo.BlobBaseFee(strippedCfg)
 	expected, ok := new(big.Int).SetString("45441352348192177559", 10)
 	require.True(t, ok)
 	require.Equal(t, expected, derivedBlobBaseFee)
 }
 
-func TestBpoActivationBlock(t *testing.T) {
-	t.Run("celo mainnet returns nil", func(t *testing.T) {
-		assert.Nil(t, bpoActivationBlock(params.CeloMainnetChainID))
+func TestIsPreJovialCeloChain(t *testing.T) {
+	t.Run("celo mainnet returns true at block 0", func(t *testing.T) {
+		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloMainnetChainID)}, 0))
 	})
-	t.Run("celo sepolia returns nil", func(t *testing.T) {
-		assert.Nil(t, bpoActivationBlock(params.CeloSepoliaChainID))
+	t.Run("celo sepolia returns true at block 0", func(t *testing.T) {
+		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloSepoliaChainID)}, 0))
 	})
-	t.Run("celo chaos returns nil", func(t *testing.T) {
-		assert.Nil(t, bpoActivationBlock(params.CeloChaosChainID))
+	t.Run("celo chaos returns true at block 0", func(t *testing.T) {
+		assert.True(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(params.CeloChaosChainID)}, 0))
 	})
-	t.Run("default chain returns zero", func(t *testing.T) {
-		result := bpoActivationBlock(999)
-		require.NotNil(t, result)
-		assert.Equal(t, uint64(0), *result)
+	t.Run("default chain returns false at block 0", func(t *testing.T) {
+		assert.False(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(999)}, 0))
 	})
-	t.Run("op mainnet returns zero", func(t *testing.T) {
-		result := bpoActivationBlock(10)
-		require.NotNil(t, result)
-		assert.Equal(t, uint64(0), *result)
+	t.Run("op mainnet returns false at block 0", func(t *testing.T) {
+		assert.False(t, isPreJovialCeloChain(&rollup.Config{L2ChainID: big.NewInt(10)}, 0))
 	})
 }
 
-func TestStripBPOActivations(t *testing.T) {
+func TestStripPreJovialBPOActivations(t *testing.T) {
 	osakaTime := uint64(1000)
 	bpo1Time := uint64(2000)
 	bpo2Time := uint64(3000)
@@ -351,38 +347,39 @@ func TestStripBPOActivations(t *testing.T) {
 				Prague: &params.BlobConfig{Target: 3, Max: 6},
 			},
 		}
-
-		result := stripBPOActivations(cfg)
+		stripped := stripPreJovialBPOActivations(cfg)
 
 		// BPO/Osaka times should be nil
-		assert.Nil(t, result.OsakaTime)
-		assert.Nil(t, result.BPO1Time)
-		assert.Nil(t, result.BPO2Time)
-		assert.Nil(t, result.BPO3Time)
-		assert.Nil(t, result.BPO4Time)
-		assert.Nil(t, result.BPO5Time)
+		assert.Nil(t, stripped.OsakaTime)
+		assert.Nil(t, stripped.BPO1Time)
+		assert.Nil(t, stripped.BPO2Time)
 
 		// Other times should be preserved
-		require.NotNil(t, result.PragueTime)
-		assert.Equal(t, pragueTime, *result.PragueTime)
+		assert.NotNil(t, stripped.BPO3Time)
+		assert.NotNil(t, stripped.BPO4Time)
+		assert.NotNil(t, stripped.BPO5Time)
+		assert.NotNil(t, stripped.PragueTime)
 
 		// BlobScheduleConfig BPO/Osaka entries should be nil
-		require.NotNil(t, result.BlobScheduleConfig)
-		assert.Nil(t, result.BlobScheduleConfig.Osaka)
-		assert.Nil(t, result.BlobScheduleConfig.BPO1)
-		assert.Nil(t, result.BlobScheduleConfig.BPO2)
-		assert.Nil(t, result.BlobScheduleConfig.BPO3)
-		assert.Nil(t, result.BlobScheduleConfig.BPO4)
-		assert.Nil(t, result.BlobScheduleConfig.BPO5)
+		require.NotNil(t, stripped.BlobScheduleConfig)
+		assert.Nil(t, stripped.BlobScheduleConfig.Osaka)
+		assert.Nil(t, stripped.BlobScheduleConfig.BPO1)
+		assert.Nil(t, stripped.BlobScheduleConfig.BPO2)
 
 		// Other BlobScheduleConfig entries should be preserved
-		require.NotNil(t, result.BlobScheduleConfig.Prague)
-		assert.Equal(t, 3, result.BlobScheduleConfig.Prague.Target)
+		assert.NotNil(t, stripped.BlobScheduleConfig.BPO3)
+		assert.NotNil(t, stripped.BlobScheduleConfig.BPO4)
+		assert.NotNil(t, stripped.BlobScheduleConfig.BPO5)
+		require.NotNil(t, stripped.BlobScheduleConfig.Prague)
 
 		// Original should be unmodified
 		require.NotNil(t, cfg.OsakaTime)
-		assert.Equal(t, osakaTime, *cfg.OsakaTime)
+		require.NotNil(t, cfg.BlobScheduleConfig)
 		require.NotNil(t, cfg.BlobScheduleConfig.Osaka)
+		require.NotNil(t, cfg.BPO1Time)
+		require.NotNil(t, cfg.BlobScheduleConfig.BPO1)
+		require.NotNil(t, cfg.BPO2Time)
+		require.NotNil(t, cfg.BlobScheduleConfig.BPO2)
 	})
 
 	t.Run("nil blob schedule config is safe", func(t *testing.T) {
@@ -392,9 +389,9 @@ func TestStripBPOActivations(t *testing.T) {
 			BlobScheduleConfig: nil,
 		}
 
-		result := stripBPOActivations(cfg)
-		assert.Nil(t, result.OsakaTime)
-		assert.Nil(t, result.BPO1Time)
-		assert.Nil(t, result.BlobScheduleConfig)
+		stripped := stripPreJovialBPOActivations(cfg)
+		assert.Nil(t, stripped.OsakaTime)
+		assert.Nil(t, stripped.BPO1Time)
+		assert.Nil(t, stripped.BlobScheduleConfig)
 	})
 }


### PR DESCRIPTION
The previous implementation was broken since it was using block numbers to determine if jovian was active, but in fact jovian is activated by timestamp. Thanks to @seolaoh for pointing this out.