### PR TITLE
Use streamer v2

### DIFF
--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -6,16 +6,10 @@ import (
 	"strings"
 	"time"
 
-	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/urfave/cli/v2"
-
-	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
-	espressoLightClient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
 )
 
 // espressoFlags returns the flag names for espresso
@@ -261,48 +255,4 @@ func ReadCLIConfig(c *cli.Context) CLIConfig {
 	}
 
 	return config
-}
-
-func BatchStreamerFromCLIConfig[B espressoStreamers.Batch](
-	cfg CLIConfig,
-	log log.Logger,
-	unmarshalBatch func(data []byte, l1Finalized uint64) (*B, error),
-	syncStatusProvider espressoStreamers.SyncStatusProvider,
-) (*espressoStreamers.BatchStreamer[B], error) {
-	if !cfg.Enabled {
-		return nil, fmt.Errorf("espresso is not enabled")
-	}
-
-	l1Client, err := ethclient.Dial(cfg.L1URL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial L1 RPC at %s: %w", cfg.L1URL, err)
-	}
-
-	RollupL1Client, err := ethclient.Dial(cfg.RollupL1URL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial Rollup L1 RPC at %s: %w", cfg.RollupL1URL, err)
-	}
-
-	urlZero := cfg.QueryServiceURLs[0]
-	espressoClient := espressoClient.NewClient(urlZero)
-
-	espressoLightClient, err := espressoLightClient.NewLightclientCaller(cfg.LightClientAddr, l1Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Espresso light client")
-	}
-
-	return espressoStreamers.NewEspressoStreamer(
-		cfg.Namespace,
-		NewAdaptL1BlockRefClient(l1Client),
-		NewAdaptL1BlockRefClient(RollupL1Client),
-		espressoClient,
-		espressoLightClient,
-		syncStatusProvider,
-		log,
-		unmarshalBatch,
-		cfg.CaffeinationHeightEspresso,
-		cfg.CaffeinationHeightL2,
-		cfg.BatchAuthenticatorAddr,
-		false,
-	)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/EspressoSystems/espresso-network/sdks/go v0.3.5-0.20260410134522-1a819609a513
-	github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731122451-83eab3d058ed
+	github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731024110-22c396aa0934
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/andybalholm/brotli v1.1.0
 	github.com/base/go-bip39 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/EspressoSystems/espresso-network/sdks/go v0.3.5-0.20260410134522-1a819609a513 h1:4KqlmnDg8pPPj1hCtiLnN0Fh9ltp+PPKOft9I06zQOA=
 github.com/EspressoSystems/espresso-network/sdks/go v0.3.5-0.20260410134522-1a819609a513/go.mod h1:kaxR08mJb5Mijy7a2RhWCIWOevFI4PcXwDkzoEbsVTk=
-github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731122451-83eab3d058ed h1:Xm8wCCXQMvvXLPH/Ns9Rl3rhrQXSk9SBVwYN9JUxsqY=
-github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731122451-83eab3d058ed/go.mod h1:Op3SNwQnZ3bqwrUXMAORnL2/pNiFzpfOED4ltYs5o/U=
+github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731024110-22c396aa0934 h1:9GAjAI/zuWDVHTQWJuA2EZzeOeKrmM34jPuH0x8puvM=
+github.com/EspressoSystems/espresso-streamers v1.3.1-0.20260731024110-22c396aa0934/go.mod h1:Op3SNwQnZ3bqwrUXMAORnL2/pNiFzpfOED4ltYs5o/U=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
-	"github.com/EspressoSystems/espresso-streamers/op/derivation"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -158,10 +157,7 @@ type BatchSubmitter struct {
 	authGroup sync.WaitGroup
 
 	espressoSubmitter *espressoTransactionSubmitter
-	espressoStreamer  espressoStreamers.EspressoStreamer[derivation.EspressoBatch]
-	// espressoSyncStatus feeds the streamer the sync status this batcher has already
-	// polled, so Refresh does not poll op-node again.
-	espressoSyncStatus *cachedSyncStatus
+	espressoStreamer  *espressoStreamers.Streamer
 
 	// clearStateRequested asks the espresso batch loading loop to run clearState
 	clearStateRequested atomic.Bool
@@ -190,8 +186,6 @@ func NewBatchSubmitter(setup DriverSetup) *BatchSubmitter {
 	if err != nil {
 		panic(err)
 	}
-
-	batcher.setupEspressoStreamer()
 
 	return batcher
 }
@@ -233,6 +227,11 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 	l.publishSignal = publishSignal
 
 	if l.Config.Espresso.Enabled {
+		// Constructed here rather than in NewBatchSubmitter: it performs an L2 lookup, so
+		// it has to run after waitForL2Genesis and needs a context to do it with.
+		if err := l.setupEspressoStreamer(l.shutdownCtx); err != nil {
+			return fmt.Errorf("could not set up the Espresso streamer: %w", err)
+		}
 		if err := l.startEspressoLoops(receiptsCh, publishSignal, unsafeBytesUpdated); err != nil {
 			return err
 		}
@@ -317,6 +316,10 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	l.cancelShutdownCtx()
 	l.wg.Wait()
 	l.cancelKillCtx()
+
+	if l.espressoStreamer != nil {
+		l.espressoStreamer.Stop()
+	}
 
 	l.Log.Info("Batch Submitter stopped")
 	return nil
@@ -895,7 +898,7 @@ func (l *BatchSubmitter) clearState(ctx context.Context) {
 			l.channelMgrMutex.Lock()
 			defer l.channelMgrMutex.Unlock()
 			l.channelMgr.Clear(l1SafeOrigin)
-			l.resetEspressoStreamer()
+			l.resetEspressoStreamer(ctx)
 			return true
 		}
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -159,6 +159,14 @@ type BatchSubmitter struct {
 	espressoSubmitter *espressoTransactionSubmitter
 	espressoStreamer  *espressoStreamers.Streamer
 
+	// espressoAnchorFloor is the L2 block at --espresso.origin-height-l2, resolved
+	// during setup when the local-safe head is still below it. It floors every
+	// streamer anchor and sync comparison so the Espresso pipeline never treats
+	// pre-caffeination blocks (the fallback batcher's territory) as its own.
+	// Zero when the safe head was already past the caffeination point at setup.
+	// Written once in setupEspressoStreamer before the loops start.
+	espressoAnchorFloor eth.L2BlockRef
+
 	// clearStateRequested asks the espresso batch loading loop to run clearState
 	clearStateRequested atomic.Bool
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -159,14 +159,6 @@ type BatchSubmitter struct {
 	espressoSubmitter *espressoTransactionSubmitter
 	espressoStreamer  *espressoStreamers.Streamer
 
-	// espressoAnchorFloor is the L2 block at --espresso.origin-height-l2, resolved
-	// during setup when the local-safe head is still below it. It floors every
-	// streamer anchor and sync comparison so the Espresso pipeline never treats
-	// pre-caffeination blocks (the fallback batcher's territory) as its own.
-	// Zero when the safe head was already past the caffeination point at setup.
-	// Written once in setupEspressoStreamer before the loops start.
-	espressoAnchorFloor eth.L2BlockRef
-
 	// clearStateRequested asks the espresso batch loading loop to run clearState
 	clearStateRequested atomic.Bool
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -230,9 +230,11 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 		// Constructed here rather than in NewBatchSubmitter: it performs an L2 lookup, so
 		// it has to run after waitForL2Genesis and needs a context to do it with.
 		if err := l.setupEspressoStreamer(l.shutdownCtx); err != nil {
+			l.rollbackFailedStart()
 			return fmt.Errorf("could not set up the Espresso streamer: %w", err)
 		}
 		if err := l.startEspressoLoops(receiptsCh, publishSignal, unsafeBytesUpdated); err != nil {
+			l.rollbackFailedStart()
 			return err
 		}
 	} else {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -895,14 +895,22 @@ func (l *BatchSubmitter) clearState(ctx context.Context) {
 		if err != nil {
 			l.Log.Warn("Failed to query L1 safe origin, will retry", "err", err)
 			return false
-		} else {
-			l.Log.Info("Clearing state with safe L1 origin", "origin", l1SafeOrigin)
-			l.channelMgrMutex.Lock()
-			defer l.channelMgrMutex.Unlock()
-			l.channelMgr.Clear(l1SafeOrigin)
-			l.resetEspressoStreamer(ctx)
-			return true
 		}
+		// Fetch the streamer re-anchor target before mutating anything so the
+		// channel-manager clear and the streamer re-anchor happen together or
+		// not at all; see espressoReanchorTarget for the partial-clear hazard.
+		reanchorTarget, ok := l.espressoReanchorTarget(ctx)
+		if !ok {
+			return false
+		}
+		l.Log.Info("Clearing state with safe L1 origin", "origin", l1SafeOrigin)
+		l.channelMgrMutex.Lock()
+		defer l.channelMgrMutex.Unlock()
+		l.channelMgr.Clear(l1SafeOrigin)
+		if reanchorTarget != nil {
+			l.espressoStreamer.SetBatchPosition(*reanchorTarget)
+		}
+		return true
 	}
 
 	// Attempt to set the L1 safe origin and clear the state, if fetching fails -- fall through to an infinite retry

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -822,18 +822,10 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 	return nil
 }
 
-func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStatus *eth.SyncStatus) {
-	// Hand the streamer the status we just polled: Refresh reads its positions from the
-	// provider, and taking them from one status keeps them related to each other.
-	l.espressoSyncStatus.status = newSyncStatus
-
-	err := l.EspressoStreamer().Refresh(ctx)
-	if err != nil {
-		l.degradedLog.Warn(l.Log, "espressoStreamerRefreshErr", "Failed to refresh Espresso streamer", "err", err)
-	} else {
-		l.degradedLog.Clear(l.Log, "espressoStreamerRefreshErr", "Espresso streamer refresh recovered")
-	}
-
+// espressoSyncChannelManager reconciles the channel manager with the latest sync
+// status. The streamer no longer needs pumping here: it refreshes L1 finality and
+// fetches HotShot blocks from its own poll loops.
+func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatus) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
 	syncActions, outOfSync := computeSyncActions(*newSyncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
@@ -845,61 +837,11 @@ func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStat
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
 	if syncActions.clearState != nil {
 		l.channelMgr.Clear(*syncActions.clearState)
-		l.EspressoStreamer().Reset()
+		l.espressoStreamer.SetBatchPosition(newSyncStatus.SafeL2)
 	} else {
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
 	}
-}
-
-// peekNextBatch returns the next batch from the streamer, performing a fork check
-// against an expected parent hash.
-//
-// The expected parent is tip when tip is set. When tip is zero (channel manager was
-// just cleared), we fall back to safeL2.Hash if the batch is at exactly safeL2+1 —
-// the one position where we can set tip to the known safe head. Otherwise we accept the batch as-is.
-func (l *BatchSubmitter) peekNextBatch(ctx context.Context, syncStatus *eth.SyncStatus) *derivation.EspressoBatch {
-	l.channelMgrMutex.Lock()
-	tip := l.channelMgr.tip
-	l.channelMgrMutex.Unlock()
-
-	batch := l.EspressoStreamer().Peek(ctx)
-	if batch == nil {
-		return nil
-	}
-
-	// Check if we can set the tip if not set
-	if tip == (common.Hash{}) && (*batch).Number() == syncStatus.SafeL2.Number+1 {
-		l.Log.Info(
-			"setting tip to safe l2 hash",
-			"batchNr", (*batch).Number(),
-			"batchParent", (*batch).Header().ParentHash.Hex(),
-			"tip", tip,
-		)
-		tip = syncStatus.SafeL2.Hash
-	}
-
-	if tip == (common.Hash{}) {
-		l.Log.Warn(
-			"tip is not set, taking available batch",
-			"blockParentHash", (*batch).Header().ParentHash.Hex(),
-			"blockHash", (*batch).Header().Hash().Hex(),
-		)
-		return batch
-	}
-
-	if (*batch).Header().ParentHash != tip {
-		l.Log.Warn(
-			"head batch fork mismatch, seeking to proper head",
-			"batchNr", (*batch).Number(),
-			"batchParent", (*batch).Header().ParentHash,
-			"tip", tip,
-		)
-		l.EspressoStreamer().SetProperHead(tip)
-		return nil
-	}
-
-	return batch
 }
 
 // requestClearState asks the batch loading loop to perform `l.clearState`.
@@ -918,7 +860,8 @@ func (l *BatchSubmitter) performClearState(ctx context.Context) bool {
 	return true
 }
 
-// Periodically refreshes the sync status and polls Espresso streamer for new batches.
+// Periodically refreshes the sync status and drains the Espresso streamer of any
+// batches that extend the tip it is tracking.
 // Owns publishSignal and unsafeBytesUpdated: it is their only closer, so the loops
 // ranging over them (publishingLoop, throttlingLoop) terminate when this loop exits.
 func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.WaitGroup, publishSignal chan pubInfo, unsafeBytesUpdated chan int64) {
@@ -943,11 +886,8 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 			}
 			l.degradedLog.Clear(l.Log, "syncStatusErr/espressoBatchLoading", "sync status fetch recovered")
 
-			l.espressoSyncAndRefresh(ctx, newSyncStatus)
+			l.espressoSyncChannelManager(newSyncStatus)
 
-			err = l.EspressoStreamer().Update(ctx)
-
-			var batch *derivation.EspressoBatch
 			blocksAdded := 0
 
 			for {
@@ -956,19 +896,20 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 					break
 				}
 
-				batch = l.peekNextBatch(ctx, newSyncStatus)
-
+				batch := l.espressoStreamer.Peek(ctx)
 				if batch == nil {
 					break
 				}
 
 				// This should happen ONLY if the batch is malformed. ToBlock has to guarantee no
-				// transient errors.
+				// transient errors. Advancing past it would promote a block the channel manager
+				// never received to the streamer's tip, stalling every later batch, so re-anchor
+				// instead of skipping.
 				block, err := batch.ToBlock(l.RollupConfig)
 				if err != nil {
 					l.Log.Error("failed to convert singular batch to block", "err", err)
-					l.EspressoStreamer().Next(ctx)
-					continue
+					l.clearState(ctx)
+					break
 				}
 
 				l.Log.Info(
@@ -984,12 +925,12 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 
 				if err != nil {
 					l.Log.Error("failed to add L2 block to channel manager", "err", err)
+					// clearState re-anchors the streamer to the safe head.
 					l.clearState(ctx)
-					l.EspressoStreamer().Reset()
 					break
 				}
 
-				l.EspressoStreamer().Next(ctx)
+				l.espressoStreamer.AdvancePosition()
 				l.Log.Info("Added L2 block to channel manager", "blockNr", block.NumberU64())
 
 				// During a large drain, signal periodically so throttling can engage
@@ -1002,13 +943,6 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 
 			l.sendToThrottlingLoop(unsafeBytesUpdated)
 			l.tryPublishSignal(publishSignal, pubInfo{})
-
-			// A failure in the streamer Update can happen after the buffer has been partially filled
-			if err != nil {
-				l.degradedLog.Warn(l.Log, "espressoStreamerUpdateErr", "failed to update Espresso streamer", "err", err)
-				continue
-			}
-			l.degradedLog.Clear(l.Log, "espressoStreamerUpdateErr", "Espresso streamer update recovered")
 
 		case <-ctx.Done():
 			l.Log.Info("espressoBatchLoadingLoop returning")

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -911,6 +911,21 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 					break
 				}
 
+				// A batch at or below the (floored) local-safe head is already derived
+				// from L1, and adding it would make the publish path resubmit it. The
+				// cursor falls behind the safe head when previously submitted channels
+				// finish deriving while the streamer backfills (e.g. after a restart),
+				// and an empty channel manager gives computeSyncActions nothing to
+				// reconcile. Jump past the whole stale range in one re-anchor: the sync
+				// status ref is canonical, unlike a stale candidate's own hash, which
+				// advancing batch-by-batch would promote to the streamer's tip.
+				if base := l.espressoAnchorBase(newSyncStatus.LocalSafeL2); batch.Number() <= base.Number {
+					l.Log.Info("Peeked batch at or below the local-safe head, re-anchoring the streamer",
+						"batchNr", batch.Number(), "localSafeL2", newSyncStatus.LocalSafeL2, "anchor", base)
+					l.espressoStreamer.SetBatchPosition(base)
+					break
+				}
+
 				// This should happen ONLY if the batch is malformed. ToBlock has to guarantee no
 				// transient errors. Advancing past it would promote a block the channel manager
 				// never received to the streamer's tip, stalling every later batch, so re-anchor

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -1039,10 +1039,21 @@ const (
 // If reorg is detected, empty range and ActionReset is returned.
 // If there isn't enough information or no blocks to load yet, empty range and ActionRetry is returned.
 func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBlockRange, EnqueueBlockAction) {
-	if newSyncStatus.HeadL1 == (eth.L1BlockRef{}) {
-		// empty sync status
+	// Mirror computeSyncActions' zero-field guard: op-node has transiently
+	// reported statuses with individual fields zeroed while the rest are
+	// populated (see sync_actions_test.go). Treating a zero LocalSafeL2 as the
+	// queue floor would enqueue the entire pre-caffeination history, so retry
+	// until the status is fully populated.
+	if isZero(newSyncStatus.LocalSafeL2) ||
+		isZero(newSyncStatus.UnsafeL2) ||
+		isZero(newSyncStatus.HeadL1) ||
+		isZero(newSyncStatus.CurrentL1) {
+		l.batcher.degradedLog.Warn(l.batcher.Log, "emptySyncStatusField", "empty BlockRef in sync status",
+			"localSafeL2", newSyncStatus.LocalSafeL2, "unsafeL2", newSyncStatus.UnsafeL2,
+			"headL1", newSyncStatus.HeadL1, "currentL1", newSyncStatus.CurrentL1)
 		return inclusiveBlockRange{}, ActionRetry
 	}
+	l.batcher.degradedLog.Clear(l.batcher.Log, "emptySyncStatusField", "sync status fully populated")
 
 	if l.prevSyncStatus != nil && newSyncStatus.CurrentL1.Number < l.prevSyncStatus.CurrentL1.Number {
 		// Sequencer restarted and hasn't caught up yet
@@ -1056,7 +1067,8 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 	// LocalSafeL2 rather than SafeL2 (cross-safe), for the same reason as
 	// computeSyncActions: cross-safe can lag local-safe, and blocks at or below
 	// local-safe are already derived from L1 so they must not be re-enqueued.
-	// Always at or past the caffeination point (startup gates on that), so
+	// A populated LocalSafeL2 is always at or past the caffeination point
+	// (startup gates on that; the guard above rejects zeroed statuses), so
 	// pre-caffeination blocks - the fallback batcher's - are never enqueued.
 	safeL2 := newSyncStatus.LocalSafeL2
 

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -828,7 +828,13 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatus) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
-	syncActions, outOfSync := computeSyncActions(*newSyncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
+	// Floor the local-safe head at the caffeination point before reconciling. Our
+	// blocks start at caffeination+1, so comparing them against a pre-caffeination
+	// safe head would read as "next safe block below oldest block in state" and
+	// clear-loop for the whole activation window.
+	flooredStatus := *newSyncStatus
+	flooredStatus.LocalSafeL2 = l.espressoAnchorBase(newSyncStatus.LocalSafeL2)
+	syncActions, outOfSync := computeSyncActions(flooredStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
 	if outOfSync {
 		l.degradedLog.Warn(l.Log, "sequencerOutOfSync", "Sequencer is out of sync, retrying next tick.")
 		return
@@ -837,9 +843,10 @@ func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatu
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
 	if syncActions.clearState != nil {
 		l.channelMgr.Clear(*syncActions.clearState)
-		// LocalSafeL2, matching the base computeSyncActions derived clearState from:
-		// the channel manager and the streamer must not be reset onto different heads.
-		l.espressoStreamer.SetBatchPosition(newSyncStatus.LocalSafeL2)
+		// The floored local-safe head, matching the base computeSyncActions derived
+		// clearState from: the channel manager and the streamer must not be reset
+		// onto different heads.
+		l.espressoStreamer.SetBatchPosition(flooredStatus.LocalSafeL2)
 	} else {
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
@@ -1039,7 +1046,9 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 	// LocalSafeL2 rather than SafeL2 (cross-safe), for the same reason as
 	// computeSyncActions: cross-safe can lag local-safe, and blocks at or below
 	// local-safe are already derived from L1 so they must not be re-enqueued.
-	safeL2 := newSyncStatus.LocalSafeL2
+	// Floored at the caffeination point: pre-caffeination blocks are batched by
+	// the fallback batcher and must never be enqueued to Espresso.
+	safeL2 := l.batcher.espressoAnchorBase(newSyncStatus.LocalSafeL2)
 
 	// State empty, just enqueue all unsafe blocks
 	if len(l.queuedBlocks) == 0 {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -19,6 +19,7 @@ import (
 	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 	espressoCommon "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/EspressoSystems/espresso-streamers/op/derivation"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -1193,7 +1194,7 @@ func (l *BatchSubmitter) fetchBlock(ctx context.Context, blockNumber uint64) (*t
 
 // resolveTEEVerifierAddress queries the BatchAuthenticator contract to get the
 // EspressoTEEVerifier address.
-func (l *BatchSubmitter) resolveTEEVerifierAddress() error {
+func (l *BatchSubmitter) resolveTEEVerifierAddress(ctx context.Context) error {
 	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
 		// If batcher authenticator address is nil, we will keep teeVerifierAddress to nil as well
 		return nil
@@ -1202,7 +1203,9 @@ func (l *BatchSubmitter) resolveTEEVerifierAddress() error {
 	if err != nil {
 		return fmt.Errorf("failed to create BatchAuthenticator caller: %w", err)
 	}
-	addr, err := auth.EspressoTEEVerifier(nil)
+	callCtx, cancel := l.networkTimeoutCtx(ctx)
+	defer cancel()
+	addr, err := auth.EspressoTEEVerifier(&bind.CallOpts{Context: callCtx})
 	if err != nil {
 		return fmt.Errorf("failed to query EspressoTEEVerifier address: %w", err)
 	}
@@ -1223,7 +1226,9 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 	}
 
 	l.Log.Info("Batch authenticator address", "value", l.RollupConfig.BatchAuthenticatorAddress)
-	code, err := l.L1Client.CodeAt(ctx, l.RollupConfig.BatchAuthenticatorAddress, nil)
+	codeCtx, cancel := l.networkTimeoutCtx(ctx)
+	code, err := l.L1Client.CodeAt(codeCtx, l.RollupConfig.BatchAuthenticatorAddress, nil)
+	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to check code at contract address: %w", err)
 	}

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -829,13 +829,7 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatus) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
-	// Floor the local-safe head at the caffeination point before reconciling. Our
-	// blocks start at caffeination+1, so comparing them against a pre-caffeination
-	// safe head would read as "next safe block below oldest block in state" and
-	// clear-loop for the whole activation window.
-	flooredStatus := *newSyncStatus
-	flooredStatus.LocalSafeL2 = l.espressoAnchorBase(newSyncStatus.LocalSafeL2)
-	syncActions, outOfSync := computeSyncActions(flooredStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
+	syncActions, outOfSync := computeSyncActions(*newSyncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
 	if outOfSync {
 		l.degradedLog.Warn(l.Log, "sequencerOutOfSync", "Sequencer is out of sync, retrying next tick.")
 		return
@@ -844,10 +838,10 @@ func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatu
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
 	if syncActions.clearState != nil {
 		l.channelMgr.Clear(*syncActions.clearState)
-		// The floored local-safe head, matching the base computeSyncActions derived
-		// clearState from: the channel manager and the streamer must not be reset
-		// onto different heads.
-		l.espressoStreamer.SetBatchPosition(flooredStatus.LocalSafeL2)
+		// LocalSafeL2, matching the base computeSyncActions derived clearState from:
+		// the channel manager and the streamer must not be reset onto different heads.
+		// Always at or past the caffeination point: startup gates on that.
+		l.espressoStreamer.SetBatchPosition(newSyncStatus.LocalSafeL2)
 	} else {
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
@@ -911,18 +905,18 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 					break
 				}
 
-				// A batch at or below the (floored) local-safe head is already derived
-				// from L1, and adding it would make the publish path resubmit it. The
-				// cursor falls behind the safe head when previously submitted channels
-				// finish deriving while the streamer backfills (e.g. after a restart),
-				// and an empty channel manager gives computeSyncActions nothing to
-				// reconcile. Jump past the whole stale range in one re-anchor: the sync
-				// status ref is canonical, unlike a stale candidate's own hash, which
-				// advancing batch-by-batch would promote to the streamer's tip.
-				if base := l.espressoAnchorBase(newSyncStatus.LocalSafeL2); batch.Number() <= base.Number {
+				// A batch at or below the local-safe head is already derived from L1,
+				// and adding it would make the publish path resubmit it. The cursor
+				// falls behind the safe head when previously submitted channels finish
+				// deriving while the streamer backfills (e.g. after a restart), and an
+				// empty channel manager gives computeSyncActions nothing to reconcile.
+				// Jump past the whole stale range in one re-anchor: the sync status ref
+				// is canonical, unlike a stale candidate's own hash, which advancing
+				// batch-by-batch would promote to the streamer's tip.
+				if batch.Number() <= newSyncStatus.LocalSafeL2.Number {
 					l.Log.Info("Peeked batch at or below the local-safe head, re-anchoring the streamer",
-						"batchNr", batch.Number(), "localSafeL2", newSyncStatus.LocalSafeL2, "anchor", base)
-					l.espressoStreamer.SetBatchPosition(base)
+						"batchNr", batch.Number(), "localSafeL2", newSyncStatus.LocalSafeL2)
+					l.espressoStreamer.SetBatchPosition(newSyncStatus.LocalSafeL2)
 					break
 				}
 
@@ -1062,9 +1056,9 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 	// LocalSafeL2 rather than SafeL2 (cross-safe), for the same reason as
 	// computeSyncActions: cross-safe can lag local-safe, and blocks at or below
 	// local-safe are already derived from L1 so they must not be re-enqueued.
-	// Floored at the caffeination point: pre-caffeination blocks are batched by
-	// the fallback batcher and must never be enqueued to Espresso.
-	safeL2 := l.batcher.espressoAnchorBase(newSyncStatus.LocalSafeL2)
+	// Always at or past the caffeination point (startup gates on that), so
+	// pre-caffeination blocks - the fallback batcher's - are never enqueued.
+	safeL2 := newSyncStatus.LocalSafeL2
 
 	// State empty, just enqueue all unsafe blocks
 	if len(l.queuedBlocks) == 0 {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -837,7 +837,9 @@ func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatu
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
 	if syncActions.clearState != nil {
 		l.channelMgr.Clear(*syncActions.clearState)
-		l.espressoStreamer.SetBatchPosition(newSyncStatus.SafeL2)
+		// LocalSafeL2, matching the base computeSyncActions derived clearState from:
+		// the channel manager and the streamer must not be reset onto different heads.
+		l.espressoStreamer.SetBatchPosition(newSyncStatus.LocalSafeL2)
 	} else {
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
@@ -1034,7 +1036,10 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 
 	l.prevSyncStatus = newSyncStatus
 
-	safeL2 := newSyncStatus.SafeL2
+	// LocalSafeL2 rather than SafeL2 (cross-safe), for the same reason as
+	// computeSyncActions: cross-safe can lag local-safe, and blocks at or below
+	// local-safe are already derived from L1 so they must not be re-enqueued.
+	safeL2 := newSyncStatus.LocalSafeL2
 
 	// State empty, just enqueue all unsafe blocks
 	if len(l.queuedBlocks) == 0 {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -824,15 +824,16 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 }
 
 // espressoSyncChannelManager reconciles the channel manager with the latest sync
-// status. The streamer no longer needs pumping here: it refreshes L1 finality and
-// fetches HotShot blocks from its own poll loops.
-func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatus) {
+// status, reporting whether the sequencer is out of sync (malformed status or
+// reversed CurrentL1). The streamer no longer needs pumping here: it refreshes L1
+// finality and fetches HotShot blocks from its own poll loops.
+func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatus) (outOfSync bool) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
 	syncActions, outOfSync := computeSyncActions(*newSyncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
 	if outOfSync {
 		l.degradedLog.Warn(l.Log, "sequencerOutOfSync", "Sequencer is out of sync, retrying next tick.")
-		return
+		return true
 	}
 	l.degradedLog.Clear(l.Log, "sequencerOutOfSync", "Sequencer back in sync")
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
@@ -846,6 +847,7 @@ func (l *BatchSubmitter) espressoSyncChannelManager(newSyncStatus *eth.SyncStatu
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
 	}
+	return false
 }
 
 // requestClearState asks the batch loading loop to perform `l.clearState`.
@@ -890,7 +892,14 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 			}
 			l.degradedLog.Clear(l.Log, "syncStatusErr/espressoBatchLoading", "sync status fetch recovered")
 
-			l.espressoSyncChannelManager(newSyncStatus)
+			// An out-of-sync status (zeroed fields or reversed CurrentL1) cannot
+			// be trusted as the drain floor: with LocalSafeL2 zeroed, the
+			// stale-batch re-anchor check below never fires and already-derived
+			// blocks would be republished. Skip the tick, mirroring how the base
+			// driver skips loading when computeSyncActions reports out-of-sync.
+			if l.espressoSyncChannelManager(newSyncStatus) {
+				continue
+			}
 
 			blocksAdded := 0
 

--- a/op-batcher/batcher/espresso_block_loader_test.go
+++ b/op-batcher/batcher/espresso_block_loader_test.go
@@ -1,8 +1,11 @@
 package batcher
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -103,5 +106,61 @@ func TestEspressoSyncChannelManagerReportsOutOfSync(t *testing.T) {
 		l := newTestSubmitter(t)
 		l.prevCurrentL1 = eth.L1BlockRef{Number: 3, Hash: common.Hash{0x06}}
 		require.True(t, l.espressoSyncChannelManager(&populated))
+	})
+}
+
+// clearState must not clear the channel manager unless the streamer re-anchor
+// target is already in hand: espressoReanchorTarget reporting ok=false makes
+// the caller retry the whole clear instead of performing it partially, which
+// would leave an emptied channel manager with the streamer at its old cursor.
+func TestEspressoReanchorTarget(t *testing.T) {
+	newReanchorSubmitter := func(t *testing.T, enabled bool, streamer *espressoStreamers.Streamer) (*BatchSubmitter, *mockL2EndpointProvider) {
+		ep := newEndpointProvider()
+		return &BatchSubmitter{
+			DriverSetup: DriverSetup{
+				Log: testlog.Logger(t, log.LevelDebug),
+				Config: BatcherConfig{
+					NetworkTimeout: time.Second,
+					Espresso:       EspressoBatcherConfig{Enabled: enabled},
+				},
+				EndpointProvider: ep,
+			},
+			espressoStreamer: streamer,
+		}, ep
+	}
+
+	t.Run("espresso disabled needs no target", func(t *testing.T) {
+		l, _ := newReanchorSubmitter(t, false, nil)
+		target, ok := l.espressoReanchorTarget(t.Context())
+		require.True(t, ok)
+		require.Nil(t, target)
+	})
+
+	t.Run("startup before streamer construction needs no target", func(t *testing.T) {
+		l, _ := newReanchorSubmitter(t, true, nil)
+		target, ok := l.espressoReanchorTarget(t.Context())
+		require.True(t, ok)
+		require.Nil(t, target)
+	})
+
+	t.Run("sync status failure blocks the clear", func(t *testing.T) {
+		l, ep := newReanchorSubmitter(t, true, &espressoStreamers.Streamer{})
+		ep.rollupClient.ExpectSyncStatus(nil, errors.New("transient RPC failure"))
+		target, ok := l.espressoReanchorTarget(t.Context())
+		require.False(t, ok)
+		require.Nil(t, target)
+	})
+
+	t.Run("populated status yields the local-safe target", func(t *testing.T) {
+		l, ep := newReanchorSubmitter(t, true, &espressoStreamers.Streamer{})
+		localSafe := eth.L2BlockRef{Number: 104, Hash: common.Hash{0x03}}
+		ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
+			HeadL1:      eth.L1BlockRef{Number: 5, Hash: common.Hash{0x01}},
+			LocalSafeL2: localSafe,
+		}, nil)
+		target, ok := l.espressoReanchorTarget(t.Context())
+		require.True(t, ok)
+		require.NotNil(t, target)
+		require.Equal(t, localSafe, *target)
 	})
 }

--- a/op-batcher/batcher/espresso_block_loader_test.go
+++ b/op-batcher/batcher/espresso_block_loader_test.go
@@ -1,0 +1,61 @@
+package batcher
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBlockLoader(t *testing.T) *BlockLoader {
+	return &BlockLoader{
+		batcher: &BatchSubmitter{
+			DriverSetup: DriverSetup{Log: testlog.Logger(t, log.LevelDebug)},
+			degradedLog: oplog.NewRepeatStateLogger(),
+		},
+	}
+}
+
+// op-node has transiently reported sync statuses with individual fields zeroed
+// while the rest are populated (see the "LocalSafeL2=0,SafeL2>0" case in
+// sync_actions_test.go). The loader must retry rather than treat a zero
+// LocalSafeL2 as the queue floor and enqueue the whole pre-caffeination history.
+func TestNextBlockRangeZeroStatusFields(t *testing.T) {
+	populated := eth.SyncStatus{
+		HeadL1:      eth.L1BlockRef{Number: 5, Hash: common.Hash{0x01}},
+		CurrentL1:   eth.L1BlockRef{Number: 2, Hash: common.Hash{0x02}},
+		LocalSafeL2: eth.L2BlockRef{Number: 104, Hash: common.Hash{0x03}},
+		SafeL2:      eth.L2BlockRef{Number: 103, Hash: common.Hash{0x04}},
+		UnsafeL2:    eth.L2BlockRef{Number: 109, Hash: common.Hash{0x05}},
+	}
+
+	t.Run("fully populated status enqueues from local-safe", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		r, action := loader.nextBlockRange(&populated)
+		require.Equal(t, EnqueueBlockAction(ActionEnqueue), action)
+		require.Equal(t, inclusiveBlockRange{105, 109}, r)
+	})
+
+	zeroings := map[string]func(*eth.SyncStatus){
+		"LocalSafeL2": func(s *eth.SyncStatus) { s.LocalSafeL2 = eth.L2BlockRef{} },
+		"UnsafeL2":    func(s *eth.SyncStatus) { s.UnsafeL2 = eth.L2BlockRef{} },
+		"HeadL1":      func(s *eth.SyncStatus) { s.HeadL1 = eth.L1BlockRef{} },
+		"CurrentL1":   func(s *eth.SyncStatus) { s.CurrentL1 = eth.L1BlockRef{} },
+	}
+	for field, zero := range zeroings {
+		t.Run("zero "+field+" retries", func(t *testing.T) {
+			status := populated
+			zero(&status)
+			loader := newTestBlockLoader(t)
+			r, action := loader.nextBlockRange(&status)
+			require.Equal(t, EnqueueBlockAction(ActionRetry), action)
+			require.Equal(t, inclusiveBlockRange{}, r)
+			require.Nil(t, loader.prevSyncStatus,
+				"a zeroed status must not become the comparison baseline for later ticks")
+		})
+	}
+}

--- a/op-batcher/batcher/espresso_block_loader_test.go
+++ b/op-batcher/batcher/espresso_block_loader_test.go
@@ -3,6 +3,8 @@ package batcher
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -58,4 +60,48 @@ func TestNextBlockRangeZeroStatusFields(t *testing.T) {
 				"a zeroed status must not become the comparison baseline for later ticks")
 		})
 	}
+}
+
+// espressoSyncChannelManager must report an out-of-sync status so that
+// espressoBatchLoadingLoop skips draining against an untrustworthy local-safe
+// floor: with LocalSafeL2 zeroed, the stale-batch re-anchor check in the drain
+// loop never fires and already-derived blocks would be republished.
+func TestEspressoSyncChannelManagerReportsOutOfSync(t *testing.T) {
+	newTestSubmitter := func(t *testing.T) *BatchSubmitter {
+		lgr := testlog.Logger(t, log.LevelDebug)
+		return &BatchSubmitter{
+			DriverSetup: DriverSetup{Log: lgr},
+			channelMgr:  NewChannelManager(lgr, metrics.NoopMetrics, ChannelConfig{}, &rollup.Config{}),
+			degradedLog: oplog.NewRepeatStateLogger(),
+		}
+	}
+
+	populated := eth.SyncStatus{
+		HeadL1:      eth.L1BlockRef{Number: 5, Hash: common.Hash{0x01}},
+		CurrentL1:   eth.L1BlockRef{Number: 2, Hash: common.Hash{0x02}},
+		LocalSafeL2: eth.L2BlockRef{Number: 104, Hash: common.Hash{0x03}},
+		SafeL2:      eth.L2BlockRef{Number: 103, Hash: common.Hash{0x04}},
+		UnsafeL2:    eth.L2BlockRef{Number: 109, Hash: common.Hash{0x05}},
+	}
+
+	t.Run("fully populated status is in sync", func(t *testing.T) {
+		l := newTestSubmitter(t)
+		require.False(t, l.espressoSyncChannelManager(&populated))
+		require.Equal(t, populated.CurrentL1, l.prevCurrentL1)
+	})
+
+	t.Run("zeroed LocalSafeL2 is out of sync", func(t *testing.T) {
+		l := newTestSubmitter(t)
+		status := populated
+		status.LocalSafeL2 = eth.L2BlockRef{}
+		require.True(t, l.espressoSyncChannelManager(&status))
+		require.Zero(t, l.prevCurrentL1,
+			"an out-of-sync status must not advance the CurrentL1 baseline")
+	})
+
+	t.Run("reversed CurrentL1 is out of sync", func(t *testing.T) {
+		l := newTestSubmitter(t)
+		l.prevCurrentL1 = eth.L1BlockRef{Number: 3, Hash: common.Hash{0x06}}
+		require.True(t, l.espressoSyncChannelManager(&populated))
+	})
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -172,16 +172,18 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 		return fmt.Errorf("could not register with BatchAuthenticator contract: %w", err)
 	}
 
-	// The streamer drives itself from its own poll loops, so it is started here rather
-	// than being pumped by espressoBatchLoadingLoop. Bound to shutdownCtx so it stops
-	// fetching before the publish path winds down.
-	if err := l.espressoStreamer.Start(l.shutdownCtx); err != nil {
-		return fmt.Errorf("could not start the Espresso streamer: %w", err)
-	}
-
 	// Resolve the TEE verifier address from the BatchAuthenticator contract.
 	if err := l.resolveTEEVerifierAddress(); err != nil {
 		return fmt.Errorf("could not resolve TEE verifier address: %w", err)
+	}
+
+	// The streamer drives itself from its own poll loops, so it is started here rather
+	// than being pumped by espressoBatchLoadingLoop. Bound to shutdownCtx so it stops
+	// fetching before the publish path winds down. Must stay the last setup step that
+	// can fail: a failed StartBatchSubmitting returns without cancelling shutdownCtx,
+	// so an error after this point would leave the streamer's poll loops running.
+	if err := l.espressoStreamer.Start(l.shutdownCtx); err != nil {
+		return fmt.Errorf("could not start the Espresso streamer: %w", err)
 	}
 
 	l.espressoSubmitter = NewEspressoTransactionSubmitter(

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -2,9 +2,9 @@ package batcher
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	espressoLightClient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
@@ -12,9 +12,11 @@ import (
 	"github.com/EspressoSystems/espresso-streamers/op/derivation"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
@@ -35,7 +37,7 @@ type EspressoDriverSetup struct {
 }
 
 // batcherL1Adapter wraps the batcher's L1Client to implement espresso.L1Client
-// (HeaderHashByNumber + bind.ContractCaller).
+// (HeaderHashByNumber + HeaderByNumber + bind.ContractCaller).
 type batcherL1Adapter struct {
 	L1Client L1Client
 }
@@ -48,6 +50,10 @@ func (a *batcherL1Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 	return h.Hash(), nil
 }
 
+func (a *batcherL1Adapter) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return a.L1Client.HeaderByNumber(ctx, number)
+}
+
 func (a *batcherL1Adapter) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
 	return a.L1Client.CodeAt(ctx, contract, blockNumber)
 }
@@ -56,63 +62,104 @@ func (a *batcherL1Adapter) CallContract(ctx context.Context, call ethereum.CallM
 	return a.L1Client.CallContract(ctx, call, blockNumber)
 }
 
-// EspressoStreamer returns the Espresso batch streamer for use by the service and tests.
-func (l *BatchSubmitter) EspressoStreamer() espressoStreamers.EspressoStreamer[derivation.EspressoBatch] {
-	return l.espressoStreamer
+// batcherL2Adapter wraps the batcher's L2 eth client to implement espresso.L2Client.
+// The streamer uses it once, at construction, to resolve the block hash of the
+// batch position it is anchored to. dial.EthClientInterface exposes no
+// header-only accessor, so this fetches the full block and takes its hash.
+type batcherL2Adapter struct {
+	EthClient dial.EthClientInterface
 }
 
-// cachedSyncStatus is the streamer's SyncStatusProvider, serving the status the batch
-// loading loop polled on its current tick rather than a second call to op-node.
+func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.Int) (common.Hash, error) {
+	block, err := a.EthClient.BlockByNumber(ctx, number)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return block.Hash(), nil
+}
+
+// setupEspressoStreamer constructs the Espresso streamer for a BatchSubmitter that
+// is starting up; no-op when --espresso.enabled is false.
 //
-// Unsynchronised on purpose: the streamer holds no locks of its own, so every call into it
-// already has to come from espressoBatchLoadingLoop, and so does every write here.
-type cachedSyncStatus struct {
-	status *eth.SyncStatus
-}
-
-// FetchSyncStatus implements espressoStreamers.SyncStatusProvider.
-func (c *cachedSyncStatus) FetchSyncStatus(context.Context) (*eth.SyncStatus, error) {
-	if c.status == nil {
-		return nil, errors.New("no sync status polled yet")
-	}
-	return c.status, nil
-}
-
-// setupEspressoStreamer constructs the Espresso streamer (and its buffered
-// wrapper) for a freshly-built BatchSubmitter. Called from NewBatchSubmitter
-// only when --espresso.enabled is set; no-op otherwise. Panics on streamer
-// construction failure to mirror the existing NewBatchSubmitter behavior.
-func (l *BatchSubmitter) setupEspressoStreamer() {
+// Called from StartBatchSubmitting rather than NewBatchSubmitter: the streamer
+// resolves its anchor batch's hash from the L2 client while constructing, so it
+// needs a context and an L2 node that has reached genesis. It also returns an error
+// rather than panicking, which construction inside NewBatchSubmitter could not do.
+func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	if !l.Config.Espresso.Enabled {
-		return
+		return nil
 	}
-	l1Adapter := &batcherL1Adapter{L1Client: l.L1Client}
+
+	ethClient, err := l.EndpointProvider.EthClient(ctx)
+	if err != nil {
+		return fmt.Errorf("getting the L2 eth client for the Espresso streamer: %w", err)
+	}
+
 	// Convert typed nil pointer to untyped nil interface to avoid typed-nil interface panic
 	// in confirmEspressoBlockHeight when EspressoLightClient is not configured.
 	var lightClientIface espressoStreamers.LightClientCallerInterface
 	if l.Espresso.LightClient != nil {
 		lightClientIface = l.Espresso.LightClient
 	}
-	l.espressoSyncStatus = &cachedSyncStatus{}
-	unbufferedStreamer, err := espressoStreamers.NewEspressoStreamer(
-		bigs.Uint64Strict(l.RollupConfig.L2ChainID),
-		l1Adapter,
-		l1Adapter,
+
+	streamer, err := espressoStreamers.NewStreamer(
+		ctx,
 		l.Espresso.Client,
+		&batcherL1Adapter{L1Client: l.L1Client},
+		&batcherL2Adapter{EthClient: ethClient},
 		lightClientIface,
-		l.espressoSyncStatus,
-		l.Log,
+		l.RollupConfig.BatchAuthenticatorAddress,
+		bigs.Uint64Strict(l.RollupConfig.L2ChainID),
 		derivation.CreateEspressoBatchUnmarshaler(),
+		l.getSyncStatus,
+		l.Config.Espresso.PollInterval,
+		l.Log,
 		l.Config.Espresso.CaffeinationHeightEspresso,
 		l.Config.Espresso.CaffeinationHeightL2,
-		l.RollupConfig.BatchAuthenticatorAddress,
-		false,
 	)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create Espresso streamer: %v", err))
+		return fmt.Errorf("failed to create Espresso streamer: %w", err)
 	}
-	l.espressoStreamer = espressoStreamers.NewBufferedEspressoStreamer(unbufferedStreamer, l.espressoSyncStatus)
-	l.Log.Info("Streamer started", "streamer", l.espressoStreamer)
+	l.espressoStreamer = streamer
+
+	// Re-anchor to the safe L2 head.
+	return l.anchorEspressoStreamerAtSafeHead(ctx)
+}
+
+const (
+	espressoAnchorTimeout       = 1 * time.Minute
+	espressoAnchorRetryInterval = 1 * time.Second
+)
+
+// anchorEspressoStreamerAtSafeHead repositions a freshly-constructed streamer from
+// its configured origin onto the current safe L2 head, waiting for the sync status
+// to report one.
+func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, espressoAnchorTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(espressoAnchorRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		syncStatus, err := l.getSyncStatus(ctx)
+		switch {
+		case err != nil:
+			l.Log.Warn("Failed to fetch sync status to anchor the Espresso streamer, retrying", "err", err)
+		case syncStatus.SafeL2 == (eth.L2BlockRef{}):
+			l.Log.Warn("Sync status has no safe L2 head yet, retrying")
+		default:
+			l.espressoStreamer.SetBatchPosition(syncStatus.SafeL2)
+			l.Log.Info("Anchored the Espresso streamer at the safe L2 head", "safeL2", syncStatus.SafeL2)
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return fmt.Errorf("could not anchor the Espresso streamer at the safe L2 head within %s: %w", espressoAnchorTimeout, ctx.Err())
+		}
+	}
 }
 
 // startEspressoLoops registers the batcher with the BatchAuthenticator
@@ -123,6 +170,13 @@ func (l *BatchSubmitter) setupEspressoStreamer() {
 func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRef], publishSignal chan pubInfo, unsafeBytesUpdated chan int64) error {
 	if err := l.registerBatcher(l.killCtx); err != nil {
 		return fmt.Errorf("could not register with BatchAuthenticator contract: %w", err)
+	}
+
+	// The streamer drives itself from its own poll loops, so it is started here rather
+	// than being pumped by espressoBatchLoadingLoop. Bound to shutdownCtx so it stops
+	// fetching before the publish path winds down.
+	if err := l.espressoStreamer.Start(l.shutdownCtx); err != nil {
+		return fmt.Errorf("could not start the Espresso streamer: %w", err)
 	}
 
 	// Resolve the TEE verifier address from the BatchAuthenticator contract.
@@ -181,12 +235,21 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 	return !isActive
 }
 
-// resetEspressoStreamer resets the Espresso streamer when --espresso.enabled
-// is set; no-op otherwise. Called from clearState alongside the upstream
-// channel-manager reset so the streamer's view of "next batch" matches the
+// resetEspressoStreamer re-anchors the Espresso streamer to the safe L2 head when
+// --espresso.enabled is set; no-op otherwise. Called from clearState alongside the
+// upstream channel-manager reset so the streamer's view of "next batch" matches the
 // freshly-cleared channel state.
-func (l *BatchSubmitter) resetEspressoStreamer() {
-	if l.Config.Espresso.Enabled {
-		l.EspressoStreamer().Reset()
+//
+// The nil check covers the startup path: clearState runs before the streamer is
+// constructed, so the first call of a start cycle finds nothing to re-anchor.
+func (l *BatchSubmitter) resetEspressoStreamer(ctx context.Context) {
+	if !l.Config.Espresso.Enabled || l.espressoStreamer == nil {
+		return
 	}
+	syncStatus, err := l.getSyncStatus(ctx)
+	if err != nil {
+		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, keeping the current position", "err", err)
+		return
+	}
+	l.espressoStreamer.SetBatchPosition(syncStatus.SafeL2)
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -97,32 +96,25 @@ func (l *BatchSubmitter) networkTimeoutCtx(ctx context.Context) (context.Context
 // that has reached genesis. It also returns an error rather than panicking, which
 // construction inside NewBatchSubmitter could not do.
 //
-// The streamer is anchored at max(local-safe head, --espresso.origin-height-l2):
-// the safe head normally, floored at the caffeination point so the streamer never
-// starts inside pre-Espresso history (those blocks are the fallback batcher's to
-// submit). Once the safe head is past the caffeination point, the configured height
-// is not looked up at all: NewStreamer resolves its anchor block's hash from the L2
-// client, which fails on endpoints that no longer serve the (ever aging) configured
-// height and would wedge restarts. --espresso.origin-height-espresso keeps its role:
-// it decides where the streamer starts polling HotShot.
+// The streamer is anchored at the local-safe head, which waitForLocalSafeHead
+// guarantees is at or past --espresso.origin-height-l2, so the streamer never starts
+// inside pre-Espresso history (those blocks are the fallback batcher's to submit).
+// Gating startup on the caffeination point being local-safe - rather than anchoring
+// on the configured height directly - means the anchor hash always comes from the
+// derived chain: an unsafe caffeination block could reorg after being cached and
+// permanently wedge fork selection. The configured height is never looked up either:
+// NewStreamer resolves its anchor block's hash from the L2 client, which fails on
+// endpoints that no longer serve the (ever aging) configured height and would wedge
+// restarts. --espresso.origin-height-espresso keeps its role: it decides where the
+// streamer starts polling HotShot.
 func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	if !l.Config.Espresso.Enabled {
 		return nil
 	}
 
-	safeL2, err := l.waitForLocalSafeHead(ctx)
+	anchor, err := l.waitForLocalSafeHead(ctx)
 	if err != nil {
 		return err
-	}
-
-	anchor := safeL2
-	if safeL2.Number < l.Config.Espresso.CaffeinationHeightL2 {
-		floor, err := l.resolveCaffeinationFloor(ctx)
-		if err != nil {
-			return err
-		}
-		l.espressoAnchorFloor = floor
-		anchor = floor
 	}
 
 	ethClient, err := l.EndpointProvider.EthClient(ctx)
@@ -162,45 +154,10 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	l.espressoStreamer = streamer
 
 	// Re-anchor on the exact ref we resolved: NewStreamer resolved a hash for the
-	// same height, but the sync status / fetched block is the authoritative view.
+	// same height, but the sync status is the authoritative view.
 	streamer.SetBatchPosition(anchor)
-	l.Log.Info("Anchored the Espresso streamer", "anchor", anchor, "localSafeL2", safeL2)
+	l.Log.Info("Anchored the Espresso streamer at the local-safe L2 head", "anchor", anchor)
 	return nil
-}
-
-// resolveCaffeinationFloor fetches the L2 block at --espresso.origin-height-l2 and
-// turns it into a full L2BlockRef (including its L1 origin, which the channel manager
-// needs when clearing against the floor). Only called while the local-safe head is
-// below the caffeination point, so the block is recent or pending: an error here
-// usually means the chain has not reached the configured height yet.
-func (l *BatchSubmitter) resolveCaffeinationFloor(ctx context.Context) (eth.L2BlockRef, error) {
-	height := l.Config.Espresso.CaffeinationHeightL2
-	block, err := l.fetchBlock(ctx, height)
-	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("fetching the caffeination L2 block %d (has the chain produced it yet?): %w", height, err)
-	}
-	ref, err := derive.L2BlockToBlockRef(l.RollupConfig, block)
-	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("deriving the block ref of the caffeination L2 block %d: %w", height, err)
-	}
-	return ref, nil
-}
-
-// espressoAnchorBase floors a local-safe head at the caffeination point: blocks at or
-// below --espresso.origin-height-l2 belong to the fallback batcher, so the streamer
-// must never be anchored into them and sync comparisons must not use a base inside
-// them. An empty ref is passed through so callers keep their "ignore empty" handling.
-func (l *BatchSubmitter) espressoAnchorBase(localSafe eth.L2BlockRef) eth.L2BlockRef {
-	if localSafe == (eth.L2BlockRef{}) || localSafe.Number >= l.Config.Espresso.CaffeinationHeightL2 {
-		return localSafe
-	}
-	if l.espressoAnchorFloor == (eth.L2BlockRef{}) {
-		// Only reachable if the safe head fell below the caffeination point after setup
-		// saw it above (a reorg deeper than the activation). Match pre-floor behavior.
-		l.Log.Error("Local-safe head below the caffeination point but no floor is cached, using the safe head", "localSafe", localSafe)
-		return localSafe
-	}
-	return l.espressoAnchorFloor
 }
 
 const (
@@ -208,12 +165,19 @@ const (
 	espressoAnchorRetryInterval = 1 * time.Second
 )
 
-// waitForLocalSafeHead polls the sync status until it reports a local-safe L2 head to
-// anchor the streamer on, giving up after espressoAnchorTimeout.
+// waitForLocalSafeHead polls the sync status until it reports a local-safe L2 head at
+// or past the caffeination point to anchor the streamer on, giving up after
+// espressoAnchorTimeout.
 //
 // LocalSafeL2 rather than SafeL2 (cross-safe): every streamer anchor must share the
 // base computeSyncActions and safeL1Origin derive clearing/pruning from, and cross-safe
 // can lag local-safe (see the note in computeSyncActions).
+//
+// Requiring the caffeination point to be local-safe is what enforces the anchor floor:
+// the Espresso batcher refuses to run - with a clean, retryable startup failure - until
+// the fallback batcher's pre-activation channels have derived. Blocks at or below
+// --espresso.origin-height-l2 are thereby never this batcher's to track, and the
+// anchor hash always comes from the derived chain rather than a reorgable unsafe block.
 func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockRef, error) {
 	ctx, cancel := context.WithTimeout(ctx, espressoAnchorTimeout)
 	defer cancel()
@@ -221,6 +185,7 @@ func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockR
 	ticker := time.NewTicker(espressoAnchorRetryInterval)
 	defer ticker.Stop()
 
+	caffeinationL2 := l.Config.Espresso.CaffeinationHeightL2
 	for {
 		syncStatus, err := l.getSyncStatus(ctx)
 		switch {
@@ -228,6 +193,9 @@ func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockR
 			l.Log.Warn("Failed to fetch sync status to anchor the Espresso streamer, retrying", "err", err)
 		case syncStatus.LocalSafeL2 == (eth.L2BlockRef{}):
 			l.Log.Warn("Sync status has no local-safe L2 head yet, retrying")
+		case syncStatus.LocalSafeL2.Number < caffeinationL2:
+			l.Log.Warn("Local-safe L2 head has not reached the caffeination point yet, retrying",
+				"localSafeL2", syncStatus.LocalSafeL2.Number, "caffeinationL2", caffeinationL2)
 		default:
 			return syncStatus.LocalSafeL2, nil
 		}
@@ -235,7 +203,9 @@ func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockR
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
-			return eth.L2BlockRef{}, fmt.Errorf("no local-safe L2 head to anchor the Espresso streamer within %s: %w", espressoAnchorTimeout, ctx.Err())
+			return eth.L2BlockRef{}, fmt.Errorf(
+				"no local-safe L2 head at or past the caffeination point (%d) to anchor the Espresso streamer within %s (safe to retry once activation has been derived from L1): %w",
+				caffeinationL2, espressoAnchorTimeout, ctx.Err())
 		}
 	}
 }
@@ -347,5 +317,5 @@ func (l *BatchSubmitter) resetEspressoStreamer(ctx context.Context) {
 		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, keeping the current position", "err", err)
 		return
 	}
-	l.espressoStreamer.SetBatchPosition(l.espressoAnchorBase(syncStatus.LocalSafeL2))
+	l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -301,21 +301,26 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 	return !isActive
 }
 
-// resetEspressoStreamer re-anchors the Espresso streamer to the local-safe L2 head
-// when --espresso.enabled is set; no-op otherwise. Called from clearState alongside the
-// upstream channel-manager reset so the streamer's view of "next batch" matches the
-// freshly-cleared channel state (which is likewise derived from LocalSafeL2).
+// espressoReanchorTarget fetches the local-safe L2 head the Espresso streamer
+// must be re-anchored to when clearState resets the channel manager. clearState
+// calls it BEFORE clearing anything so the clear and the re-anchor are atomic:
+// clearing first and fetching after would, on a transient fetch failure, leave
+// an emptied channel manager with the streamer still at its old cursor, and the
+// blocks in between would only be recovered once computeSyncActions notices the
+// gap - or not at all while the streamer has nothing to serve.
 //
-// The nil check covers the startup path: clearState runs before the streamer is
-// constructed, so the first call of a start cycle finds nothing to re-anchor.
-func (l *BatchSubmitter) resetEspressoStreamer(ctx context.Context) {
+// Reports ok=false when the sync status cannot be fetched: the caller must
+// retry the whole clear rather than perform it partially. Reports a nil target
+// (and ok=true) when there is nothing to re-anchor: --espresso.enabled unset,
+// or the startup path, where clearState runs before the streamer is constructed.
+func (l *BatchSubmitter) espressoReanchorTarget(ctx context.Context) (target *eth.L2BlockRef, ok bool) {
 	if !l.Config.Espresso.Enabled || l.espressoStreamer == nil {
-		return
+		return nil, true
 	}
 	syncStatus, err := l.getSyncStatus(ctx)
 	if err != nil {
-		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, keeping the current position", "err", err)
-		return
+		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, will retry the clear", "err", err)
+		return nil, false
 	}
-	l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
+	return &syncStatus.LocalSafeL2, true
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -79,6 +79,16 @@ func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 	return block.Hash(), nil
 }
 
+// networkTimeoutCtx bounds a single external call with the configured network
+// timeout. Every raw RPC read on the Espresso startup path must go through it:
+// StartBatchSubmitting holds the start mutex, and StopBatchSubmitting needs that
+// mutex before it can cancel anything, so an unbounded call on a stalled endpoint
+// would wedge the batcher beyond even a graceful shutdown. Calls with their own
+// timeout regime (the attestation service client, Txmgr.Send) are exempt.
+func (l *BatchSubmitter) networkTimeoutCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, l.Config.NetworkTimeout)
+}
+
 // setupEspressoStreamer constructs the Espresso streamer for a BatchSubmitter that
 // is starting up; no-op when --espresso.enabled is false.
 //
@@ -127,8 +137,12 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 		lightClientIface = l.Espresso.LightClient
 	}
 
