### PR TITLE
Use config from celo's fork of superchain registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 )
 
 // Use this command to find the pseudoversion for an op-geth commit `go list -m github.com/celo-org/op-geth@<commit-hash>`
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260224115301-4a481bb6aff9
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
-github.com/celo-org/op-geth v1.101411.1-0.20260224115301-4a481bb6aff9 h1:8PqPjI+Hv7qJA3EL9zESgeU3Rj5uD7kB6+kEBPEm088=
-github.com/celo-org/op-geth v1.101411.1-0.20260224115301-4a481bb6aff9/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
+github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e h1:0eaGY5/2zKhRMlm/jADSRS/yZsjamYrgfEejWpuYXig=
+github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -104,4 +104,5 @@ func applyHardforks(cfg *Config, hardforks superchain.HardforkConfig) {
 	cfg.IsthmusTime = hardforks.IsthmusTime
 	cfg.InteropTime = hardforks.InteropTime
 	cfg.JovianTime = hardforks.JovianTime
+	cfg.Cel2Time = hardforks.Cel2Time
 }

--- a/op-node/rollup/superchain_test.go
+++ b/op-node/rollup/superchain_test.go
@@ -37,6 +37,11 @@ func requireAllHardforksSetCorrectly(t *testing.T, cfg Config, hardforkCfg super
 	cfgVal := reflect.ValueOf(&cfg).Elem()
 	for i := 0; i < hardforkVal.NumField(); i++ {
 		hardforkField := hardforkType.Field(i)
+		if hardforkField.Name == "GingerbreadBlock" {
+			// GingerbreadBlock is a chain config concept (block number, not timestamp),
+			// not a rollup config field.
+			continue
+		}
 		cfgField := cfgVal.FieldByName(hardforkField.Name)
 		require.Equalf(t, hardforkVal.Field(i).Elem(), cfgField.Elem(), "missing hard fork field %v", hardforkField.Name)
 	}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -248,7 +248,6 @@ func NewRollupConfigFromCLI(log log.Logger, ctx cliiface.Context) (*rollup.Confi
 	if err != nil {
 		return nil, err
 	}
-	applyCeloHardforks(rollupConfig)
 	applyOverrides(ctx, rollupConfig)
 	return rollupConfig, nil
 }
@@ -290,41 +289,6 @@ func applyOverrides(ctx cliiface.Context, rollupConfig *rollup.Config) {
 			timestamp := ctx.Uint64(flagName)
 			rollupConfig.SetActivationTime(fork, &timestamp)
 		}
-	}
-}
-
-// applyCeloHardforks modifies the rollupConfig to apply Celo-specific hardforks.
-// This code is a shortcut and the proper config should be added to the superchain registry.
-// See https://github.com/celo-org/op-geth/issues/389
-func applyCeloHardforks(rollupConfig *rollup.Config) {
-	switch rollupConfig.L2ChainID.Uint64() {
-	case params.CeloMainnetChainID:
-		activationTime := params.CeloMainnetIsthmusTimestamp
-		rollupConfig.HoloceneTime = &activationTime
-		rollupConfig.IsthmusTime = &activationTime
-
-		// It seems we didn't need this to be set, since at the time of mainnet launch we were already
-		// using a version of optimism that used a version of op-geth that correctly handled the Pectra
-		// blob fee calculations. The addition of this flag means that we have been calculating the
-		// blobBaseFee (stored in the l1 info contract) with the Cancun parameters up until this the flag time.
-		// So from Prage mainnet activation on May 7th 2025 up until The isthmus time on Jul 9th 2025
-		// we've been using the Cancun parametrs and incorrectly calculating the blobBaseFee.
-		//
-		// We can check with the following commands, looking at a celo block ocurring on May 23rd 2025:
-		// ❯ cast call 0x4200000000000000000000000000000000000015 "blobBaseFee()" -r https://forno.celo.org 36066500 | cast to-dec
-		// 6449008216286192
-		//
-		// ❯ cast call 0x4200000000000000000000000000000000000015 "number()" -r https://forno.celo.org 36066500 | cast to-dec
-		// 24290057
-		//
-		// ❯ cast base-fee -r https://ethereum-rpc.publicnode.com 24290025
-		// 68041857
-		//
-		// See the below link for a description of the original bug the required the addition of the PectraBlobScheduleTime config option:
-		// https://docs.optimism.io/notices/archive/blob-fee-bug
-		rollupConfig.PectraBlobScheduleTime = &activationTime
-	default:
-		// No Celo hardforks for other chains, do nothing.
 	}
 }
 


### PR DESCRIPTION
Updates op-geth to use a version with correct celo superchain registry config.

Unfortunately we still need some code changes in optimism to copy the cel2
field over into the rollup.Config struct defined in the optimism repo.

Also we need to ignore the gingerbread block in a test, as it is only
relevant for constructing the chain config in op-geth.

But we do get to get rid of our original celo hardfork overrides.

Relates to - https://github.com/celo-org/celo-blockchain-planning/issues/1346