### PR TITLE
rust: Address new advisories failing cargo deny

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aquamarine"
@@ -2823,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -24,6 +24,10 @@ ignore = [
   # hickory-proto O(n^2) name compression; fix in 0.26.1, but libp2p 0.56 pins
   # hickory 0.25. Revisit when libp2p upgrades.
   "RUSTSEC-2026-0119",
+  # proc-macro-error2 is unmaintained; no safe upgrade available. Build-time dep
+  # pulled in transitively via alloy-sol-macro -> alloy-sol-types across the
+  # reth/alloy tree.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
- Bump anyhow 1.0.101 -> 1.0.103 (fixes RUSTSEC-2026-0190, unsoundness in Error::downcast_mut()).
- Bump crossbeam-epoch 0.9.18 -> 0.9.20 (fixes RUSTSEC-2026-0204, invalid pointer dereference in the fmt::Pointer impl for Atomic/Shared).
- Ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained, no safe upgrade). Build-time dep pulled in transitively via alloy-sol-macro -> alloy-sol-types across the reth/alloy tree.

`cargo deny --all-features check all` passes (advisories, bans, licenses, sources all ok).