+	// NewStreamer performs one L2 lookup (its anchor block's hash), so it gets the
+	// same per-call bound as every other startup RPC.
+	streamerCtx, cancel := l.networkTimeoutCtx(ctx)
+	defer cancel()
 	streamer, err := espressoStreamers.NewStreamer(
-		ctx,
+		streamerCtx,
 		l.Espresso.Client,
 		&batcherL1Adapter{L1Client: l.L1Client},
 		&batcherL2Adapter{EthClient: ethClient},
@@ -253,7 +267,7 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 	}
 
 	// Resolve the TEE verifier address from the BatchAuthenticator contract.
-	if err := l.resolveTEEVerifierAddress(); err != nil {
+	if err := l.resolveTEEVerifierAddress(l.killCtx); err != nil {
 		return fmt.Errorf("could not resolve TEE verifier address: %w", err)
 	}
 

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -86,12 +87,14 @@ func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 // that has reached genesis. It also returns an error rather than panicking, which
 // construction inside NewBatchSubmitter could not do.
 //
-// The streamer is constructed anchored at the local-safe head, not at the configured
-// --espresso.origin-height-l2: the anchor always ends up at the safe head anyway, and
-// NewStreamer resolves its anchor block's hash from the L2 client, which fails on
-// endpoints that no longer serve the (ever aging) configured height and would wedge
-// restarts. --espresso.origin-height-espresso keeps its role: it decides where the
-// streamer starts polling HotShot.
+// The streamer is anchored at max(local-safe head, --espresso.origin-height-l2):
+// the safe head normally, floored at the caffeination point so the streamer never
+// starts inside pre-Espresso history (those blocks are the fallback batcher's to
+// submit). Once the safe head is past the caffeination point, the configured height
+// is not looked up at all: NewStreamer resolves its anchor block's hash from the L2
+// client, which fails on endpoints that no longer serve the (ever aging) configured
+// height and would wedge restarts. --espresso.origin-height-espresso keeps its role:
+// it decides where the streamer starts polling HotShot.
 func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	if !l.Config.Espresso.Enabled {
 		return nil
@@ -100,6 +103,16 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	safeL2, err := l.waitForLocalSafeHead(ctx)
 	if err != nil {
 		return err
+	}
+
+	anchor := safeL2
+	if safeL2.Number < l.Config.Espresso.CaffeinationHeightL2 {
+		floor, err := l.resolveCaffeinationFloor(ctx)
+		if err != nil {
+			return err
+		}
+		l.espressoAnchorFloor = floor
+		anchor = floor
 	}
 
 	ethClient, err := l.EndpointProvider.EthClient(ctx)
@@ -127,18 +140,53 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 		l.Config.Espresso.PollInterval,
 		l.Log,
 		l.Config.Espresso.CaffeinationHeightEspresso,
-		safeL2.Number,
+		anchor.Number,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Espresso streamer: %w", err)
 	}
 	l.espressoStreamer = streamer
 
-	// Re-anchor on the exact ref from the sync status: NewStreamer resolved a hash for
-	// the same height, but the rollup node's view is the authoritative one.
-	streamer.SetBatchPosition(safeL2)
-	l.Log.Info("Anchored the Espresso streamer at the local-safe L2 head", "localSafeL2", safeL2)
+	// Re-anchor on the exact ref we resolved: NewStreamer resolved a hash for the
+	// same height, but the sync status / fetched block is the authoritative view.
+	streamer.SetBatchPosition(anchor)
+	l.Log.Info("Anchored the Espresso streamer", "anchor", anchor, "localSafeL2", safeL2)
 	return nil
+}
+
+// resolveCaffeinationFloor fetches the L2 block at --espresso.origin-height-l2 and
+// turns it into a full L2BlockRef (including its L1 origin, which the channel manager
+// needs when clearing against the floor). Only called while the local-safe head is
+// below the caffeination point, so the block is recent or pending: an error here
+// usually means the chain has not reached the configured height yet.
+func (l *BatchSubmitter) resolveCaffeinationFloor(ctx context.Context) (eth.L2BlockRef, error) {
+	height := l.Config.Espresso.CaffeinationHeightL2
+	block, err := l.fetchBlock(ctx, height)
+	if err != nil {
+		return eth.L2BlockRef{}, fmt.Errorf("fetching the caffeination L2 block %d (has the chain produced it yet?): %w", height, err)
+	}
+	ref, err := derive.L2BlockToBlockRef(l.RollupConfig, block)
+	if err != nil {
+		return eth.L2BlockRef{}, fmt.Errorf("deriving the block ref of the caffeination L2 block %d: %w", height, err)
+	}
+	return ref, nil
+}
+
+// espressoAnchorBase floors a local-safe head at the caffeination point: blocks at or
+// below --espresso.origin-height-l2 belong to the fallback batcher, so the streamer
+// must never be anchored into them and sync comparisons must not use a base inside
+// them. An empty ref is passed through so callers keep their "ignore empty" handling.
+func (l *BatchSubmitter) espressoAnchorBase(localSafe eth.L2BlockRef) eth.L2BlockRef {
+	if localSafe == (eth.L2BlockRef{}) || localSafe.Number >= l.Config.Espresso.CaffeinationHeightL2 {
+		return localSafe
+	}
+	if l.espressoAnchorFloor == (eth.L2BlockRef{}) {
+		// Only reachable if the safe head fell below the caffeination point after setup
+		// saw it above (a reorg deeper than the activation). Match pre-floor behavior.
+		l.Log.Error("Local-safe head below the caffeination point but no floor is cached, using the safe head", "localSafe", localSafe)
+		return localSafe
+	}
+	return l.espressoAnchorFloor
 }
 
 const (
@@ -285,5 +333,5 @@ func (l *BatchSubmitter) resetEspressoStreamer(ctx context.Context) {
 		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, keeping the current position", "err", err)
 		return
 	}
-	l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
+	l.espressoStreamer.SetBatchPosition(l.espressoAnchorBase(syncStatus.LocalSafeL2))
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -81,13 +81,25 @@ func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 // setupEspressoStreamer constructs the Espresso streamer for a BatchSubmitter that
 // is starting up; no-op when --espresso.enabled is false.
 //
-// Called from StartBatchSubmitting rather than NewBatchSubmitter: the streamer
-// resolves its anchor batch's hash from the L2 client while constructing, so it
-// needs a context and an L2 node that has reached genesis. It also returns an error
-// rather than panicking, which construction inside NewBatchSubmitter could not do.
+// Called from StartBatchSubmitting rather than NewBatchSubmitter: it waits for the
+// rollup node to report a local-safe L2 head, so it needs a context and an L2 node
+// that has reached genesis. It also returns an error rather than panicking, which
+// construction inside NewBatchSubmitter could not do.
+//
+// The streamer is constructed anchored at the local-safe head, not at the configured
+// --espresso.origin-height-l2: the anchor always ends up at the safe head anyway, and
+// NewStreamer resolves its anchor block's hash from the L2 client, which fails on
+// endpoints that no longer serve the (ever aging) configured height and would wedge
+// restarts. --espresso.origin-height-espresso keeps its role: it decides where the
+// streamer starts polling HotShot.
 func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 	if !l.Config.Espresso.Enabled {
 		return nil
+	}
+
+	safeL2, err := l.waitForLocalSafeHead(ctx)
+	if err != nil {
+		return err
 	}
 
 	ethClient, err := l.EndpointProvider.EthClient(ctx)
@@ -115,15 +127,18 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 		l.Config.Espresso.PollInterval,
 		l.Log,
 		l.Config.Espresso.CaffeinationHeightEspresso,
-		l.Config.Espresso.CaffeinationHeightL2,
+		safeL2.Number,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Espresso streamer: %w", err)
 	}
 	l.espressoStreamer = streamer
 
