### PR TITLE
op-node: Reduce log level for finalized block check

### DIFF
--- a/op-node/rollup/finalized/finalized.go
+++ b/op-node/rollup/finalized/finalized.go
@@ -25,7 +25,7 @@ func (f *finalized) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1B
 	if num == 0 || num <= l1Finalized.Number {
 		return f.L1Fetcher.L1BlockRefByNumber(ctx, num)
 	}
-	f.log.Warn("requested L1 block is beyond local finalized height", "requested_block", num, "finalized_block", l1Finalized.Number)
+	f.log.Debug("requested L1 block is beyond local finalized height", "requested_block", num, "finalized_block", l1Finalized.Number)
 	return eth.L1BlockRef{}, ethereum.NotFound
 }
 


### PR DESCRIPTION
## Summary
- Reduces the log level from `Warn` to `Debug` for the "requested L1 block is beyond local finalized height" message in `op-node/rollup/finalized/finalized.go`
- This message fires frequently during normal operation and is not actionable, making it noise at the `Warn` level

Fixes #425

## Test plan
- [x] Existing tests in `op-node/rollup/finalized/finalized_test.go` continue to pass
- [ ] Verify reduced log noise in staging environment
