### PR TITLE
op-node: reset (not retry) when a batch-auth lookback block is NotFound

### DIFF
--- a/op-node/rollup/derive/batch_authenticator.go
+++ b/op-node/rollup/derive/batch_authenticator.go
@@ -2,10 +2,12 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -156,7 +158,14 @@ func CollectAuthenticatedBatches(
 		} else {
 			// Cache miss: fetch receipts, extract events, cache the result
 			_, receipts, err := fetcher.FetchReceipts(ctx, currentBlock.Hash)
-			if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				// A block in the lookback window is no longer available, e.g. an L1
+				// reorg orphaned it. Treat this like the data sources treat a missing
+				// ref block (calldata_source.go / blob_data_source.go): signal a reset so
+				// the pipeline re-derives from a canonical origin, rather than retrying
+				// the same step forever as a temporary error.
+				return nil, NewResetError(fmt.Errorf("batch auth: receipts for block %d not found: %w", currentBlock.Number, err))
+			} else if err != nil {
 				return nil, NewTemporaryError(fmt.Errorf("batch auth: failed to fetch receipts for block %d: %w", currentBlock.Number, err))
 			}
 			events := collectAuthEventsFromReceipts(receipts, authenticatorAddr)
@@ -177,7 +186,11 @@ func CollectAuthenticatedBatches(
 			refCacheHits++
 		} else {
 			parentRef, err := fetcher.L1BlockRefByHash(ctx, parentHash)
-			if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				// See the FetchReceipts NotFound case above: a missing ancestor means the
+				// lookback window crossed a reorg, so reset rather than retry forever.
+				return nil, NewResetError(fmt.Errorf("batch auth: L1 block ref %s not found: %w", parentHash.String(), err))
+			} else if err != nil {
 				return nil, NewTemporaryError(fmt.Errorf("batch auth: failed to fetch L1 block ref %s: %w", parentHash.String(), err))
 			}
 			refCache.Add(parentHash, parentRef)

--- a/op-node/rollup/derive/espresso_batch_authenticator_test.go
+++ b/op-node/rollup/derive/espresso_batch_authenticator_test.go
@@ -2,9 +2,11 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -298,6 +300,76 @@ func TestCollectAuthenticatedBatchesBlockRefCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result2, 0)
 	l1F2.AssertExpectations(t)
