### PR TITLE
Update to an op-geth with superchain config without gingerbread block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 )
 
 // Use this command to find the pseudoversion for an op-geth commit `go list -m github.com/celo-org/op-geth@<commit-hash>`
-replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e
+replace github.com/ethereum/go-ethereum => github.com/celo-org/op-geth v1.101411.1-0.20260303170601-25709731226d
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
-github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e h1:0eaGY5/2zKhRMlm/jADSRS/yZsjamYrgfEejWpuYXig=
-github.com/celo-org/op-geth v1.101411.1-0.20260226170727-ceddbe76099e/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
+github.com/celo-org/op-geth v1.101411.1-0.20260303170601-25709731226d h1:KKeiaLs0eyUL+RJs7AmdBxvM1i0vaY+7WybY6lY5Nts=
+github.com/celo-org/op-geth v1.101411.1-0.20260303170601-25709731226d/go.mod h1:9J7De8kDwXE/lrMgVEHc0F33TZqcN1Lb5nYaW6UZt38=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/op-node/rollup/superchain_test.go
+++ b/op-node/rollup/superchain_test.go
@@ -37,11 +37,6 @@ func requireAllHardforksSetCorrectly(t *testing.T, cfg Config, hardforkCfg super
 	cfgVal := reflect.ValueOf(&cfg).Elem()
 	for i := 0; i < hardforkVal.NumField(); i++ {
 		hardforkField := hardforkType.Field(i)
-		if hardforkField.Name == "GingerbreadBlock" {
-			// GingerbreadBlock is a chain config concept (block number, not timestamp),
-			// not a rollup config field.
-			continue
-		}
 		cfgField := cfgVal.FieldByName(hardforkField.Name)
 		require.Equalf(t, hardforkVal.Field(i).Elem(), cfgField.Elem(), "missing hard fork field %v", hardforkField.Name)
 	}


### PR DESCRIPTION
Instead of relying on the suprechain config to provide the gingerbread block, it is now hardcoded in op-geth in params/superchain.go which means the handling of the gingerbread hardfork is consistent with all other pre bedrock eth forks.

Relates to - https://github.com/celo-org/celo-blockchain-planning/issues/1346