### PR TITLE
ci: disable nightly build-images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,9 +22,9 @@ on:
       - '.github/workflows/build-images.yaml'
       - '.github/images.json'
       - '.github/actions/docker-build-prep/**'
-  schedule:
-    # Daily build of all images at 02:00 UTC (matches the previous CircleCI schedule).
-    - cron: '0 2 * * *'
+  # No nightly schedule on the Celo fork: this workflow publishes to Optimism Labs'
+  # registry (oplabs-tools-artifacts), which the fork has no access to. Image builds
+  # for the fork are handled by docker-build-scan.yaml. Kept for manual/upstream parity.
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What

Removes the nightly `schedule` cron from the upstream `build images` workflow on the Celo fork. Kept `workflow_dispatch` for manual/upstream parity.

## Why

The nightly run [always fails](https://github.com/celo-org/optimism/actions/runs/27663334629):

- On a `schedule` trigger the checkout forces `ref: develop` (`build-images.yaml:52`/`:95`), but on the fork `develop` is a stale upstream branch that predates the factory image pipeline and has no `.github/images.json` → the `plan` step fails with `Config file not found: .github/images.json`.
- Even past that, the `build` job publishes to Optimism Labs' registry (`oplabs-tools-artifacts`, via `vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS`) — infra the fork has no access to — so it can never succeed here.

Image builds for the fork are handled by `docker-build-scan.yaml`, which publishes to Celo's own registry. `push`/`pull_request` only target `develop` (never pushed to on the fork), so removing `schedule` stops the only trigger that actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)