### PR TITLE
Refactor Celo hardfork overrides to use nil-guarded defaults

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -293,38 +293,42 @@ func applyOverrides(ctx cliiface.Context, rollupConfig *rollup.Config) {
 	}
 }
 
-// applyCeloHardforks modifies the rollupConfig to apply Celo-specific hardforks.
-// This code is a shortcut and the proper config should be added to the superchain registry.
-// See https://github.com/celo-org/op-geth/issues/389
+// applyCeloHardforks fills in hardfork activation times that may be missing from the
+// superchain registry or rollup config file. Values already set (by registry or file)
+// are not overwritten, and CLI --override.<fork> flags applied afterwards always win.
+// This is a temporary measure until the superchain registry is fully up to date.
+// See https://github.com/celo-org/celo-blockchain-planning/issues/1346
 func applyCeloHardforks(rollupConfig *rollup.Config) {
 	switch rollupConfig.L2ChainID.Uint64() {
 	case params.CeloMainnetChainID:
 		activationTime := params.CeloMainnetIsthmusTimestamp
-		rollupConfig.HoloceneTime = &activationTime
-		rollupConfig.IsthmusTime = &activationTime
-
-		// It seems we didn't need this to be set, since at the time of mainnet launch we were already
-		// using a version of optimism that used a version of op-geth that correctly handled the Pectra
-		// blob fee calculations. The addition of this flag means that we have been calculating the
-		// blobBaseFee (stored in the l1 info contract) with the Cancun parameters up until this the flag time.
-		// So from Prage mainnet activation on May 7th 2025 up until The isthmus time on Jul 9th 2025
-		// we've been using the Cancun parametrs and incorrectly calculating the blobBaseFee.
-		//
-		// We can check with the following commands, looking at a celo block ocurring on May 23rd 2025:
-		// ❯ cast call 0x4200000000000000000000000000000000000015 "blobBaseFee()" -r https://forno.celo.org 36066500 | cast to-dec
-		// 6449008216286192
-		//
-		// ❯ cast call 0x4200000000000000000000000000000000000015 "number()" -r https://forno.celo.org 36066500 | cast to-dec
-		// 24290057
-		//
-		// ❯ cast base-fee -r https://ethereum-rpc.publicnode.com 24290025
-		// 68041857
-		//
-		// See the below link for a description of the original bug the required the addition of the PectraBlobScheduleTime config option:
-		// https://docs.optimism.io/notices/archive/blob-fee-bug
-		rollupConfig.PectraBlobScheduleTime = &activationTime
-	default:
-		// No Celo hardforks for other chains, do nothing.
+		if rollupConfig.HoloceneTime == nil {
+			rollupConfig.HoloceneTime = &activationTime
+		}
+		if rollupConfig.IsthmusTime == nil {
+			rollupConfig.IsthmusTime = &activationTime
+		}
+		if rollupConfig.PectraBlobScheduleTime == nil {
+			// At the time of mainnet launch we were already using a version of optimism
+			// that used a version of op-geth that correctly handled the Pectra blob fee
+			// calculations. The addition of this flag means that we have been calculating
+			// the blobBaseFee (stored in the l1 info contract) with the Cancun parameters
+			// up until this flag time. So from Prague mainnet activation on May 7th 2025
+			// up until the isthmus time on Jul 9th 2025 we've been using the Cancun
+			// parameters and incorrectly calculating the blobBaseFee.
+			//
+			// See the below link for a description of the original bug that required the
+			// addition of the PectraBlobScheduleTime config option:
+			// https://docs.optimism.io/notices/archive/blob-fee-bug
+			rollupConfig.PectraBlobScheduleTime = &activationTime
+		}
+	case params.CeloSepoliaChainID:
+		// Sepolia had isthmus active from genesis but the superchain
+		// registry config is missing the isthmus time.
+		zero := uint64(0)
+		if rollupConfig.IsthmusTime == nil {
+			rollupConfig.IsthmusTime = &zero
+		}
 	}
 }
 


### PR DESCRIPTION
Use nil-guards in applyCeloHardforks so that values already set by the superchain registry or rollup config file are not overwritten, and CLI --override.<fork> flags always win. Add Celo Sepolia isthmus override.

This approach removes our reliance on the superchain registry, since we cannot safely rely on our updates to the superchain registry being merged in a timely manner.

For this to work correctly we need to have a similar change in op-geth see https://github.com/celo-org/op-geth/pull/478

See https://github.com/celo-org/celo-blockchain-planning/issues/1346