### PR TITLE
Report fallback auth-tx failures under a calldata-typed txRef

### DIFF
--- a/op-batcher/batcher/fallback_auth.go
+++ b/op-batcher/batcher/fallback_auth.go
@@ -43,6 +43,13 @@ func computeCommitment(candidate *txmgr.TxCandidate) ([32]byte, error) {
 // separate signature is needed — the L1 transaction is already signed by the TxManager's key.
 func (l *BatchSubmitter) sendTxWithFallbackAuth(txdata txData, isCancel bool, candidate *txmgr.TxCandidate, queue TxSender[txRef], receiptsCh chan txmgr.TxReceipt[txRef]) {
 	transactionReference := newTxRef(txdata, isCancel)
+	// The auth tx shares the batch txdata's identity (so a failure requeues the right frames)
+	// but is always a calldata tx. Auth failures must carry its real type: an ErrAlreadyReserved
+	// receipt labeled with the batch's blob type would make cancelBlockingTx cancel the wrong
+	// pool, leaving the reserving tx stuck.
+	authReference := transactionReference
+	authReference.isBlob = false
+	authReference.daType = DaTypeCalldata
 	l.Log.Debug("Sending fallback-authenticated L1 transaction", "txRef", transactionReference)
 
 	commitment, err := computeCommitment(candidate)
@@ -88,13 +95,13 @@ func (l *BatchSubmitter) sendTxWithFallbackAuth(txdata txData, isCancel bool, ca
 	// Submit the auth tx and wait for its receipt, then send the batch tx. Each Send
 	// blocks here when the queue is at its MaxPendingTransactions limit.
 	authReceiptCh := make(chan txmgr.TxReceipt[txRef], 1)
-	queue.Send(transactionReference, verifyCandidate, authReceiptCh)
+	queue.Send(authReference, verifyCandidate, authReceiptCh)
 	authResult := <-authReceiptCh
 
 	if authResult.Err != nil {
 		l.Log.Error("Failed to send fallback authenticateBatchInfo transaction", "txRef", transactionReference, "err", authResult.Err)
 		receiptsCh <- txmgr.TxReceipt[txRef]{
-			ID:  transactionReference,
+			ID:  authReference,
 			Err: fmt.Errorf("failed to send fallback authenticateBatchInfo transaction: %w", authResult.Err),
 		}
 		return
@@ -108,7 +115,7 @@ func (l *BatchSubmitter) sendTxWithFallbackAuth(txdata txData, isCancel bool, ca
 	if authResult.Receipt.Status != types.ReceiptStatusSuccessful {
 		l.Log.Error("Fallback authenticateBatchInfo transaction reverted", "txRef", transactionReference, "txHash", authResult.Receipt.TxHash)
 		receiptsCh <- txmgr.TxReceipt[txRef]{
-			ID:  transactionReference,
+			ID:  authReference,
 			Err: fmt.Errorf("fallback authenticateBatchInfo transaction reverted: %s", authResult.Receipt.TxHash),
 		}
 		return

--- a/op-batcher/batcher/fallback_auth_test.go
+++ b/op-batcher/batcher/fallback_auth_test.go
@@ -117,6 +117,61 @@ func TestFallbackAuth_AuthFailureRetried(t *testing.T) {
 	require.Len(t, queue.sends, 1)
 }
 
+// TestFallbackAuth_AuthFailureTxRefType verifies that an auth-tx failure is
+// reported under a calldata-typed txRef even when the batch txdata is blob.
+// The auth tx is always calldata; if its ErrAlreadyReserved failure were
+// labeled with the batch's blob type, cancelBlockingTx would send a calldata
+// cancel against a blobpool reservation, which is rejected the same way,
+// looping forever without ever displacing the stuck blob tx.
+func TestFallbackAuth_AuthFailureTxRefType(t *testing.T) {
+	l := newFallbackAuthSubmitter(t)
+	txdata := testFallbackTxData(t)
+	txdata.daType = DaTypeBlob
+	candidate := &txmgr.TxCandidate{TxData: []byte("batch-calldata")}
+
+	queue := &fakeTxSender{
+		responses: []txmgr.TxReceipt[txRef]{
+			{Err: errSendFailed}, // auth fails. No batch response, it must never be sent
+		},
+	}
+	receiptsCh := make(chan txmgr.TxReceipt[txRef], 1)
+
+	l.sendTxWithFallbackAuth(txdata, false, candidate, queue, receiptsCh)
+
+	got := <-receiptsCh
+	require.Error(t, got.Err)
+	require.Equal(t, txdata.ID().String(), got.ID.id.String())
+	require.Len(t, queue.sends, 1)
+	require.False(t, got.ID.isBlob)
+	require.Equal(t, DaTypeCalldata, got.ID.daType)
+}
+
+// TestFallbackAuth_BatchFailureTxRefType verifies the converse: a batch-tx
+// failure keeps the batch txdata's own type on the forwarded receipt.
+func TestFallbackAuth_BatchFailureTxRefType(t *testing.T) {
+	l := newFallbackAuthSubmitter(t)
+	txdata := testFallbackTxData(t)
+	txdata.daType = DaTypeBlob
+	candidate := &txmgr.TxCandidate{TxData: []byte("batch-calldata")}
+
+	queue := &fakeTxSender{
+		responses: []txmgr.TxReceipt[txRef]{
+			{Receipt: receiptWithBlock(100)}, // auth lands
+			{Err: errSendFailed},             // batch fails
+		},
+	}
+	receiptsCh := make(chan txmgr.TxReceipt[txRef], 1)
+
+	l.sendTxWithFallbackAuth(txdata, false, candidate, queue, receiptsCh)
+
+	got := <-receiptsCh
+	require.Error(t, got.Err)
+	require.Equal(t, txdata.ID().String(), got.ID.id.String())
+	require.Len(t, queue.sends, 2)
+	require.True(t, got.ID.isBlob)
+	require.Equal(t, DaTypeBlob, got.ID.daType)
+}
+
 func TestFallbackAuth_BatchFailureRetried(t *testing.T) {
 	l := newFallbackAuthSubmitter(t)
 	txdata := testFallbackTxData(t)


### PR DESCRIPTION
Fixes a txpool-recovery livelock found while reviewing this branch. The bug predates #467 but the fix lands on the rewritten synchronous function.

The auth tx is always calldata, but its failure receipts are forwarded under the batch txdata's txRef, so with blob batches an auth failure is labeled as a blob failure. That matters for ErrAlreadyReserved: geth refuses a tx at submission when a tx of the other type from the same account is still in the pool, so a blob batch tx left in the blobpool across a restart makes the first auth tx bounce. The recovery in cancelBlockingTx infers the stuck tx's type from the failed tx's type and sends a cancel of the stuck type to replace it in its own pool. Fed the wrong label, it sends a calldata cancel, which the same blobpool reservation rejects; the txpool state then resets to good on the cancel's receipt and the next auth tx starts the cycle again. The blob cancel that would replace the stuck tx is never sent, so the batcher spins without landing batches until an operator intervenes.

The fix derives a calldata-typed authReference used for the auth tx's queue.Send and its failure receipts, keeping the batch txdata's id so a failed pair still requeues the right frames. Batch failures, the window check and the success receipt keep the batch ref, which is where the daType and size metrics read from.

https://claude.ai/code/session_013uE8M5ZPGXWTdhpeqmL5g3