-	// Re-anchor to the safe L2 head.
-	return l.anchorEspressoStreamerAtSafeHead(ctx)
+	// Re-anchor on the exact ref from the sync status: NewStreamer resolved a hash for
+	// the same height, but the rollup node's view is the authoritative one.
+	streamer.SetBatchPosition(safeL2)
+	l.Log.Info("Anchored the Espresso streamer at the local-safe L2 head", "localSafeL2", safeL2)
+	return nil
 }
 
 const (
@@ -131,14 +146,13 @@ const (
 	espressoAnchorRetryInterval = 1 * time.Second
 )
 
-// anchorEspressoStreamerAtSafeHead repositions a freshly-constructed streamer from
-// its configured origin onto the current local-safe L2 head, waiting for the sync
-// status to report one.
+// waitForLocalSafeHead polls the sync status until it reports a local-safe L2 head to
+// anchor the streamer on, giving up after espressoAnchorTimeout.
 //
 // LocalSafeL2 rather than SafeL2 (cross-safe): every streamer anchor must share the
 // base computeSyncActions and safeL1Origin derive clearing/pruning from, and cross-safe
 // can lag local-safe (see the note in computeSyncActions).
-func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) error {
+func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockRef, error) {
 	ctx, cancel := context.WithTimeout(ctx, espressoAnchorTimeout)
 	defer cancel()
 
@@ -153,15 +167,13 @@ func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) e
 		case syncStatus.LocalSafeL2 == (eth.L2BlockRef{}):
 			l.Log.Warn("Sync status has no local-safe L2 head yet, retrying")
 		default:
