### PR TITLE
ci: celo-rebase-18 CI fixes (rust-ci base branch + disable contracts checks-fast)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3242,11 +3242,17 @@ workflows:
       #       - circleci-repo-readonly-authenticated-github-token
       #       - circleci-repo-rpc-secrets
       #       - slack
-      - contracts-bedrock-checks-fast:
-          name: contracts-bedrock-checks-fast-feature-tests
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
+      # celo: disable contracts-bedrock-checks-fast. Contracts are managed on a
+      # separate branch; celo-rebase-18 is the no-contracts node/rust branch and
+      # already disables the other contracts jobs above. The op-node/v1.18.2
+      # rebase reshaped this job (new -feature-tests name + fail-closed
+      # semver-diff that needs a GitHub token from a context celo-org's CircleCI
+      # does not define), so it slipped past the disable list and 403s on PRs.
+      # - contracts-bedrock-checks-fast:
+      #     name: contracts-bedrock-checks-fast-feature-tests
+      #     context:
+      #       - circleci-repo-readonly-authenticated-github-token
+      #       - slack
       # -----------------------------------------------------------------------
       # required-contracts-ci: GitHub required status for this workflow. Terminal requires
       # keep this job scheduled even when upstream jobs fail; ci-gate then checks they passed.
@@ -3260,7 +3266,8 @@ workflows:
             # - contracts-bedrock-coverage main: terminal
             # celo: disable contracts-bedrock-tests-upgrade — job removed above.
             # - contracts-bedrock-tests-upgrade op-mainnet main: terminal
-            - contracts-bedrock-checks-fast-feature-tests: terminal
+            # celo: disable contracts-bedrock-checks-fast-feature-tests; see job above.
+            # - contracts-bedrock-checks-fast-feature-tests: terminal
           context:
             - circleci-api-token
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -641,7 +641,7 @@ jobs:
           name: Generate compact vectors from base
           command: |
             # Use the main branch as the base
-            BASE_BRANCH="celo-rebase-17"
+            BASE_BRANCH="celo-rebase-18"
 
             # Save current state
             git stash || true


### PR DESCRIPTION
Follow-up to `ci: Update CI base branch` (commit 48f89c4278), which bumped the semgrep `diff_branch` in `main.yml` to `celo-rebase-18` but missed the `op-reth-compact-codec` job in `rust-ci.yml`. That job still pinned `celo-rebase-17` as the base it generates the reth Compact-codec test vectors from, so on `celo-rebase-18` PRs the backwards-compat check (a required `rust-ci` gate) was comparing against the wrong, old baseline.

The job exercises this repo's upstream op-reth, not the celo-reth node we actually run (it lives in a separate repo), so it doesn't gate anything we ship. It's still worth keeping correct: as a required rust-ci check, a stale base branch either silently compares against the wrong baseline or fails spuriously and blocks every celo-rebase-18 PR. The fix is cheap and correct regardless of whether we later decide to drop the op-reth jobs altogether.

Also disables contracts-bedrock-checks-fast, which the op-node/v1.18.2 rebase reshaped (fail-closed semver-diff needing a GitHub token from a context celo-org's CircleCI does not define). celo-rebase-18 is the no-contracts branch and already disables the other contracts jobs, so this just completes that.