+}
+
+// TestCollectAuthenticatedBatchesResetOnNotFound verifies that when an L1 block
+// in the lookback window is no longer available (FetchReceipts or L1BlockRefByHash
+// returns ethereum.NotFound, e.g. after a reorg orphaned it), CollectAuthenticatedBatches
+// returns a ResetError rather than a TemporaryError. A TemporaryError would cause the
+// pipeline to retry the same step forever (a silent stall); a ResetError makes it
+// re-derive from a canonical origin, matching how the calldata/blob data sources
+// classify a missing ref block.
+func TestCollectAuthenticatedBatchesResetOnNotFound(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelDebug)
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(9012))
+
+	authenticatorAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	emptyReceipts := types.Receipts{}
+
+	t.Run("FetchReceipts NotFound on an ancestor", func(t *testing.T) {
+		caches := NewBatchAuthCaches()
+		l1F := &testutils.MockL1Source{}
+		chain := buildL1Chain(rng, 100, 200)
+		ref := chain[200]
+
+		// Block 200 (ref) is fetched fine and its parent ref resolves, then the
+		// ancestor block 199's receipts come back NotFound.
+		l1F.ExpectFetchReceipts(chain[200].Hash, nil, emptyReceipts, nil)
+		l1F.ExpectL1BlockRefByHash(chain[199].Hash, chain[199], nil)
+		l1F.ExpectFetchReceipts(chain[199].Hash, nil, types.Receipts(nil), ethereum.NotFound)
+
+		result, err := CollectAuthenticatedBatches(ctx, l1F, ref, authenticatorAddr, caches, logger)
+		require.Nil(t, result)
+		require.ErrorIs(t, err, ErrReset)
+		require.ErrorIs(t, err, ethereum.NotFound)
+		l1F.AssertExpectations(t)
+	})
+
+	t.Run("L1BlockRefByHash NotFound on an ancestor", func(t *testing.T) {
+		caches := NewBatchAuthCaches()
+		l1F := &testutils.MockL1Source{}
+		chain := buildL1Chain(rng, 100, 200)
+		ref := chain[200]
+
+		// Block 200 (ref) is fetched fine, but resolving its parent ref (block 199)
+		// comes back NotFound.
+		l1F.ExpectFetchReceipts(chain[200].Hash, nil, emptyReceipts, nil)
+		l1F.ExpectL1BlockRefByHash(chain[199].Hash, eth.L1BlockRef{}, ethereum.NotFound)
+
+		result, err := CollectAuthenticatedBatches(ctx, l1F, ref, authenticatorAddr, caches, logger)
+		require.Nil(t, result)
+		require.ErrorIs(t, err, ErrReset)
+		require.ErrorIs(t, err, ethereum.NotFound)
+		l1F.AssertExpectations(t)
+	})
+
+	t.Run("non-NotFound error stays temporary", func(t *testing.T) {
+		caches := NewBatchAuthCaches()
+		l1F := &testutils.MockL1Source{}
+		chain := buildL1Chain(rng, 100, 200)
+		ref := chain[200]
+
+		// A transient RPC failure (not NotFound) must remain a TemporaryError so the
+		// pipeline retries rather than resetting.
+		l1F.ExpectFetchReceipts(chain[200].Hash, nil, types.Receipts(nil), errors.New("connection refused"))
+
+		result, err := CollectAuthenticatedBatches(ctx, l1F, ref, authenticatorAddr, caches, logger)
+		require.Nil(t, result)
+		require.ErrorIs(t, err, ErrTemporary)
+		require.NotErrorIs(t, err, ErrReset)
+		l1F.AssertExpectations(t)
+	})
 }
 
 func TestBatchInfoAuthenticatedABIHash(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacks on #457. `CollectAuthenticatedBatches` mis-classifies a missing L1 block in the batch-auth lookback window as a **temporary** error, which makes derivation retry the same step forever (a silent stall) instead of resetting. This PR classifies `ethereum.NotFound` as a `ResetError` at both L1 fetch sites, matching how the calldata/blob data sources already handle a missing ref block, and adds tests.

## The bug

`CollectAuthenticatedBatches` walks the L1 parent chain backward over `BatchAuthLookbackWindow` (100 blocks), calling `FetchReceipts` and `L1BlockRefByHash` on each block. Both error sites wrapped **every** error — including `ethereum.NotFound` — as `NewTemporaryError`:

```go
_, receipts, err := fetcher.FetchReceipts(ctx, currentBlock.Hash)
if err != nil {
    return nil, NewTemporaryError(fmt.Errorf("batch auth: failed to fetch receipts for block %d: %w", currentBlock.Number, err))
}
```

Both fetchers genuinely surface `ethereum.NotFound` (with the `%w` chain preserved) for an unknown/pruned/orphaned hash:
- `L1BlockRefByHash` → … → `headerCall`: `if rpcHdr == nil { return nil, ethereum.NotFound }` (`op-service/sources/eth_client.go`)
- `FetchReceipts` → … → `blockCall`: `if block == nil { return nil, nil, ethereum.NotFound }` (same file)

## Why it matters

The error level drives recovery (`deriver.go`):
- **TemporaryError** → `EngineTemporaryErrorEvent` → `RequestStep(ctx, false)` → exponential backoff with **no max-attempts**. A persistently unavailable in-window ancestor retries the same step at the same L1 origin **forever** — a silent stall, no progress, no self-recovery.
- **ResetError** → `ResetEvent` → rewind the L1 origin and re-derive from the canonical chain — the correct response to a missing/orphaned L1 block.

Independent reorg detection does **not** rescue this case. `L1Traversal.AdvanceL1Block` only validates the **single forward parent-hash link** to the next origin:

```go
if l1t.block.Hash != nextL1Origin.ParentHash {
    return NewResetError(fmt.Errorf("detected L1 reorg ..."))
}
```

It never re-verifies the deeper `[ref-100, ref-1]` window the lookback walks, so a missing deep ancestor surfaces **only** through the lookback fetch — exactly the path that mislabels it `Temporary`.

## The fix

Mirror the sibling data sources (`calldata_source.go`, `blob_data_source.go`), which already classify a `NotFound` ref block as a `ResetError`. At both fetch sites: `NotFound` → `ResetError`, everything else stays `TemporaryError`.

```go
_, receipts, err := fetcher.FetchReceipts(ctx, currentBlock.Hash)
if errors.Is(err, ethereum.NotFound) {
    return nil, NewResetError(fmt.Errorf("batch auth: receipts for block %d not found: %w", currentBlock.Number, err))
} else if err != nil {
    return nil, NewTemporaryError(fmt.Errorf("batch auth: failed to fetch receipts for block %d: %w", currentBlock.Number, err))
}
```

## Tests

`TestCollectAuthenticatedBatchesResetOnNotFound`:
- `FetchReceipts` → `NotFound` on an in-window ancestor ⇒ error is `ErrReset` (and wraps `ethereum.NotFound`).
- `L1BlockRefByHash` → `NotFound` on an ancestor ⇒ `ErrReset`.
- A non-`NotFound` transient error (`"connection refused"`) ⇒ stays `ErrTemporary`, **not** a reset.

The negative case pins the boundary so a future change can't collapse "block is gone → reset" and "RPC blip → retry" back together in either direction.

`gofmt`/`go vet` clean; the full `op-node/rollup/derive` package passes.

## Scope / caveat

Behavior-only change to the post-Espresso path; pre-fork derivation is unaffected. This converts a *persistently* missing ancestor from a silent retry-stall into a reset. If such a block is genuinely, permanently unavailable (a pruned/misconfigured L1 backend), the reset will re-occur rather than make progress — but that is the correct, house-consistent way to surface the condition (loudly, as a reorg-like reset), and it matches the existing ref-block handling; a permanently-broken L1 backend remains an operator concern either way. The common transient case self-heals under either classification.
