### PR TITLE
deps: raise go.mod go directive to 1.26.4 (audit Issue A follow-up)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ethereum-optimism/optimism
 
-go 1.26.0
-
-toolchain go1.26.4
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
## Summary

Follow-up to #476 (Least Authority audit Issue A).

#476 pinned Go 1.26.4 via a `toolchain go1.26.4` directive in `go.mod`, but that directive only takes effect when toolchain auto-download is enabled (`GOTOOLCHAIN=auto`). The official `golang` Docker images set `GOTOOLCHAIN=local`, which ignores the `toolchain` directive entirely — only the `go` directive is enforced, as a hard minimum. With `go 1.26.0`, a builder image older than 1.26.4 (e.g. `golang:1.26.1`) would silently compile with a stdlib missing the Issue A CVE fixes (GO-2026-4870 TLS KeyUpdate deadlock, GO-2026-5037 quadratic X.509 SAN verification).

This PR raises the `go` directive to `1.26.4`, so any build with an older toolchain fails loudly instead of silently producing a vulnerable binary. The `toolchain` line is removed because it is implied by the `go` line once the two are equal (`go mod tidy` deletes it automatically).

## Notes

- All Docker builder images (`ops/docker/op-stack-go`, `ops/docker/deployment-utils`, `cannon/Dockerfile.diff`, `op-program/Dockerfile.repro`/`.vmcompat`, kona `cannon-repro.dockerfile`) and the `mise.toml` CI pin are already on 1.26.4, so no other changes are needed.
- The intentionally old-pinned modules (`cannon/testdata/*`) are untouched.
- Verified locally: `go mod tidy -diff` is clean and packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217289097624718