-			l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
-			l.Log.Info("Anchored the Espresso streamer at the local-safe L2 head", "localSafeL2", syncStatus.LocalSafeL2)
-			return nil
+			return syncStatus.LocalSafeL2, nil
 		}
 
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
-			return fmt.Errorf("could not anchor the Espresso streamer at the safe L2 head within %s: %w", espressoAnchorTimeout, ctx.Err())
+			return eth.L2BlockRef{}, fmt.Errorf("no local-safe L2 head to anchor the Espresso streamer within %s: %w", espressoAnchorTimeout, ctx.Err())
 		}
 	}
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -132,8 +132,12 @@ const (
 )
 
 // anchorEspressoStreamerAtSafeHead repositions a freshly-constructed streamer from
-// its configured origin onto the current safe L2 head, waiting for the sync status
-// to report one.
+// its configured origin onto the current local-safe L2 head, waiting for the sync
+// status to report one.
+//
+// LocalSafeL2 rather than SafeL2 (cross-safe): every streamer anchor must share the
+// base computeSyncActions and safeL1Origin derive clearing/pruning from, and cross-safe
+// can lag local-safe (see the note in computeSyncActions).
 func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, espressoAnchorTimeout)
 	defer cancel()
@@ -146,11 +150,11 @@ func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) e
 		switch {
 		case err != nil:
 			l.Log.Warn("Failed to fetch sync status to anchor the Espresso streamer, retrying", "err", err)
-		case syncStatus.SafeL2 == (eth.L2BlockRef{}):
-			l.Log.Warn("Sync status has no safe L2 head yet, retrying")
+		case syncStatus.LocalSafeL2 == (eth.L2BlockRef{}):
+			l.Log.Warn("Sync status has no local-safe L2 head yet, retrying")
 		default:
-			l.espressoStreamer.SetBatchPosition(syncStatus.SafeL2)
-			l.Log.Info("Anchored the Espresso streamer at the safe L2 head", "safeL2", syncStatus.SafeL2)
+			l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
+			l.Log.Info("Anchored the Espresso streamer at the local-safe L2 head", "localSafeL2", syncStatus.LocalSafeL2)
 			return nil
 		}
 
