### PR TITLE
op-node: default --l2.enginekind to reth

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2173,7 +2173,7 @@ jobs:
     parameters:
       diff_branch:
         type: string
-        default: celo-rebase-17
+        default: celo-rebase-18
       scan_command:
         type: string
         default: semgrep ci --timeout=100

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -235,7 +235,7 @@ var (
 			openum.EnumString(engine.Kinds),
 		EnvVars: prefixEnvVars("L2_ENGINE_KIND"),
 		Value: func() *engine.Kind {
-			out := engine.Geth
+			out := engine.Reth
 			return &out
 		}(),
 		Category: RollupCategory,

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -20,6 +20,10 @@ ignore = [
   # hickory-proto <0.26.1 O(n^2) name-compression CPU exhaustion in BinEncoder;
   # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
   "RUSTSEC-2026-0119",
+  # proc-macro-error2 is unmaintained (no vulnerability, no patched release exists).
+  # Build-time-only dep pulled in via alloy-sol-macro; latest alloy-core (1.6.0) and
+  # its main branch still pin it (it uses a private API), so no upgrade removes it.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cherry-picked from upstream https://github.com/ethereum-optimism/optimism/commit/811c1f686972c09c0e84541bc9e0ec597b1f79ca