### PR TITLE
op-deployer: update drifted Sepolia SuperchainConfigImpl in reuse test

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -120,7 +120,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				ProtocolVersionsProxy:    superCfg.ProtocolVersionsAddr,
 				ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0xb08Cc720F511062537ca78BdB0AE691F04F5a957"),
+				SuperchainConfigImpl:     common.HexToAddress("0xE4F9779ab53070a55db24dFAeFf9AF147c6ED550"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM


### PR DESCRIPTION
Does this test make sense for us? Should we keep updating it like this after every change or should we disable the test?

---

TestInitLiveStrategy_OPCMReuseLogicSepolia forks live Sepolia and asserts the standard superchain's on-chain SuperchainConfig implementation against a hardcoded address. That proxy's implementation was upgraded on Sepolia since the constant was last set, so the "embedded L1 locator with standard intent types and standard roles" subtest fails with:

  expected SuperchainConfigImpl 0xb08Cc720...a957
  actual   SuperchainConfigImpl 0xE4F9779a...D550

The new value is what the forked-Sepolia read returned in CI (i.e. the current live implementation), so update the constant to match. Only this subtest is affected; the other assertions read a different, older superchain and are unchanged.

Note: this assertion is inherently drift-prone and will break again on the next Sepolia SuperchainConfig upgrade.