@@ -237,10 +241,10 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 	return !isActive
 }
 
-// resetEspressoStreamer re-anchors the Espresso streamer to the safe L2 head when
-// --espresso.enabled is set; no-op otherwise. Called from clearState alongside the
+// resetEspressoStreamer re-anchors the Espresso streamer to the local-safe L2 head
+// when --espresso.enabled is set; no-op otherwise. Called from clearState alongside the
 // upstream channel-manager reset so the streamer's view of "next batch" matches the
-// freshly-cleared channel state.
+// freshly-cleared channel state (which is likewise derived from LocalSafeL2).
 //
 // The nil check covers the startup path: clearState runs before the streamer is
 // constructed, so the first call of a start cycle finds nothing to re-anchor.
@@ -253,5 +257,5 @@ func (l *BatchSubmitter) resetEspressoStreamer(ctx context.Context) {
 		l.Log.Warn("Failed to fetch sync status to re-anchor the Espresso streamer, keeping the current position", "err", err)
 		return
 	}
-	l.espressoStreamer.SetBatchPosition(syncStatus.SafeL2)
+	l.espressoStreamer.SetBatchPosition(syncStatus.LocalSafeL2)
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -166,6 +166,22 @@ func (l *BatchSubmitter) anchorEspressoStreamerAtSafeHead(ctx context.Context) e
 	}
 }
 
+// rollbackFailedStart undoes the startup state set at the top of StartBatchSubmitting
+// (running flag, shutdown/kill contexts) so a failed start does not wedge later
+// attempts behind "batcher is already running". Cancelling shutdownCtx also winds down
+// the streamer's poll loops if they were started, and Stop waits for them; a streamer
+// that was constructed but never started makes Stop a no-op. Only the Espresso setup
+// error paths roll back: the upstream error paths (waitForL2Genesis, waitNodeSync)
+// deliberately keep upstream's behavior. Caller must hold l.mutex.
+func (l *BatchSubmitter) rollbackFailedStart() {
+	l.cancelShutdownCtx()
+	l.cancelKillCtx()
+	if l.espressoStreamer != nil {
+		l.espressoStreamer.Stop()
+	}
+	l.running = false
+}
+
 // startEspressoLoops registers the batcher with the BatchAuthenticator
 // contract, resolves the TEE verifier address, spawns the Espresso transaction
 // submitter, and starts the four Espresso-specific batcher goroutines (in
@@ -183,9 +199,9 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 
 	// The streamer drives itself from its own poll loops, so it is started here rather
 	// than being pumped by espressoBatchLoadingLoop. Bound to shutdownCtx so it stops
-	// fetching before the publish path winds down. Must stay the last setup step that
-	// can fail: a failed StartBatchSubmitting returns without cancelling shutdownCtx,
-	// so an error after this point would leave the streamer's poll loops running.
+	// fetching before the publish path winds down. Kept as the last setup step that
+	// can fail, so a setup error never has running poll loops to unwind
+	// (rollbackFailedStart would stop them anyway).
 	if err := l.espressoStreamer.Start(l.shutdownCtx); err != nil {
 		return fmt.Errorf("could not start the Espresso streamer: %w", err)
 	}

--- a/op-batcher/batcher/espresso_service.go
+++ b/op-batcher/batcher/espresso_service.go
@@ -8,7 +8,6 @@ import (
 	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	espressoLightClient "github.com/EspressoSystems/espresso-network/sdks/go/light-client"
 	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
-	"github.com/EspressoSystems/espresso-streamers/op/derivation"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -55,7 +54,7 @@ type EspressoBatcherConfig struct {
 }
 
 // EspressoStreamer returns the Espresso batch streamer driven by this batcher.
-func (bs *BatcherService) EspressoStreamer() espressoStreamers.EspressoStreamer[derivation.EspressoBatch] {
+func (bs *BatcherService) EspressoStreamer() *espressoStreamers.Streamer {
 	return bs.driver.espressoStreamer
 }
 


### PR DESCRIPTION
### This PR

Points the streamer dependency at [espresso-streamers#36](https://github.com/EspressoSystems/espresso-streamers/pull/36) (op streamer v2, pinned to `22c396aa`) and adapts the batcher, following the reference integration in [optimism-espresso-integration#444](https://github.com/EspressoSystems/optimism-espresso-integration/pull/444):

- streamer constructed in `StartBatchSubmitting`, anchored at the safe L2 head, self-driven via `Start`/`Stop`
- loading loop just `Peek`s / `AdvancePosition`s; `peekNextBatch`, `cachedSyncStatus`, and all `Reset`/`SetProperHead`/`Refresh`/`Update` calls removed
- re-anchor (`SetBatchPosition(safeL2)`) instead of skipping on `ToBlock`/`AddL2Block` failures
- drop dead `BatchStreamerFromCLIConfig` (v1-only API, no callers)

Note: v2 owns the tip tracking (position and tip hash move together), so [the stall noted in this review comment on #459](https://github.com/celo-org/optimism/pull/459#discussion_r3692923141) is resolved as a consequence — `SetProperHead` no longer exists.

Whole module builds, `go vet` clean, full `op-batcher` test suite passes.

### Why v2 removes the stall

**Before (v1 + `batcher.peekNextBatch()`).** The derivation cursor was split across two components — the streamer held only a block *number*, the channel manager only a tip *hash* — and the batcher compared them assuming they described adjacent blocks. After a half-reset (streamer rewound, channel manager not cleared), the comparison crossed heights and could only be read as a fork:

```mermaid
flowchart LR
    subgraph SV1["Streamer v1"]
        POS["position = 50<br/>number only — Reset() rewound it 100 → 50"]
        BAT["candidates at height 50:<br/>batch 50 · parent = h(49)"]
    end
    subgraph CM["Channel manager"]
        TIP["tip = h(100)<br/>hash only — never cleared"]
    end
    POS -. "one logical cursor — split across two components" .- TIP
    PNB["batcher.peekNextBatch()<br/>batch.parent == tip ?<br/>h(49) ≠ h(100) ✗ — looks like a fork, isn't one"]
    BAT -- "Peek()" --> PNB
    TIP -- "tip" --> PNB
    PNB -- "SetProperHead(h(100)) → discard batch 50" --> SV1
    STALL(["∞ every candidate at height 50 has parent h(49)<br/>→ discarded again next tick → permanent stall"])
    PNB --> STALL
```

**After (v2).** The reviewer's suggested fix — *"or do the tip tracking in streamer"* — is what v2 does. Position and tip hash live in one struct behind one lock, and the only two mutators move both together, so `Peek()` always compares same-height hashes. The cross-component edge that caused the bug (`channelMgr.tip → SetProperHead`) is deleted along with both methods; a mismatch now returns nil and keeps the candidates instead of discarding them:

```mermaid
flowchart LR
    ADV["AdvancePosition()<br/>(50, h49) → (51, h50)"] --> CUR
    SBP["SetBatchPosition(ref)<br/>(ref.n + 1, ref.hash)"] --> CUR
    subgraph SV2["Streamer v2 · batchStore"]
        CUR["cursor: one struct, one lock<br/>nextBatchPos = 50<br/>tipHash = h(49)<br/>invariant: tipHash = h(nextBatchPos − 1)"]
    end
    CUR -- "Peek(): serve batch 50 only if parent == tipHash<br/>same height by construction · no match → nil, nothing discarded" --> OUT["batch 50 → channel manager"]
    CM2["Channel manager tip:<br/>never consulted anymore"] -. "✗ edge deleted (was: tip → SetProperHead)" .-x CUR
```

**If the two components still drift**, the loop self-heals instead of stalling: `AddL2Block` rejects the non-extending block and `clearState` re-anchors *both* sides from the same sync status — the "streamer was reset and channel manager was not" half-state can no longer be produced:

```mermaid
flowchart LR
    ADD["channelMgr.AddL2Block()<br/>rejects a block that doesn't extend its tip"] -- "error" --> CS["clearState()"]
    CS --> CLR["channelMgr.Clear(l1SafeOrigin)"]
    CS --> SBP2["streamer.SetBatchPosition(safeL2)"]
```

| v1 (removed) | what it moved | v2 replacement |
| --- | --- | --- |
| `Reset()` | number only — hash stayed wherever the channel manager left it | `SetBatchPosition(safeL2)` — number + hash set together from one block ref |
| `SetProperHead(hash)` | hash only — discarded the peeked batch | deleted — `Peek()` matches the parent internally; no match returns nil, candidates are kept |
| `Next()` | number only, past a possibly unconsumed batch | `AdvancePosition()` — promotes the just-peeked batch's own hash to tip as the number increments |
| `Refresh()` / `Update()` | pumped by the batcher on every loading-loop tick | `Start()` — the streamer runs its own finality and HotShot poll loops |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
