### PR TITLE
op-batcher: key the publish gates on batch-auth enforcement, not fork time

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -162,6 +162,11 @@ type BatchSubmitter struct {
 	// clearStateRequested asks the espresso batch loading loop to run clearState
 	clearStateRequested atomic.Bool
 
+	// batchAuthEnforced memoizes the first time derive.IsEspressoAuthEnforced was
+	// observed true at the L1 tip; enforcement is monotone in time, so once set the
+	// publish gate skips the per-tick tip fetch (see isBatchAuthEnforcedAtTip).
+	batchAuthEnforced atomic.Bool
+
 	teeVerifierAddress common.Address
 
 	// degradedLog throttles repeated warnings from tick-driven loops so the

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -877,6 +877,12 @@ func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queu
 		}
 
 		if l.shouldSkipPublishForActiveSeq(ctx) {
+			// A force-publish must not override the gate (it would double-publish
+			// or revert), but dropping pi silently makes admin_flushBatcher look
+			// like it did nothing.
+			if pi.forcePublish {
+				l.Log.Warn("Discarding a forced publish: this batcher is not currently publishing (see the publish_gate_decision metric)")
+			}
 			return
 		}
 

--- a/op-batcher/batcher/espresso_active.go
+++ b/op-batcher/batcher/espresso_active.go
@@ -14,6 +14,11 @@ import (
 // the BatchAuthenticator contract. Returns true if this batcher instance should
 // be publishing batches, false if it should stay idle.
 //
+// Only meaningful once event-based batch auth is enforced: the caller
+// (shouldSkipPublishForActiveSeq) must gate on derive.IsEspressoAuthEnforced
+// first, since pre-enforcement the contract may be undeployed and its
+// activeIsEspresso default of true does not confer ownership.
+//
 // It applies two gates:
 //  1. Mode: the contract's activeIsEspresso flag must match this node's role
 //     (Config.Espresso.Enabled). activeIsEspresso==true means the Espresso batcher

--- a/op-batcher/batcher/espresso_active.go
+++ b/op-batcher/batcher/espresso_active.go
@@ -59,13 +59,17 @@ func (l *BatchSubmitter) isBatcherActive(ctx context.Context) (bool, error) {
 	modeActive := (activeIsEspresso && l.Config.Espresso.Enabled) ||
 		(!activeIsEspresso && !l.Config.Espresso.Enabled)
 	if !modeActive {
-		l.Log.Warn("Batcher is not the active batcher, skipping publish",
+		// Throttled: standing by while the other role publishes is a normal
+		// steady state (the TEE batcher idles as a hot standby until handoff),
+		// and the gate re-evaluates on every publish tick.
+		l.degradedLog.Warn(l.Log, "batcherNotActive", "Batcher is not the active batcher, skipping publish",
 			"batcherAddr", batcherAddr,
 			"activeIsEspresso", activeIsEspresso,
 			"EspressoEnabled", l.Config.Espresso.Enabled,
 		)
 		return false, nil
 	}
+	l.degradedLog.Clear(l.Log, "batcherNotActive", "Batcher is now the active batcher")
 
 	// Our mode is active; make sure our sender key is the authorized batcher for it,
 	// otherwise every publish reverts (Unauthorized*Batcher) in a loop.
@@ -83,13 +87,15 @@ func (l *BatchSubmitter) isBatcherActive(ctx context.Context) (bool, error) {
 	}
 
 	if batcherAddr != expected {
-		l.Log.Warn("Configured batcher key is not the authorized batcher for the active mode, skipping publish",
+		l.degradedLog.Warn(l.Log, "batcherKeyUnauthorized",
+			"Configured batcher key is not the authorized batcher for the active mode, skipping publish",
 			"batcherAddr", batcherAddr,
 			"expected", expected,
 			"activeIsEspresso", activeIsEspresso,
 		)
 		return false, nil
 	}
+	l.degradedLog.Clear(l.Log, "batcherKeyUnauthorized", "Configured batcher key is the authorized batcher again")
 
 	return true, nil
 }

--- a/op-batcher/batcher/espresso_active.go
+++ b/op-batcher/batcher/espresso_active.go
@@ -17,7 +17,8 @@ import (
 // Only meaningful once event-based batch auth is enforced: the caller
 // (shouldSkipPublishForActiveSeq) must gate on derive.IsEspressoAuthEnforced
 // first, since pre-enforcement the contract may be undeployed and its
-// activeIsEspresso default of true does not confer ownership.
+// activeIsEspresso flag does not confer ownership: only the SystemConfig batcher
+// key can publish a batch that derives before the boundary.
 //
 // It applies two gates:
 //  1. Mode: the contract's activeIsEspresso flag must match this node's role

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -286,27 +287,48 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 }
 
 // shouldSkipPublishForActiveSeq returns true if publishStateToL1 should skip
-// publishing because this batcher is not the on-chain "active" batcher
-// (BatchAuthenticator.activeIsEspresso). The Espresso TEE batcher always
-// honors the flag (it is fundamentally a post-fork actor); the fallback
-// batcher honors it only once fallback auth is required (pre-fork it must run
-// as a vanilla upstream Optimism batcher with no BatchAuthenticator coupling).
-// Fails closed: if either gate cannot be evaluated, publishing is skipped for
-// this tick and retried on the next.
+// publishing this tick. Ownership of batch submission is keyed on the verifier's
+// event-auth enforcement boundary (derive.IsEspressoAuthEnforced at the L1 tip
+// time), not on the EspressoTime fork or the BatchAuthenticator's
+// activeIsEspresso flag alone:
+//
+//   - Pre-enforcement (pre-fork and the whole grace window), derivation accepts
+//     only sender-authenticated batches from the SystemConfig batcher key. The
+//     fallback batcher therefore keeps publishing regardless of activeIsEspresso
+//     (which defaults to true and would otherwise stand it down mid-window), and
+//     the TEE batcher must not publish: its batches would mine, burn L1 fees,
+//     and be dropped by every verifier. The contract is not consulted at all.
+//   - Once enforced, the activeIsEspresso flag plus the sender-identity check
+//     (see isBatcherActive) decide which batcher owns publishing.
+//
+// Gating only the TEE side would not be enough: with activeIsEspresso=true
+// during the grace window the fallback would stand down, leaving a guaranteed
+// no-publisher gap. Keying both roles on the same boundary leaves no
+// dropped-sender window and no gap. Deciding on the L1 tip time is safe on both
+// sides of the boundary: enforcement is monotone in time and a batch published
+// now lands after the tip, so a TEE batch decided post-enforcement lands
+// enforced, and a fallback batch straddling the boundary stays valid because the
+// fallback event-authenticates from fork time (see isFallbackAuthRequired,
+// deliberately still keyed at fork time; the grace window exists to cover
+// exactly this inclusion delay).
+//
+// Fails closed: if any gate input cannot be evaluated, publishing is skipped
+// for this tick and retried on the next.
 func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool {
 	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
 		return false
 	}
-	consultActiveFlag := l.Config.Espresso.Enabled
-	if !consultActiveFlag {
-		fallbackAuthRequired, err := l.isFallbackAuthRequired(ctx)
-		if err != nil {
-			l.Log.Warn("Failed to evaluate fallback-auth gate, skipping publish", "err", err)
+	tip, err := l.l1Tip(ctx)
+	if err != nil {
+		l.Log.Warn("Failed to fetch the L1 tip for the publish gate, skipping publish", "err", err)
+		return true
+	}
+	if !derive.IsEspressoAuthEnforced(l.RollupConfig, tip.Time) {
+		if l.Config.Espresso.Enabled {
+			l.Log.Info("Event-based batch auth is not enforced at the L1 tip yet, leaving publishing to the fallback batcher",
+				"tipTime", tip.Time)
 			return true
 		}
-		consultActiveFlag = fallbackAuthRequired
-	}
-	if !consultActiveFlag {
 		return false
 	}
 	isActive, err := l.isBatcherActive(ctx)

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -291,9 +291,13 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 // enforcement boundary (derive.IsEspressoAuthEnforced at the L1 tip time):
 // pre-enforcement, only sender-authenticated batches from the SystemConfig
 // batcher key derive, so the fallback batcher publishes unconditionally —
-// without consulting activeIsEspresso, whose default of true would leave no
-// publisher — and the TEE batcher stands down rather than burn L1 fees on
-// batches every verifier drops. Once enforced, activeIsEspresso plus the
+// without consulting activeIsEspresso, which cannot confer ownership here — and
+// the TEE batcher stands down rather than burn L1 fees on batches every verifier
+// drops. That leaves the fallback as the only possible publisher before
+// enforcement, which is why activeIsEspresso must be false until the boundary:
+// with it set, the fallback's authenticateBatchInfo call reverts and takes the
+// paired batch leg with it. See op-batcher/readme.md. Once enforced,
+// the flag is consulted normally, and activeIsEspresso plus the
 // sender-identity check decide (see isBatcherActive).
 //
 // Deciding on the tip time is safe on both sides of the boundary: enforcement

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -295,22 +295,20 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 //   - Pre-enforcement (pre-fork and the whole grace window), derivation accepts
 //     only sender-authenticated batches from the SystemConfig batcher key. The
 //     fallback batcher therefore keeps publishing regardless of activeIsEspresso
-//     (which defaults to true and would otherwise stand it down mid-window), and
-//     the TEE batcher must not publish: its batches would mine, burn L1 fees,
-//     and be dropped by every verifier. The contract is not consulted at all.
+//     — which defaults to true and would otherwise stand it down mid-window,
+//     leaving no publisher at all — and the TEE batcher must not publish: its
+//     batches would mine, burn L1 fees, and be dropped by every verifier. The
+//     contract is not consulted at all.
 //   - Once enforced, the activeIsEspresso flag plus the sender-identity check
 //     (see isBatcherActive) decide which batcher owns publishing.
 //
-// Gating only the TEE side would not be enough: with activeIsEspresso=true
-// during the grace window the fallback would stand down, leaving a guaranteed
-// no-publisher gap. Keying both roles on the same boundary leaves no
-// dropped-sender window and no gap. Deciding on the L1 tip time is safe on both
-// sides of the boundary: enforcement is monotone in time and a batch published
-// now lands after the tip, so a TEE batch decided post-enforcement lands
-// enforced, and a fallback batch straddling the boundary stays valid because the
-// fallback event-authenticates from fork time (see isFallbackAuthRequired,
-// deliberately still keyed at fork time; the grace window exists to cover
-// exactly this inclusion delay).
+// Deciding on the L1 tip time is safe on both sides of the boundary:
+// enforcement is monotone in time and a batch published now lands after the
+// tip, so a TEE batch decided post-enforcement lands enforced, and a fallback
+// batch straddling the boundary stays valid because the fallback
+// event-authenticates from fork time (see isFallbackAuthRequired, deliberately
+// still keyed at fork time; the grace window exists to cover exactly this
+// inclusion delay).
 //
 // Fails closed: if any gate input cannot be evaluated, publishing is skipped
 // for this tick and retried on the next.
@@ -318,15 +316,14 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
 		return false
 	}
-	tip, err := l.l1Tip(ctx)
+	enforced, err := l.isBatchAuthEnforcedAtTip(ctx)
 	if err != nil {
-		l.Log.Warn("Failed to fetch the L1 tip for the publish gate, skipping publish", "err", err)
+		l.Log.Warn("Failed to evaluate the batch-auth enforcement boundary, skipping publish", "err", err)
 		return true
 	}
-	if !derive.IsEspressoAuthEnforced(l.RollupConfig, tip.Time) {
+	if !enforced {
 		if l.Config.Espresso.Enabled {
-			l.Log.Info("Event-based batch auth is not enforced at the L1 tip yet, leaving publishing to the fallback batcher",
-				"tipTime", tip.Time)
+			l.Log.Debug("Event-based batch auth is not enforced at the L1 tip yet, leaving publishing to the fallback batcher")
 			return true
 		}
 		return false
@@ -337,6 +334,33 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 		return true
 	}
 	return !isActive
+}
+
+// isBatchAuthEnforcedAtTip reports whether event-based batch authentication is
+// enforced at the current L1 tip. Enforcement is monotone in time — once true it
+// never reverts — so the first true observation is memoized on batchAuthEnforced
+// and later calls skip the tip fetch; the gate runs once per publishStateToL1
+// iteration, so post-enforcement (the chain's steady state forever) this keeps
+// the per-tick cost at the isBatcherActive contract reads alone. An unscheduled
+// fork can never enforce and is answered without any RPC.
+func (l *BatchSubmitter) isBatchAuthEnforcedAtTip(ctx context.Context) (bool, error) {
+	if l.batchAuthEnforced.Load() {
+		return true, nil
+	}
+	if l.RollupConfig.EspressoTime == nil {
+		return false, nil
+	}
+	tip, err := l.l1Tip(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fetching the L1 tip for the enforcement boundary: %w", err)
+	}
+	if !derive.IsEspressoAuthEnforced(l.RollupConfig, tip.Time) {
+		return false, nil
+	}
+	if l.batchAuthEnforced.CompareAndSwap(false, true) {
+		l.Log.Info("Event-based batch authentication is now enforced at the L1 tip", "tipTime", tip.Time)
+	}
+	return true, nil
 }
 
 // espressoReanchorTarget fetches the local-safe L2 head the Espresso streamer

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -287,31 +287,23 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 }
 
 // shouldSkipPublishForActiveSeq returns true if publishStateToL1 should skip
-// publishing this tick. Ownership of batch submission is keyed on the verifier's
-// event-auth enforcement boundary (derive.IsEspressoAuthEnforced at the L1 tip
-// time), not on the EspressoTime fork or the BatchAuthenticator's
-// activeIsEspresso flag alone:
+// publishing this tick. Batch-submission ownership is keyed on the verifier's
+// enforcement boundary (derive.IsEspressoAuthEnforced at the L1 tip time):
+// pre-enforcement, only sender-authenticated batches from the SystemConfig
+// batcher key derive, so the fallback batcher publishes unconditionally —
+// without consulting activeIsEspresso, whose default of true would leave no
+// publisher — and the TEE batcher stands down rather than burn L1 fees on
+// batches every verifier drops. Once enforced, activeIsEspresso plus the
+// sender-identity check decide (see isBatcherActive).
 //
-//   - Pre-enforcement (pre-fork and the whole grace window), derivation accepts
-//     only sender-authenticated batches from the SystemConfig batcher key. The
-//     fallback batcher therefore keeps publishing regardless of activeIsEspresso
-//     — which defaults to true and would otherwise stand it down mid-window,
-//     leaving no publisher at all — and the TEE batcher must not publish: its
-//     batches would mine, burn L1 fees, and be dropped by every verifier. The
-//     contract is not consulted at all.
-//   - Once enforced, the activeIsEspresso flag plus the sender-identity check
-//     (see isBatcherActive) decide which batcher owns publishing.
-//
-// Deciding on the L1 tip time is safe on both sides of the boundary:
-// enforcement is monotone in time and a batch published now lands after the
-// tip, so a TEE batch decided post-enforcement lands enforced, and a fallback
+// Deciding on the tip time is safe on both sides of the boundary: enforcement
+// is monotone and a batch published now lands after the tip, and a fallback
 // batch straddling the boundary stays valid because the fallback
-// event-authenticates from fork time (see isFallbackAuthRequired, deliberately
-// still keyed at fork time; the grace window exists to cover exactly this
-// inclusion delay).
+// event-authenticates from fork time (see isFallbackAuthRequired; the grace
+// window exists to cover exactly this inclusion delay).
 //
-// Fails closed: if any gate input cannot be evaluated, publishing is skipped
-// for this tick and retried on the next.
+// Fails closed: if a gate input cannot be evaluated, publishing is skipped for
+// this tick and retried on the next.
 func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool {
 	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
 		return false

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
@@ -309,27 +310,45 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 // Fails closed: if a gate input cannot be evaluated, publishing is skipped for
 // this tick and retried on the next.
 func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool {
+	// No BatchAuthenticator: the gate does not apply, and reporting a decision
+	// would put the gauge on chains that have no such gate.
 	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
 		return false
 	}
+	decision := l.publishGateDecision(ctx)
+	l.Metr.RecordPublishGateDecision(decision)
+	return decision != metrics.PublishGatePublishing
+}
+
+// publishGateDecision evaluates the gate and reports why it decided as it did,
+// so the reason reaches the gauge rather than only the logs. Every non-publishing
+// answer is a skip; see shouldSkipPublishForActiveSeq for the ownership rules.
+func (l *BatchSubmitter) publishGateDecision(ctx context.Context) metrics.PublishGateDecision {
 	enforced, err := l.isBatchAuthEnforcedAtTip(ctx)
 	if err != nil {
-		l.Log.Warn("Failed to evaluate the batch-auth enforcement boundary, skipping publish", "err", err)
-		return true
+		l.degradedLog.Warn(l.Log, "publishGate/boundary",
+			"Failed to evaluate the batch-auth enforcement boundary, skipping publish", "err", err)
+		return metrics.PublishGateBoundaryUnavailable
 	}
+	l.degradedLog.Clear(l.Log, "publishGate/boundary", "Batch-auth enforcement boundary readable again")
 	if !enforced {
 		if l.Config.Espresso.Enabled {
 			l.Log.Debug("Event-based batch auth is not enforced at the L1 tip yet, leaving publishing to the fallback batcher")
-			return true
+			return metrics.PublishGateAwaitingEnforcement
 		}
-		return false
+		return metrics.PublishGatePublishing
 	}
 	isActive, err := l.isBatcherActive(ctx)
 	if err != nil {
-		l.Log.Warn("Failed to check if batcher is active, skipping publish", "err", err)
-		return true
+		l.degradedLog.Warn(l.Log, "publishGate/activeCheck",
+			"Failed to check if batcher is active, skipping publish", "err", err)
+		return metrics.PublishGateActiveCheckFailed
 	}
-	return !isActive
+	l.degradedLog.Clear(l.Log, "publishGate/activeCheck", "Batcher active-check reads recovered")
+	if !isActive {
+		return metrics.PublishGateNotActiveBatcher
+	}
+	return metrics.PublishGatePublishing
 }
 
 // isBatchAuthEnforcedAtTip reports whether event-based batch authentication is

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -329,12 +329,10 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 }
 
 // isBatchAuthEnforcedAtTip reports whether event-based batch authentication is
-// enforced at the current L1 tip. Enforcement is monotone in time — once true it
-// never reverts — so the first true observation is memoized on batchAuthEnforced
-// and later calls skip the tip fetch; the gate runs once per publishStateToL1
-// iteration, so post-enforcement (the chain's steady state forever) this keeps
-// the per-tick cost at the isBatcherActive contract reads alone. An unscheduled
-// fork can never enforce and is answered without any RPC.
+// enforced at the current L1 tip. Enforcement is monotone in time, so the first
+// true observation is memoized and later calls skip the tip fetch — the gate
+// runs every publish tick, forever. An unscheduled fork never enforces and is
+// answered without any RPC.
 func (l *BatchSubmitter) isBatchAuthEnforcedAtTip(ctx context.Context) (bool, error) {
 	if l.batchAuthEnforced.Load() {
 		return true, nil

--- a/op-batcher/batcher/espresso_fallback_gate.go
+++ b/op-batcher/batcher/espresso_fallback_gate.go
@@ -18,8 +18,10 @@ import (
 // fallback batcher consults isFallbackAuthRequired to gate authentication
 // behind the EspressoTime hardfork: pre-fork the verifier accepts plain
 // sender-authenticated batches, and the BatchAuthenticator contract is
-// irrelevant; calling authenticateBatchInfo pre-fork would also revert against
-// the default activeIsEspresso=true contract state.
+// irrelevant. From EspressoTime onward the fallback authenticates every batch,
+// which requires activeIsEspresso to be false: the contract's fallback branch is
+// the only one its key can satisfy, and a rejected auth leg cancels the paired
+// batch leg. See op-batcher/readme.md.
 func (l *BatchSubmitter) dispatchAuthenticatedSendTx(txdata txData, isCancel bool, candidate *txmgr.TxCandidate, queue TxSender[txRef], receiptsCh chan txmgr.TxReceipt[txRef]) bool {
 	if isCancel {
 		return false

--- a/op-batcher/batcher/espresso_publish_gate_test.go
+++ b/op-batcher/batcher/espresso_publish_gate_test.go
@@ -22,9 +22,30 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
+
+// noContractL1Client is an L1Client that serves the tip but fails the test on any
+// contract read. Pre-enforcement publish decisions must not depend on contract
+// state (the #492 regression consulted activeIsEspresso in-window), and a mock
+// with a nil embedded ContractBackend would enforce that by segfaulting the whole
+// binary rather than naming the offending call.
+type noContractL1Client struct {
+	mockFixedTimeL1Client
+	t *testing.T
+}
+
+func (c *noContractL1Client) CodeAt(context.Context, common.Address, *big.Int) ([]byte, error) {
+	c.t.Fatal("publish gate read contract code pre-enforcement; the decision must not depend on contract state")
+	return nil, nil
+}
+
+func (c *noContractL1Client) CallContract(context.Context, ethereum.CallMsg, *big.Int) ([]byte, error) {
+	c.t.Fatal("publish gate called the contract pre-enforcement; the decision must not depend on contract state")
+	return nil, nil
+}
 
 // errTipL1Client fails every tip fetch, for the fail-closed path of the
 // publish gate.
@@ -55,6 +76,7 @@ func mustParseABI(md *bind.MetaData) *abi.ABI {
 // from the same abigen bindings the production code calls through.
 type fakeBatchAuthBackend struct {
 	mockFixedTimeL1Client
+	t                *testing.T
 	authAddr         common.Address
 	sysCfgAddr       common.Address
 	activeIsEspresso bool
@@ -87,7 +109,62 @@ func (f *fakeBatchAuthBackend) CallContract(ctx context.Context, call ethereum.C
 			return r.abi.Methods[r.method].Outputs.Pack(r.value)
 		}
 	}
-	return nil, fmt.Errorf("unexpected contract call to %s with data %x", call.To, call.Data)
+	// Fail the test rather than only the call: the gate turns any error into a
+	// skip, so a call dispatched to the wrong address or method would otherwise
+	// be indistinguishable from a legitimate fail-closed decision and leave the
+	// skip-expecting cases passing for the wrong reason.
+	err := fmt.Errorf("unexpected contract call to %s with data %x", call.To, call.Data)
+	f.t.Error(err)
+	return nil, err
+}
+
+// Fixture addresses shared by the publish-gate tests.
+var (
+	gateAuthAddr    = common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	gateSysCfgAddr  = common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	gateTeeKey      = common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	gateFallbackKey = common.HexToAddress("0x00000000000000000000000000000000000000c2")
+)
+
+// newAuthBackend builds a fake BatchAuthenticator view at the given tip time.
+func newAuthBackend(t *testing.T, tipTime uint64, activeIsEspresso bool, callErr error) fakeBatchAuthBackend {
+	return fakeBatchAuthBackend{
+		mockFixedTimeL1Client: mockFixedTimeL1Client{time: tipTime},
+		t:                     t,
+		authAddr:              gateAuthAddr,
+		sysCfgAddr:            gateSysCfgAddr,
+		activeIsEspresso:      activeIsEspresso,
+		espressoBatcher:       gateTeeKey,
+		fallbackBatcher:       gateFallbackKey,
+		callErr:               callErr,
+	}
+}
+
+// newGateSubmitter builds a BatchSubmitter carrying the fields the publish gate
+// reads, standing in for the ones NewBatchSubmitter would have populated. A zero
+// authAddr or a nil espressoTime leaves that part of the rollup config unset.
+func newGateSubmitter(
+	t *testing.T,
+	l1 L1Client,
+	espressoEnabled bool,
+	from common.Address,
+	espressoTime *uint64,
+	authAddr common.Address,
+) *BatchSubmitter {
+	logger := testlog.Logger(t, log.LevelDebug)
+	l := &BatchSubmitter{}
+	l.Log = logger
+	l.degradedLog = oplog.NewRepeatStateLogger()
+	l.Metr = metrics.NoopMetrics
+	l.RollupConfig = &rollup.Config{
+		EspressoTime:              espressoTime,
+		BatchAuthenticatorAddress: authAddr,
+	}
+	l.Config.NetworkTimeout = time.Second
+	l.Config.Espresso.Enabled = espressoEnabled
+	l.L1Client = l1
+	l.Txmgr = testutils.NewFakeTxMgr(logger, from, eth.ChainIDFromUInt64(0))
+	return l
 }
 
 // contractState is the post-enforcement BatchAuthenticator view a test case
@@ -108,10 +185,6 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 	const espressoTime uint64 = 1_000_000
 	enforcementTime := espressoTime + derive.BatchAuthEnforcementDelaySecs
 
-	authAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
-	sysCfgAddr := common.HexToAddress("0x00000000000000000000000000000000000000bb")
-	teeKey := common.HexToAddress("0x00000000000000000000000000000000000000c1")
-	fallbackKey := common.HexToAddress("0x00000000000000000000000000000000000000c2")
 	wrongKey := common.HexToAddress("0x00000000000000000000000000000000000000c9")
 
 	tests := []struct {
@@ -120,11 +193,10 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 		unscheduled     bool // leave EspressoTime nil
 		tipTime         uint64
 		tipErr          bool
-		// contract is nil for pre-enforcement cases: they run against the bare
-		// mockFixedTimeL1Client, whose embedded ContractBackend is nil, so any
-		// contract consult panics the test — in-window publish decisions must
-		// not depend on contract state (the #492 regression consulted
-		// activeIsEspresso in-window).
+		// contract is nil for pre-enforcement cases: they run against
+		// noContractL1Client, which fails the test on any contract read —
+		// in-window publish decisions must not depend on contract state (the
+		// #492 regression consulted activeIsEspresso in-window).
 		contract *contractState
 		// teeFrom/fallbackFrom override the role's authorized key (teeKey /
 		// fallbackKey) to exercise the identity checks.
@@ -229,42 +301,32 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 				case test.tipErr:
 					l1Client = &errTipL1Client{}
 				case test.contract == nil:
-					l1Client = &mockFixedTimeL1Client{time: test.tipTime}
-				default:
-					l1Client = &fakeBatchAuthBackend{
+					l1Client = &noContractL1Client{
 						mockFixedTimeL1Client: mockFixedTimeL1Client{time: test.tipTime},
-						authAddr:              authAddr,
-						sysCfgAddr:            sysCfgAddr,
-						activeIsEspresso:      test.contract.activeIsEspresso,
-						espressoBatcher:       teeKey,
-						fallbackBatcher:       fallbackKey,
-						callErr:               test.contract.callErr,
+						t:                     t,
 					}
+				default:
+					backend := newAuthBackend(t, test.tipTime, test.contract.activeIsEspresso, test.contract.callErr)
+					l1Client = &backend
 				}
 
-				from, override, wantSkip := fallbackKey, test.fallbackFrom, test.wantSkipFallback
+				from, override, wantSkip := gateFallbackKey, test.fallbackFrom, test.wantSkipFallback
 				if role.espresso {
-					from, override, wantSkip = teeKey, test.teeFrom, test.wantSkipTee
+					from, override, wantSkip = gateTeeKey, test.teeFrom, test.wantSkipTee
 				}
 				if override != (common.Address{}) {
 					from = override
 				}
 
-				logger := testlog.Logger(t, log.LevelDebug)
-				l := &BatchSubmitter{}
-				l.Log = logger
-				l.Metr = metrics.NoopMetrics
-				l.RollupConfig = &rollup.Config{}
-				if !test.noAuthenticator {
-					l.RollupConfig.BatchAuthenticatorAddress = authAddr
-				}
+				var cfgEspressoTime *uint64
 				if !test.unscheduled {
-					l.RollupConfig.EspressoTime = u64(espressoTime)
+					cfgEspressoTime = u64(espressoTime)
 				}
-				l.Config.NetworkTimeout = time.Second
-				l.Config.Espresso.Enabled = role.espresso
-				l.L1Client = l1Client
-				l.Txmgr = testutils.NewFakeTxMgr(logger, from, eth.ChainIDFromUInt64(0))
+				var cfgAuthAddr common.Address
+				if !test.noAuthenticator {
+					cfgAuthAddr = gateAuthAddr
+				}
+				l := newGateSubmitter(t, l1Client, role.espresso, from, cfgEspressoTime, cfgAuthAddr)
 
 				require.Equal(t, wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
 			})
@@ -316,11 +378,6 @@ func batchLands(enforced, authenticates, authAccepted bool, sender, fallbackBatc
 func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
 	const espressoTime uint64 = 1_000_000
 
-	authAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
-	sysCfgAddr := common.HexToAddress("0x00000000000000000000000000000000000000bb")
-	teeKey := common.HexToAddress("0x00000000000000000000000000000000000000c1")
-	fallbackKey := common.HexToAddress("0x00000000000000000000000000000000000000c2")
-
 	regions := []struct {
 		name string
 		tip  uint64
@@ -334,8 +391,8 @@ func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
 		espresso bool
 		from     common.Address
 	}{
-		{"fallback", false, fallbackKey},
-		{"tee", true, teeKey},
+		{"fallback", false, gateFallbackKey},
+		{"tee", true, gateTeeKey},
 	}
 
 	for _, region := range regions {
@@ -343,25 +400,8 @@ func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/activeIsEspresso=%v", region.name, activeIsEspresso), func(t *testing.T) {
 				var publishing, landing []string
 				for _, role := range roles {
-					logger := testlog.Logger(t, log.LevelDebug)
-					l := &BatchSubmitter{}
-					l.Log = logger
-					l.Metr = metrics.NoopMetrics
-					l.RollupConfig = &rollup.Config{
-						EspressoTime:              u64(espressoTime),
-						BatchAuthenticatorAddress: authAddr,
-					}
-					l.Config.NetworkTimeout = time.Second
-					l.Config.Espresso.Enabled = role.espresso
-					l.L1Client = &fakeBatchAuthBackend{
-						mockFixedTimeL1Client: mockFixedTimeL1Client{time: region.tip},
-						authAddr:              authAddr,
-						sysCfgAddr:            sysCfgAddr,
-						activeIsEspresso:      activeIsEspresso,
-						espressoBatcher:       teeKey,
-						fallbackBatcher:       fallbackKey,
-					}
-					l.Txmgr = testutils.NewFakeTxMgr(logger, role.from, eth.ChainIDFromUInt64(0))
+					backend := newAuthBackend(t, region.tip, activeIsEspresso, nil)
+					l := newGateSubmitter(t, &backend, role.espresso, role.from, u64(espressoTime), gateAuthAddr)
 
 					if l.shouldSkipPublishForActiveSeq(context.Background()) {
 						continue
@@ -376,9 +416,9 @@ func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
 						require.NoError(t, err)
 						authenticates = required
 					}
-					accepted := contractAcceptsAuth(activeIsEspresso, role.from, teeKey, fallbackKey)
+					accepted := contractAcceptsAuth(activeIsEspresso, role.from, gateTeeKey, gateFallbackKey)
 					enforced := region.tip >= espressoTime+derive.BatchAuthEnforcementDelaySecs
-					if batchLands(enforced, authenticates, accepted, role.from, fallbackKey) {
+					if batchLands(enforced, authenticates, accepted, role.from, gateFallbackKey) {
 						landing = append(landing, role.name)
 					}
 				}
@@ -394,4 +434,94 @@ func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
 			})
 		}
 	}
+}
+
+// countingTipL1Client serves a tip whose time and failure mode can be changed
+// between calls and counts the tip fetches the gate performs, so the enforcement
+// memo's effect is observable. It embeds fakeBatchAuthBackend so isBatcherActive
+// still has contract state to read once enforcement is reached.
+type countingTipL1Client struct {
+	fakeBatchAuthBackend
+	tipFetches int
+	tipErr     error
+}
+
+func (c *countingTipL1Client) HeaderByNumber(context.Context, *big.Int) (*types.Header, error) {
+	c.tipFetches++
+	if c.tipErr != nil {
+		return nil, c.tipErr
+	}
+	return &types.Header{Number: big.NewInt(0), Time: c.time}, nil
+}
+
+// TestIsBatchAuthEnforcedAtTip_Memoization pins the memo in
+// isBatchAuthEnforcedAtTip, which the boundary table above cannot reach: every
+// case there builds a fresh BatchSubmitter and calls the gate once, so the memo
+// is always false on entry.
+//
+// Enforcement is monotone in wall-clock time, so the first true observation is
+// latched. The consequences are that steady state stops fetching the tip, that a
+// tip going backwards does not un-enforce, and that a tip fetch failure stops
+// failing closed at this gate once latched — the last is a real behaviour change
+// and is pinned here deliberately. It is safe because it only shifts the decision
+// onto isBatcherActive, whose own contract reads still fail closed.
+func TestIsBatchAuthEnforcedAtTip_Memoization(t *testing.T) {
+	const espressoTime uint64 = 1_000_000
+	enforcementTime := espressoTime + derive.BatchAuthEnforcementDelaySecs
+
+	// The fallback role against activeIsEspresso=false: post-enforcement this is
+	// the active batcher, so the gate's answer turns on the boundary alone.
+	newSubmitter := func(t *testing.T, tipTime uint64) (*BatchSubmitter, *countingTipL1Client) {
+		client := &countingTipL1Client{fakeBatchAuthBackend: newAuthBackend(t, tipTime, false, nil)}
+		l := newGateSubmitter(t, client, false, gateFallbackKey, u64(espressoTime), gateAuthAddr)
+		return l, client
+	}
+
+	t.Run("enforced tip is fetched once, then memoized", func(t *testing.T) {
+		l, client := newSubmitter(t, enforcementTime)
+		for range 3 {
+			enforced, err := l.isBatchAuthEnforcedAtTip(context.Background())
+			require.NoError(t, err)
+			require.True(t, enforced)
+		}
+		require.Equal(t, 1, client.tipFetches, "later calls must short-circuit on the memo")
+	})
+
+	t.Run("pre-enforcement tip is re-fetched every call", func(t *testing.T) {
+		l, client := newSubmitter(t, enforcementTime-1)
+		for range 3 {
+			enforced, err := l.isBatchAuthEnforcedAtTip(context.Background())
+			require.NoError(t, err)
+			require.False(t, enforced)
+		}
+		require.Equal(t, 3, client.tipFetches, "nothing is latched until the boundary is observed")
+	})
+
+	t.Run("tip falling back below the boundary stays enforced", func(t *testing.T) {
+		l, client := newSubmitter(t, enforcementTime)
+		enforced, err := l.isBatchAuthEnforcedAtTip(context.Background())
+		require.NoError(t, err)
+		require.True(t, enforced)
+
+		// A deep L1 reorg could put the tip back inside the grace window. The
+		// verifier judges each batch by its own L1 origin time, so un-enforcing
+		// here would only hand publishing back to a role whose batches the
+		// post-reorg chain may already require events for.
+		client.time = espressoTime
+		enforced, err = l.isBatchAuthEnforcedAtTip(context.Background())
+		require.NoError(t, err)
+		require.True(t, enforced)
+		require.Equal(t, 1, client.tipFetches)
+	})
+
+	t.Run("memoized enforcement no longer fails closed on a tip fetch failure", func(t *testing.T) {
+		l, client := newSubmitter(t, enforcementTime)
+		require.False(t, l.shouldSkipPublishForActiveSeq(context.Background()),
+			"the fallback is the active batcher at enforcement")
+
+		client.tipErr = errors.New("l1 tip unavailable")
+		require.False(t, l.shouldSkipPublishForActiveSeq(context.Background()),
+			"the memo answers the boundary without a tip fetch, so the gate stays on isBatcherActive")
+		require.Equal(t, 1, client.tipFetches)
+	})
 }

--- a/op-batcher/batcher/espresso_publish_gate_test.go
+++ b/op-batcher/batcher/espresso_publish_gate_test.go
@@ -155,8 +155,8 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 		},
 		{
 			// The #492 regression: inside the grace window the fallback keeps
-			// publishing despite activeIsEspresso defaulting true, and the TEE
-			// batcher stands down instead of burning fees on dropped batches.
+			// publishing whatever activeIsEspresso says, and the TEE batcher
+			// stands down instead of burning fees on dropped batches.
 			name:             "at fork time, grace window opens",
 			tipTime:          espressoTime,
 			wantSkipTee:      true,
@@ -267,6 +267,130 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 				l.Txmgr = testutils.NewFakeTxMgr(logger, from, eth.ChainIDFromUInt64(0))
 
 				require.Equal(t, wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
+			})
+		}
+	}
+}
+
+// contractAcceptsAuth mirrors the sender check in
+// BatchAuthenticator.authenticateBatchInfo (src/L1/BatchAuthenticator.sol): with
+// activeIsEspresso set, only espressoBatcher() may authenticate; otherwise only the
+// SystemConfig batcher may. Pinned on the Solidity side by BatchAuthenticator.t.sol —
+// mirrored here so a cell can be evaluated without a chain.
+func contractAcceptsAuth(activeIsEspresso bool, sender, espressoBatcher, fallbackBatcher common.Address) bool {
+	if activeIsEspresso {
+		return sender == espressoBatcher
+	}
+	return sender == fallbackBatcher
+}
+
+// batchLands reports whether a batch published by sender would reach the safe chain,
+// composing two rules the batcher has to satisfy at once:
+//
+//   - derivation (isBatchTxAuthorized): pre-enforcement it authorizes on the L1 sender
+//     alone, so only the SystemConfig batcher's batches derive no matter what was
+//     authenticated; once enforced the batch needs a BatchInfoAuthenticated event from
+//     its own sender.
+//   - the txmgr pairing contract (SendPairAsync): a reverted auth leg cancels the batch
+//     leg, so an auth call the contract rejects stops the batch reaching L1 at all —
+//     even where derivation would not have required it.
+func batchLands(enforced, authenticates, authAccepted bool, sender, fallbackBatcher common.Address) bool {
+	if authenticates && !authAccepted {
+		return false // cancelled batch leg
+	}
+	if enforced {
+		return authenticates
+	}
+	return sender == fallbackBatcher
+}
+
+// TestPublishAuthInvariant_RoleTimeFlag checks, across role x L1-tip-region x
+// activeIsEspresso, that exactly one role publishes and its batch lands (see
+// batchLands). Batches are judged at their decision-time tip, not landing time, so
+// the straddle case stays with the fork-boundary tests.
+//
+// The excluded cell — grace window, activeIsEspresso true — is ruled out by
+// deployment, not code: the fallback publishes, its auth call reverts, and the
+// cancelled batch leg stalls the safe head. Asserted here as a stall to record the
+// dependency on the deploy scripts' false initializer; see op-batcher/readme.md.
+func TestPublishAuthInvariant_RoleTimeFlag(t *testing.T) {
+	const espressoTime uint64 = 1_000_000
+
+	authAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	sysCfgAddr := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	teeKey := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	fallbackKey := common.HexToAddress("0x00000000000000000000000000000000000000c2")
+
+	regions := []struct {
+		name string
+		tip  uint64
+	}{
+		{"pre-fork", espressoTime - 1},
+		{"grace window", espressoTime},
+		{"enforced", espressoTime + derive.BatchAuthEnforcementDelaySecs},
+	}
+	roles := []struct {
+		name     string
+		espresso bool
+		from     common.Address
+	}{
+		{"fallback", false, fallbackKey},
+		{"tee", true, teeKey},
+	}
+
+	for _, region := range regions {
+		for _, activeIsEspresso := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/activeIsEspresso=%v", region.name, activeIsEspresso), func(t *testing.T) {
+				var publishing, landing []string
+				for _, role := range roles {
+					logger := testlog.Logger(t, log.LevelDebug)
+					l := &BatchSubmitter{}
+					l.Log = logger
+					l.Metr = metrics.NoopMetrics
+					l.RollupConfig = &rollup.Config{
+						EspressoTime:              u64(espressoTime),
+						BatchAuthenticatorAddress: authAddr,
+					}
+					l.Config.NetworkTimeout = time.Second
+					l.Config.Espresso.Enabled = role.espresso
+					l.L1Client = &fakeBatchAuthBackend{
+						mockFixedTimeL1Client: mockFixedTimeL1Client{time: region.tip},
+						authAddr:              authAddr,
+						sysCfgAddr:            sysCfgAddr,
+						activeIsEspresso:      activeIsEspresso,
+						espressoBatcher:       teeKey,
+						fallbackBatcher:       fallbackKey,
+					}
+					l.Txmgr = testutils.NewFakeTxMgr(logger, role.from, eth.ChainIDFromUInt64(0))
+
+					if l.shouldSkipPublishForActiveSeq(context.Background()) {
+						continue
+					}
+					publishing = append(publishing, role.name)
+
+					// dispatchAuthenticatedSendTx always authenticates for the TEE
+					// role; the fallback consults the auth-dispatch gate.
+					authenticates := true
+					if !role.espresso {
+						required, err := l.isFallbackAuthRequired(context.Background())
+						require.NoError(t, err)
+						authenticates = required
+					}
+					accepted := contractAcceptsAuth(activeIsEspresso, role.from, teeKey, fallbackKey)
+					enforced := region.tip >= espressoTime+derive.BatchAuthEnforcementDelaySecs
+					if batchLands(enforced, authenticates, accepted, role.from, fallbackKey) {
+						landing = append(landing, role.name)
+					}
+				}
+
+				if region.name == "grace window" && activeIsEspresso {
+					// Excluded by deployment, not by code — see the doc comment.
+					require.Equal(t, []string{"fallback"}, publishing, "the fallback is the only role that may publish in the window")
+					require.Empty(t, landing, "no role can make progress in this cell")
+					return
+				}
+				require.Len(t, publishing, 1, "exactly one role must publish")
+				require.Equal(t, publishing, landing, "the publishing role's batch must land")
 			})
 		}
 	}

--- a/op-batcher/batcher/espresso_publish_gate_test.go
+++ b/op-batcher/batcher/espresso_publish_gate_test.go
@@ -1,6 +1,7 @@
 package batcher
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -9,12 +10,14 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/espresso/bindings"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -33,18 +36,23 @@ func (e *errTipL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*
 	return nil, errors.New("l1 tip unavailable")
 }
 
-func sel4(sig string) (s [4]byte) {
-	copy(s[:], gethcrypto.Keccak256([]byte(sig)))
-	return
+var (
+	batchAuthTestABI = mustParseABI(bindings.BatchAuthenticatorMetaData)
+	sysCfgTestABI    = mustParseABI(bindings.SystemConfigMetaData)
+)
+
+func mustParseABI(md *bind.MetaData) *abi.ABI {
+	parsed, err := md.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	return parsed
 }
 
 // fakeBatchAuthBackend extends mockFixedTimeL1Client with a CodeAt and
 // CallContract that serve the read-only BatchAuthenticator/SystemConfig calls
-// isBatcherActive makes, dispatching on (contract address, 4-byte selector).
-// Pre-enforcement test cases deliberately use the bare mockFixedTimeL1Client
-// instead: its embedded ContractBackend is nil, so any contract consult
-// panics the test — the publish decision inside the grace window must not
-// depend on contract state.
+// isBatcherActive makes, dispatching on (contract address, method ID) resolved
+// from the same abigen bindings the production code calls through.
 type fakeBatchAuthBackend struct {
 	mockFixedTimeL1Client
 	authAddr         common.Address
@@ -63,33 +71,39 @@ func (f *fakeBatchAuthBackend) CallContract(ctx context.Context, call ethereum.C
 	if f.callErr != nil {
 		return nil, f.callErr
 	}
-	var sel [4]byte
-	copy(sel[:], call.Data)
-	switch {
-	case *call.To == f.authAddr && sel == sel4("activeIsEspresso()"):
-		var out common.Hash
-		if f.activeIsEspresso {
-			out[31] = 1
-		}
-		return out[:], nil
-	case *call.To == f.authAddr && sel == sel4("espressoBatcher()"):
-		return common.BytesToHash(f.espressoBatcher.Bytes()).Bytes(), nil
-	case *call.To == f.authAddr && sel == sel4("systemConfig()"):
-		return common.BytesToHash(f.sysCfgAddr.Bytes()).Bytes(), nil
-	case *call.To == f.sysCfgAddr && sel == sel4("batcherHash()"):
-		return common.BytesToHash(f.fallbackBatcher.Bytes()).Bytes(), nil
+	responses := []struct {
+		to     common.Address
+		abi    *abi.ABI
+		method string
+		value  any
+	}{
+		{f.authAddr, batchAuthTestABI, "activeIsEspresso", f.activeIsEspresso},
+		{f.authAddr, batchAuthTestABI, "espressoBatcher", f.espressoBatcher},
+		{f.authAddr, batchAuthTestABI, "systemConfig", f.sysCfgAddr},
+		{f.sysCfgAddr, sysCfgTestABI, "batcherHash", [32]byte(common.BytesToHash(f.fallbackBatcher.Bytes()))},
 	}
-	return nil, fmt.Errorf("unexpected contract call to %s with selector %x", call.To, sel)
+	for _, r := range responses {
+		if *call.To == r.to && bytes.Equal(call.Data, r.abi.Methods[r.method].ID) {
+			return r.abi.Methods[r.method].Outputs.Pack(r.value)
+		}
+	}
+	return nil, fmt.Errorf("unexpected contract call to %s with data %x", call.To, call.Data)
+}
+
+// contractState is the post-enforcement BatchAuthenticator view a test case
+// runs against; a nil *contractState means the case must not consult the
+// contract at all.
+type contractState struct {
+	activeIsEspresso bool
+	callErr          error
 }
 
 // TestShouldSkipPublish_EnforcementBoundary locks batch-submission ownership to
-// the verifier's event-auth enforcement boundary (issue #492): the fallback
-// batcher owns publishing before enforcement — including the whole grace window,
-// regardless of activeIsEspresso — and the TEE batcher owns it after, subject to
-// the activeIsEspresso flag and the sender-identity check. A divergence here
-// either burns L1 fees on batches every verifier drops (TEE publishing
-// in-window) or stalls the safe head with no publisher at all (fallback standing
-// down in-window).
+// the verifier's event-auth enforcement boundary for both batcher roles (issue
+// #492); see shouldSkipPublishForActiveSeq for the ownership rationale. Every
+// case runs once per role, so the pre-enforcement invariant — the fallback
+// always publishes, the TEE batcher never does — reads directly off the two
+// want columns.
 func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 	const espressoTime uint64 = 1_000_000
 	enforcementTime := espressoTime + derive.BatchAuthEnforcementDelaySecs
@@ -100,223 +114,160 @@ func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
 	fallbackKey := common.HexToAddress("0x00000000000000000000000000000000000000c2")
 	wrongKey := common.HexToAddress("0x00000000000000000000000000000000000000c9")
 
-	// contractBackend builds the post-enforcement L1 client, parameterized on
-	// the tip time and the contract's flag/error state.
-	contractBackend := func(tipTime uint64, activeIsEspresso bool, callErr error) *fakeBatchAuthBackend {
-		return &fakeBatchAuthBackend{
-			mockFixedTimeL1Client: mockFixedTimeL1Client{time: tipTime},
-			authAddr:              authAddr,
-			sysCfgAddr:            sysCfgAddr,
-			activeIsEspresso:      activeIsEspresso,
-			espressoBatcher:       teeKey,
-			fallbackBatcher:       fallbackKey,
-			callErr:               callErr,
-		}
-	}
-
 	tests := []struct {
 		name            string
-		espressoEnabled bool
-		authAddr        common.Address
-		espressoTime    *uint64
-		l1Client        L1Client
-		from            common.Address
-		wantSkip        bool
+		noAuthenticator bool // leave BatchAuthenticatorAddress zero
+		unscheduled     bool // leave EspressoTime nil
+		tipTime         uint64
+		tipErr          bool
+		// contract is nil for pre-enforcement cases: they run against the bare
+		// mockFixedTimeL1Client, whose embedded ContractBackend is nil, so any
+		// contract consult panics the test — in-window publish decisions must
+		// not depend on contract state (the #492 regression consulted
+		// activeIsEspresso in-window).
+		contract *contractState
+		// teeFrom/fallbackFrom override the role's authorized key (teeKey /
+		// fallbackKey) to exercise the identity checks.
+		teeFrom          common.Address
+		fallbackFrom     common.Address
+		wantSkipTee      bool
+		wantSkipFallback bool
 	}{
-		// No authenticator configured: gate disabled for both roles.
 		{
-			name:            "fallback without authenticator never skips",
-			espressoEnabled: false,
-			authAddr:        common.Address{},
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
-			wantSkip:        false,
+			name:             "no authenticator configured",
+			noAuthenticator:  true,
+			tipTime:          enforcementTime,
+			wantSkipTee:      false,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "tee without authenticator never skips",
-			espressoEnabled: true,
-			authAddr:        common.Address{},
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
-			wantSkip:        false,
-		},
-		// Pre-enforcement: the bare mockFixedTimeL1Client panics on any
-		// contract consult, so these cases also prove the contract is not read.
-		{
-			name:            "fallback publishes when espresso is unscheduled",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    nil,
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
-			wantSkip:        false,
+			name:             "espresso unscheduled",
+			unscheduled:      true,
+			tipTime:          enforcementTime,
+			wantSkipTee:      true,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "tee skips when espresso is unscheduled",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    nil,
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
-			wantSkip:        true,
+			name:             "pre-fork",
+			tipTime:          espressoTime - 1,
+			wantSkipTee:      true,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "fallback publishes pre-fork",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: espressoTime - 1},
-			wantSkip:        false,
+			// The #492 regression: inside the grace window the fallback keeps
+			// publishing despite activeIsEspresso defaulting true, and the TEE
+			// batcher stands down instead of burning fees on dropped batches.
+			name:             "at fork time, grace window opens",
+			tipTime:          espressoTime,
+			wantSkipTee:      true,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "tee skips pre-fork",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: espressoTime - 1},
-			wantSkip:        true,
-		},
-		// The #492 regression: inside the grace window the fallback must keep
-		// publishing without consulting activeIsEspresso, and the TEE batcher
-		// must stand down instead of burning fees on batches derivation drops.
-		{
-			name:            "fallback publishes at fork time despite activeIsEspresso",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: espressoTime},
-			wantSkip:        false,
+			name:             "one second before enforcement",
+			tipTime:          enforcementTime - 1,
+			wantSkipTee:      true,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "tee skips at fork time",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: espressoTime},
-			wantSkip:        true,
+			name:             "at enforcement, espresso flagged active",
+			tipTime:          enforcementTime,
+			contract:         &contractState{activeIsEspresso: true},
+			wantSkipTee:      false,
+			wantSkipFallback: true,
 		},
 		{
-			name:            "fallback publishes one second before enforcement",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime - 1},
-			wantSkip:        false,
+			name:             "at enforcement, fallback flagged active",
+			tipTime:          enforcementTime,
+			contract:         &contractState{activeIsEspresso: false},
+			wantSkipTee:      true,
+			wantSkipFallback: false,
 		},
 		{
-			name:            "tee skips one second before enforcement",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &mockFixedTimeL1Client{time: enforcementTime - 1},
-			wantSkip:        true,
-		},
-		// Post-enforcement: activeIsEspresso plus the identity check decide.
-		{
-			name:            "tee publishes exactly at enforcement when active and authorized",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, true, nil),
-			from:            teeKey,
-			wantSkip:        false,
+			name:             "at enforcement, espresso active but tee key unauthorized",
+			tipTime:          enforcementTime,
+			contract:         &contractState{activeIsEspresso: true},
+			teeFrom:          wrongKey,
+			wantSkipTee:      true,
+			wantSkipFallback: true, // flag-skipped, identity not reached
 		},
 		{
-			name:            "fallback honors activeIsEspresso once enforced",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, true, nil),
-			from:            fallbackKey,
-			wantSkip:        true,
+			name:             "at enforcement, fallback active but fallback key unauthorized",
+			tipTime:          enforcementTime,
+			contract:         &contractState{activeIsEspresso: false},
+			fallbackFrom:     wrongKey,
+			wantSkipTee:      true, // flag-skipped, identity not reached
+			wantSkipFallback: true,
 		},
 		{
-			name:            "tee skips once enforced when fallback is active",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime+1, false, nil),
-			from:            teeKey,
-			wantSkip:        true,
+			name:             "at enforcement, contract unavailable fails closed",
+			tipTime:          enforcementTime,
+			contract:         &contractState{activeIsEspresso: true, callErr: errors.New("contract unavailable")},
+			wantSkipTee:      true,
+			wantSkipFallback: true,
 		},
 		{
-			name:            "fallback publishes once enforced when flagged active and authorized",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime+1, false, nil),
-			from:            fallbackKey,
-			wantSkip:        false,
+			name:             "tip fetch failure fails closed",
+			tipErr:           true,
+			wantSkipTee:      true,
+			wantSkipFallback: true,
 		},
-		{
-			name:            "tee skips once enforced when its key is not the espresso batcher",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, true, nil),
-			from:            wrongKey,
-			wantSkip:        true,
-		},
-		{
-			name:            "fallback skips once enforced when its key is not the systemconfig batcher",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, false, nil),
-			from:            wrongKey,
-			wantSkip:        true,
-		},
-		// Fail closed on unavailable gate inputs.
-		{
-			name:            "tee fails closed on contract errors once enforced",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, true, errors.New("contract unavailable")),
-			from:            teeKey,
-			wantSkip:        true,
-		},
-		{
-			name:            "fallback fails closed on contract errors once enforced",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        contractBackend(enforcementTime, false, errors.New("contract unavailable")),
-			from:            fallbackKey,
-			wantSkip:        true,
-		},
-		{
-			name:            "fallback fails closed on tip fetch errors",
-			espressoEnabled: false,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &errTipL1Client{},
-			wantSkip:        true,
-		},
-		{
-			name:            "tee fails closed on tip fetch errors",
-			espressoEnabled: true,
-			authAddr:        authAddr,
-			espressoTime:    u64(espressoTime),
-			l1Client:        &errTipL1Client{},
-			wantSkip:        true,
-		},
+	}
+
+	roles := []struct {
+		name     string
+		espresso bool
+	}{
+		{name: "fallback", espresso: false},
+		{name: "tee", espresso: true},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			logger := testlog.Logger(t, log.LevelDebug)
-			l := &BatchSubmitter{}
-			l.Log = logger
-			l.Metr = metrics.NoopMetrics
-			l.RollupConfig = &rollup.Config{
-				BatchAuthenticatorAddress: test.authAddr,
-				EspressoTime:              test.espressoTime,
-			}
-			l.Config.NetworkTimeout = time.Second
-			l.Config.Espresso.Enabled = test.espressoEnabled
-			l.L1Client = test.l1Client
-			l.Txmgr = testutils.NewFakeTxMgr(logger, test.from, eth.ChainIDFromUInt64(0))
+		for _, role := range roles {
+			t.Run(test.name+"/"+role.name, func(t *testing.T) {
+				var l1Client L1Client
+				switch {
+				case test.tipErr:
+					l1Client = &errTipL1Client{}
+				case test.contract == nil:
+					l1Client = &mockFixedTimeL1Client{time: test.tipTime}
+				default:
+					l1Client = &fakeBatchAuthBackend{
+						mockFixedTimeL1Client: mockFixedTimeL1Client{time: test.tipTime},
+						authAddr:              authAddr,
+						sysCfgAddr:            sysCfgAddr,
+						activeIsEspresso:      test.contract.activeIsEspresso,
+						espressoBatcher:       teeKey,
+						fallbackBatcher:       fallbackKey,
+						callErr:               test.contract.callErr,
+					}
+				}
 
-			require.Equal(t, test.wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
-		})
+				from, override, wantSkip := fallbackKey, test.fallbackFrom, test.wantSkipFallback
+				if role.espresso {
+					from, override, wantSkip = teeKey, test.teeFrom, test.wantSkipTee
+				}
+				if override != (common.Address{}) {
+					from = override
+				}
+
+				logger := testlog.Logger(t, log.LevelDebug)
+				l := &BatchSubmitter{}
+				l.Log = logger
+				l.Metr = metrics.NoopMetrics
+				l.RollupConfig = &rollup.Config{}
+				if !test.noAuthenticator {
+					l.RollupConfig.BatchAuthenticatorAddress = authAddr
+				}
+				if !test.unscheduled {
+					l.RollupConfig.EspressoTime = u64(espressoTime)
+				}
+				l.Config.NetworkTimeout = time.Second
+				l.Config.Espresso.Enabled = role.espresso
+				l.L1Client = l1Client
+				l.Txmgr = testutils.NewFakeTxMgr(logger, from, eth.ChainIDFromUInt64(0))
+
+				require.Equal(t, wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
+			})
+		}
 	}
 }

--- a/op-batcher/batcher/espresso_publish_gate_test.go
+++ b/op-batcher/batcher/espresso_publish_gate_test.go
@@ -1,0 +1,322 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// errTipL1Client fails every tip fetch, for the fail-closed path of the
+// publish gate.
+type errTipL1Client struct {
+	mockFixedTimeL1Client
+}
+
+func (e *errTipL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return nil, errors.New("l1 tip unavailable")
+}
+
+func sel4(sig string) (s [4]byte) {
+	copy(s[:], gethcrypto.Keccak256([]byte(sig)))
+	return
+}
+
+// fakeBatchAuthBackend extends mockFixedTimeL1Client with a CodeAt and
+// CallContract that serve the read-only BatchAuthenticator/SystemConfig calls
+// isBatcherActive makes, dispatching on (contract address, 4-byte selector).
+// Pre-enforcement test cases deliberately use the bare mockFixedTimeL1Client
+// instead: its embedded ContractBackend is nil, so any contract consult
+// panics the test — the publish decision inside the grace window must not
+// depend on contract state.
+type fakeBatchAuthBackend struct {
+	mockFixedTimeL1Client
+	authAddr         common.Address
+	sysCfgAddr       common.Address
+	activeIsEspresso bool
+	espressoBatcher  common.Address
+	fallbackBatcher  common.Address
+	callErr          error // when set, every CallContract fails
+}
+
+func (f *fakeBatchAuthBackend) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return []byte{0x01}, nil
+}
+
+func (f *fakeBatchAuthBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	if f.callErr != nil {
+		return nil, f.callErr
+	}
+	var sel [4]byte
+	copy(sel[:], call.Data)
+	switch {
+	case *call.To == f.authAddr && sel == sel4("activeIsEspresso()"):
+		var out common.Hash
+		if f.activeIsEspresso {
+			out[31] = 1
+		}
+		return out[:], nil
+	case *call.To == f.authAddr && sel == sel4("espressoBatcher()"):
+		return common.BytesToHash(f.espressoBatcher.Bytes()).Bytes(), nil
+	case *call.To == f.authAddr && sel == sel4("systemConfig()"):
+		return common.BytesToHash(f.sysCfgAddr.Bytes()).Bytes(), nil
+	case *call.To == f.sysCfgAddr && sel == sel4("batcherHash()"):
+		return common.BytesToHash(f.fallbackBatcher.Bytes()).Bytes(), nil
+	}
+	return nil, fmt.Errorf("unexpected contract call to %s with selector %x", call.To, sel)
+}
+
+// TestShouldSkipPublish_EnforcementBoundary locks batch-submission ownership to
+// the verifier's event-auth enforcement boundary (issue #492): the fallback
+// batcher owns publishing before enforcement — including the whole grace window,
+// regardless of activeIsEspresso — and the TEE batcher owns it after, subject to
+// the activeIsEspresso flag and the sender-identity check. A divergence here
+// either burns L1 fees on batches every verifier drops (TEE publishing
+// in-window) or stalls the safe head with no publisher at all (fallback standing
+// down in-window).
+func TestShouldSkipPublish_EnforcementBoundary(t *testing.T) {
+	const espressoTime uint64 = 1_000_000
+	enforcementTime := espressoTime + derive.BatchAuthEnforcementDelaySecs
+
+	authAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	sysCfgAddr := common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	teeKey := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	fallbackKey := common.HexToAddress("0x00000000000000000000000000000000000000c2")
+	wrongKey := common.HexToAddress("0x00000000000000000000000000000000000000c9")
+
+	// contractBackend builds the post-enforcement L1 client, parameterized on
+	// the tip time and the contract's flag/error state.
+	contractBackend := func(tipTime uint64, activeIsEspresso bool, callErr error) *fakeBatchAuthBackend {
+		return &fakeBatchAuthBackend{
+			mockFixedTimeL1Client: mockFixedTimeL1Client{time: tipTime},
+			authAddr:              authAddr,
+			sysCfgAddr:            sysCfgAddr,
+			activeIsEspresso:      activeIsEspresso,
+			espressoBatcher:       teeKey,
+			fallbackBatcher:       fallbackKey,
+			callErr:               callErr,
+		}
+	}
+
+	tests := []struct {
+		name            string
+		espressoEnabled bool
+		authAddr        common.Address
+		espressoTime    *uint64
+		l1Client        L1Client
+		from            common.Address
+		wantSkip        bool
+	}{
+		// No authenticator configured: gate disabled for both roles.
+		{
+			name:            "fallback without authenticator never skips",
+			espressoEnabled: false,
+			authAddr:        common.Address{},
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
+			wantSkip:        false,
+		},
+		{
+			name:            "tee without authenticator never skips",
+			espressoEnabled: true,
+			authAddr:        common.Address{},
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
+			wantSkip:        false,
+		},
+		// Pre-enforcement: the bare mockFixedTimeL1Client panics on any
+		// contract consult, so these cases also prove the contract is not read.
+		{
+			name:            "fallback publishes when espresso is unscheduled",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    nil,
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
+			wantSkip:        false,
+		},
+		{
+			name:            "tee skips when espresso is unscheduled",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    nil,
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime},
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback publishes pre-fork",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: espressoTime - 1},
+			wantSkip:        false,
+		},
+		{
+			name:            "tee skips pre-fork",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: espressoTime - 1},
+			wantSkip:        true,
+		},
+		// The #492 regression: inside the grace window the fallback must keep
+		// publishing without consulting activeIsEspresso, and the TEE batcher
+		// must stand down instead of burning fees on batches derivation drops.
+		{
+			name:            "fallback publishes at fork time despite activeIsEspresso",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: espressoTime},
+			wantSkip:        false,
+		},
+		{
+			name:            "tee skips at fork time",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: espressoTime},
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback publishes one second before enforcement",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime - 1},
+			wantSkip:        false,
+		},
+		{
+			name:            "tee skips one second before enforcement",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &mockFixedTimeL1Client{time: enforcementTime - 1},
+			wantSkip:        true,
+		},
+		// Post-enforcement: activeIsEspresso plus the identity check decide.
+		{
+			name:            "tee publishes exactly at enforcement when active and authorized",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, true, nil),
+			from:            teeKey,
+			wantSkip:        false,
+		},
+		{
+			name:            "fallback honors activeIsEspresso once enforced",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, true, nil),
+			from:            fallbackKey,
+			wantSkip:        true,
+		},
+		{
+			name:            "tee skips once enforced when fallback is active",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime+1, false, nil),
+			from:            teeKey,
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback publishes once enforced when flagged active and authorized",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime+1, false, nil),
+			from:            fallbackKey,
+			wantSkip:        false,
+		},
+		{
+			name:            "tee skips once enforced when its key is not the espresso batcher",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, true, nil),
+			from:            wrongKey,
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback skips once enforced when its key is not the systemconfig batcher",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, false, nil),
+			from:            wrongKey,
+			wantSkip:        true,
+		},
+		// Fail closed on unavailable gate inputs.
+		{
+			name:            "tee fails closed on contract errors once enforced",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, true, errors.New("contract unavailable")),
+			from:            teeKey,
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback fails closed on contract errors once enforced",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        contractBackend(enforcementTime, false, errors.New("contract unavailable")),
+			from:            fallbackKey,
+			wantSkip:        true,
+		},
+		{
+			name:            "fallback fails closed on tip fetch errors",
+			espressoEnabled: false,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &errTipL1Client{},
+			wantSkip:        true,
+		},
+		{
+			name:            "tee fails closed on tip fetch errors",
+			espressoEnabled: true,
+			authAddr:        authAddr,
+			espressoTime:    u64(espressoTime),
+			l1Client:        &errTipL1Client{},
+			wantSkip:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := testlog.Logger(t, log.LevelDebug)
+			l := &BatchSubmitter{}
+			l.Log = logger
+			l.Metr = metrics.NoopMetrics
+			l.RollupConfig = &rollup.Config{
+				BatchAuthenticatorAddress: test.authAddr,
+				EspressoTime:              test.espressoTime,
+			}
+			l.Config.NetworkTimeout = time.Second
+			l.Config.Espresso.Enabled = test.espressoEnabled
+			l.L1Client = test.l1Client
+			l.Txmgr = testutils.NewFakeTxMgr(logger, test.from, eth.ChainIDFromUInt64(0))
+
+			require.Equal(t, test.wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
+		})
+	}
+}

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -196,6 +196,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, closeApp contex
 	if err := bs.checkFallbackAuthConfirmations(cfg); err != nil {
 		return err
 	}
+	bs.warnIfEspressoUnscheduled(cfg)
 	if err := bs.initTxManager(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init Tx manager: %w", err)
 	}
@@ -306,6 +307,22 @@ func (bs *BatcherService) checkEspressoDataAvailability(cfg *CLIConfig) error {
 			cfg.DataAvailabilityType)
 	}
 	return nil
+}
+
+// warnIfEspressoUnscheduled reports the one configuration in which a TEE batcher
+// can never publish: --espresso.enabled with no espresso_time. The publish gate
+// keys on the enforcement boundary, which an unscheduled fork never reaches, so
+// the batcher starts, syncs, streams and then stands down forever — visible only
+// at Debug per tick, so say it once at startup where it is actionable. A warning
+// rather than an error, since standing down is correct here and refusing to start
+// would break running the TEE batcher ahead of scheduling the fork.
+func (bs *BatcherService) warnIfEspressoUnscheduled(cfg *CLIConfig) {
+	if !cfg.Espresso.Enabled || bs.RollupConfig.EspressoTime != nil {
+		return
+	}
+	bs.Log.Warn("Espresso batcher enabled on a chain with no espresso_time scheduled: " +
+		"it will never publish, since event-based batch auth is never enforced. " +
+		"The fallback batcher owns batch submission until the fork is scheduled and enforced.")
 }
 
 // checkFallbackAuthConfirmations validates that the configured number of L1

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -20,6 +20,40 @@ import (
 
 const Namespace = "op_batcher"
 
+// PublishGateDecision names the outcome of the Espresso publish gate
+// (shouldSkipPublishForActiveSeq) on a single tick. Exported as a gauge so a
+// batcher that is deliberately standing down can be told apart from one that is
+// wedged: both leave batch_tx_submitted flat and the safe head lagging, but only
+// the wedged one reports PublishGatePublishing while making no progress.
+type PublishGateDecision string
+
+const (
+	// PublishGatePublishing: the gate let this tick through.
+	PublishGatePublishing PublishGateDecision = "publishing"
+	// PublishGateBoundaryUnavailable: the enforcement boundary could not be
+	// evaluated (L1 tip fetch failed), so the tick failed closed.
+	PublishGateBoundaryUnavailable PublishGateDecision = "boundary_unavailable"
+	// PublishGateAwaitingEnforcement: event-based batch auth is not enforced at
+	// the L1 tip yet, so the TEE batcher leaves publishing to the fallback.
+	PublishGateAwaitingEnforcement PublishGateDecision = "awaiting_enforcement"
+	// PublishGateActiveCheckFailed: the BatchAuthenticator reads behind
+	// isBatcherActive failed, so the tick failed closed.
+	PublishGateActiveCheckFailed PublishGateDecision = "active_check_failed"
+	// PublishGateNotActiveBatcher: the contract names the other role, or this
+	// node's key is not the authorized batcher for its role.
+	PublishGateNotActiveBatcher PublishGateDecision = "not_active_batcher"
+)
+
+// PublishGateDecisions lists every decision, so the gauge can zero the labels
+// that do not apply on each observation.
+var PublishGateDecisions = []PublishGateDecision{
+	PublishGatePublishing,
+	PublishGateBoundaryUnavailable,
+	PublishGateAwaitingEnforcement,
+	PublishGateActiveCheckFailed,
+	PublishGateNotActiveBatcher,
+}
+
 type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
@@ -70,6 +104,7 @@ type Metricer interface {
 	RecordFailoverToEthDA()
 
 	RecordFallbackAuthWindowExceeded()
+	RecordPublishGateDecision(decision PublishGateDecision)
 
 	Document() []opmetrics.DocumentedMetric
 
@@ -116,6 +151,7 @@ type Metrics struct {
 	batchStoredDataSizeBytesTotal   prometheus.CounterVec
 	altDaFailoverTotal              prometheus.Counter
 	fallbackAuthWindowExceededTotal prometheus.Counter
+	publishGateDecision             prometheus.GaugeVec
 
 	batcherTxEvs opmetrics.EventVec
 
@@ -263,6 +299,11 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "fallback_auth_window_exceeded_total",
 			Help:      "Total number of fallback-auth submissions dropped because the batch tx landed beyond BatchAuthLookbackWindow blocks after its auth tx",
 		}),
+		publishGateDecision: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "publish_gate_decision",
+			Help:      "Outcome of the Espresso publish gate on the last tick; 1 on the active decision, 0 on the others",
+		}, []string{"decision"}),
 		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "blob_used_bytes",
@@ -493,6 +534,16 @@ func (m *Metrics) RecordFailoverToEthDA() {
 
 func (m *Metrics) RecordFallbackAuthWindowExceeded() {
 	m.fallbackAuthWindowExceededTotal.Inc()
+}
+
+func (m *Metrics) RecordPublishGateDecision(decision PublishGateDecision) {
+	for _, d := range PublishGateDecisions {
+		v := 0.0
+		if d == decision {
+			v = 1.0
+		}
+		m.publishGateDecision.WithLabelValues(string(d)).Set(v)
+	}
 }
 
 func (m *Metrics) RecordChannelQueueLength(len int) {

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -66,6 +66,8 @@ func (*noopMetrics) RecordBatchDataSizeBytes(string, int) {}
 func (*noopMetrics) RecordFailoverToEthDA()               {}
 func (*noopMetrics) RecordFallbackAuthWindowExceeded()    {}
 
+func (*noopMetrics) RecordPublishGateDecision(PublishGateDecision) {}
+
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -192,6 +192,18 @@ cast rpc admin_flushBatcher -r http://localhost:8545
 ```
 The command can either be run on the batcher host machine itself, or remotely by replacing `localhost` with the appropriate remote hostname.
 
+### Espresso batcher handoff
+
+On an Espresso chain the fallback batcher (signing with the `SystemConfig` batcher key) and the TEE batcher (`--espresso.enabled`) take turns publishing. `BatchAuthenticator.activeIsEspresso` decides which of the two the contract will authenticate for, and so which one can make progress.
+
+**`activeIsEspresso` must be `false` from deployment until event-based batch authentication is enforced**, i.e. until `espresso_time + BatchAuthEnforcementDelaySecs` (20 minutes). Both deploy scripts initialize it that way.
+
+Before that boundary, derivation authorizes batches on the L1 sender alone, so only the `SystemConfig` batcher key can publish anything that derives, and the TEE batcher stands down. The fallback starts calling `authenticateBatchInfo` at `espresso_time` — a full grace period early, so batches straddling the boundary stay valid — and that call only succeeds while the flag is `false`. With the flag set it reverts, the reverted auth leg cancels the paired batch leg, and the safe head stalls for the rest of the window while the batcher retries every tick.
+
+Past the boundary the constraint lifts: the fallback keeps event-authenticating indefinitely, so the handoff is not coupled to the fork. To hand off, confirm the TEE batcher has registered with the `BatchAuthenticator` and that the L1 tip is past the boundary, then call `setActiveIsEspresso(true)`. Handing back is the same with `false`.
+
+A `BatchAuthenticator` deployed before the scripts were corrected was initialized with `true`, and needs `setActiveIsEspresso(false)` before `espresso_time` is reached.
+
 ## Known issues and future work
 
 Link to [open issues with the `op-batcher` tag](https://github.com/ethereum-optimism/optimism/issues?q=is%3Aopen+is%3Aissue+label%3AA-op-batcher).

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -204,6 +204,8 @@ Past the boundary the constraint lifts: the fallback keeps event-authenticating 
 
 A `BatchAuthenticator` deployed before the scripts were corrected was initialized with `true`, and needs `setActiveIsEspresso(false)` before `espresso_time` is reached.
 
+The `op_batcher_publish_gate_decision` gauge reports why a batcher is or is not publishing on each tick (`publishing`, `awaiting_enforcement`, `not_active_batcher`, `boundary_unavailable`, `active_check_failed`). A batcher reporting `publishing` while `op_batcher_batch_tx_submitted` stays flat is wedged; one reporting `not_active_batcher` is standing down as intended.
+
 ## Known issues and future work
 
 Link to [open issues with the `op-batcher` tag](https://github.com/ethereum-optimism/optimism/issues?q=is%3Aopen+is%3Aissue+label%3AA-op-batcher).

--- a/op-node/rollup/derive/batch_authenticator.go
+++ b/op-node/rollup/derive/batch_authenticator.go
@@ -17,12 +17,16 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// isEspressoAuthEnforced returns true once event-based batch authentication is enforced
+// IsEspressoAuthEnforced returns true once event-based batch authentication is enforced
 // at the given L1 origin time: the Espresso fork is active AND at least
 // BatchAuthEnforcementDelaySecs has elapsed since activation. Before that, derivation
 // keeps accepting sender-authenticated batches. See BatchAuthEnforcementDelaySecs
 // (params.go) for the full grace-period mechanism.
-func isEspressoAuthEnforced(cfg *rollup.Config, l1OriginTime uint64) bool {
+//
+// Exported because the op-batcher publish gate (shouldSkipPublishForActiveSeq) keys
+// batch-submission ownership on the exact predicate the verifier enforces with: the
+// fallback batcher owns publishing before enforcement, the TEE batcher after.
+func IsEspressoAuthEnforced(cfg *rollup.Config, l1OriginTime uint64) bool {
 	return cfg.IsEspresso(l1OriginTime) && l1OriginTime >= *cfg.EspressoTime+BatchAuthEnforcementDelaySecs
 }
 

--- a/op-node/rollup/derive/batch_authenticator.go
+++ b/op-node/rollup/derive/batch_authenticator.go
@@ -23,9 +23,8 @@ import (
 // keeps accepting sender-authenticated batches. See BatchAuthEnforcementDelaySecs
 // (params.go) for the full grace-period mechanism.
 //
-// Exported because the op-batcher publish gate (shouldSkipPublishForActiveSeq) keys
-// batch-submission ownership on the exact predicate the verifier enforces with: the
-// fallback batcher owns publishing before enforcement, the TEE batcher after.
+// Exported for the op-batcher publish gate (shouldSkipPublishForActiveSeq), which
+// keys batch-submission ownership on this exact predicate.
 func IsEspressoAuthEnforced(cfg *rollup.Config, l1OriginTime uint64) bool {
 	return cfg.IsEspresso(l1OriginTime) && l1OriginTime >= *cfg.EspressoTime+BatchAuthEnforcementDelaySecs
 }

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -146,7 +146,7 @@ func dataAndHashesFromTxs(ctx context.Context, txs types.Transactions, config *D
 	// enforced (Espresso active plus the enforcement grace period). Before that, the
 	// upstream sender-based authorization path is used and authenticatedHashes is unused.
 	var authenticatedHashes map[common.Hash]common.Address
-	if isEspressoAuthEnforced(config.rollupCfg, ref.Time) {
+	if IsEspressoAuthEnforced(config.rollupCfg, ref.Time) {
 		var err error
 		authenticatedHashes, err = CollectAuthenticatedBatches(
 			ctx, fetcher, ref, config.rollupCfg.BatchAuthenticatorAddress, config.batchAuthCaches, logger,

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -189,7 +189,7 @@ func isBatchTxAuthorized(
 	l1OriginTime uint64,
 	logger log.Logger,
 ) bool {
-	if !isEspressoAuthEnforced(dsCfg.rollupCfg, l1OriginTime) {
+	if !IsEspressoAuthEnforced(dsCfg.rollupCfg, l1OriginTime) {
 		// Pre-enforcement (pre-fork or within the grace period): upstream
 		// sender-based authorization.
 		return isAuthorizedBatchSender(tx, dsCfg.l1Signer, batcherAddr, logger)

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -36,9 +36,11 @@ const BatchAuthLookbackWindow uint64 = 100
 // authentication is only enforced for L1 blocks with origin time >= EspressoTime +
 // BatchAuthEnforcementDelaySecs.
 //
-// This is the canonical description of the grace-period mechanism; isEspressoAuthEnforced
-// (batch_authenticator.go), the op-batcher fallback-auth gate (isFallbackAuthRequired in
-// espresso_fallback_gate.go), and the fork-boundary tests all defer here.
+// This is the canonical description of the grace-period mechanism; IsEspressoAuthEnforced
+// (batch_authenticator.go), the op-batcher gates (the fork-time auth-dispatch gate
+// isFallbackAuthRequired in espresso_fallback_gate.go and the enforcement-time publish
+// gate shouldSkipPublishForActiveSeq in espresso_driver.go), and the fork-boundary tests
+// all defer here.
 //
 // Behavior by L1 origin time t relative to EspressoTime (E):
 //   - before enforcement (t < E+delay, i.e. pre-fork or within the grace window):

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -173,8 +173,12 @@ type Config struct {
 	// EspressoTime sets the activation time of the Espresso upgrade.
 	// Pre-fork, the derivation pipeline behaves exactly as upstream Optimism: batches are
 	// accepted based on the L1 transaction sender matching the SystemConfig batcher address.
-	// Post-fork, batches must be authenticated via BatchInfoAuthenticated events emitted by
-	// the BatchAuthenticator contract; sender-based authorization is rejected.
+	// That continues to hold for a grace period after activation: event-based batch
+	// authentication is only enforced from EspressoTime + derive.BatchAuthEnforcementDelaySecs,
+	// and only from there are batches required to carry a BatchInfoAuthenticated event from
+	// the BatchAuthenticator contract with sender-based authorization rejected. See
+	// derive.BatchAuthEnforcementDelaySecs for the grace-period mechanism, which operators
+	// setting an activation time need to account for.
 	// EspressoTime is conceptually an L2-timestamp fork activation time, but the
 	// derivation pipeline gates on it by comparing against the L1 origin time of the
 	// enclosing L1 block (the L2 epoch's L1 origin), mirroring upstream's ecotoneTime

--- a/packages/contracts-bedrock/scripts/deploy/DeployBatchAuthenticator.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployBatchAuthenticator.s.sol
@@ -79,8 +79,11 @@ contract DeployBatchAuthenticator is Script {
                 _espressoBatcher,
                 ISystemConfig(_systemConfig),
                 _batchAuthenticatorOwner,
-                // First deployment: start with the Espresso batcher active.
-                true
+                // The fallback batcher owns publishing until handoff: it can only
+                // authenticate through the pre-enforcement grace window while this is
+                // false, and no other role may publish there. Handing off is
+                // setActiveIsEspresso(true). See op-batcher/readme.md.
+                false
             )
         );
         // Initialize directly via the proxy. The deployer is still the proxy admin at this point, so

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -157,8 +157,11 @@ contract DeployEspresso is Script {
                 _input.espressoBatcher(),
                 ISystemConfig(_input.systemConfig()),
                 batchAuthenticatorOwner,
-                // First deployment: start with the Espresso batcher active.
-                true
+                // The fallback batcher owns publishing until handoff: it can only
+                // authenticate through the pre-enforcement grace window while this is
+                // false, and no other role may publish there. Handing off is
+                // setActiveIsEspresso(true). See op-batcher/readme.md.
+                false
             )
         );
         // Initialize directly via the proxy. The deployer is still the proxy admin at this point, so


### PR DESCRIPTION
Closes #492. Stacked on #459 (`espresso/batcher`).

## Problem

Derivation only enforces event-based batch auth for L1 blocks with origin time >= `EspressoTime + BatchAuthEnforcementDelaySecs` (a ~20-minute grace window); inside the window it accepts only sender-authenticated batches from the SystemConfig batcher key. The publish gate ignored that boundary and consulted only `BatchAuthenticator.activeIsEspresso`. So during the window the TEE batcher published batches that mined, burned L1 fees, and were dropped by every verifier, while the fallback batcher stood down on the flag mismatch — up to a full grace window without safe-head progress.

Fixing only the publish gate left a second stall on the same path (caught by @palango in review). The fallback's *send* path authenticates from `EspressoTime` onward, and `authenticateBatchInfo` only accepts the SystemConfig batcher while `activeIsEspresso` is `false`. Both deploy scripts initialized it to `true`, so in the window the fallback's auth leg reverted, the reverted leg cancelled the paired batch leg, and the safe head stalled anyway — now with a reverted tx and a nonce-cancellation no-op every tick.

## Fix

**Publish gate.** Key both roles' publish decisions on the verifier's own predicate, `derive.IsEspressoAuthEnforced` (newly exported), evaluated at the L1 tip:

- **Pre-enforcement**: the fallback publishes unconditionally — the contract is not consulted at all — and the TEE batcher stands down.
- **Post-enforcement**: `activeIsEspresso` plus the sender-identity check decide, exactly as before.
- Enforcement is monotone in time, so the first true observation is memoized. Errors fail closed; once memoized the boundary no longer needs the tip, and the decision rests on `isBatcherActive`, which still fails closed.

The auth-dispatch gate (`isFallbackAuthRequired`) deliberately stays keyed at fork time: the fallback event-authenticates through the window, which keeps its batches valid on both sides of the boundary.

**Deploy default.** Both deploy scripts now initialize `activeIsEspresso` to `false`. This is not a workaround but the invariant the design implies: the fallback must event-authenticate through the window (straddle protection), and the contract only accepts it while the flag is false. Under the old `true` default, no deployment — greenfield included — had a working publisher for the first grace window. It also decouples the handoff from the fork, since the fallback keeps event-authenticating past the boundary: `setActiveIsEspresso(true)` can happen whenever the TEE batcher is ready rather than being an operation timed against `espresso_time`. Runbook in `op-batcher/readme.md`.

**Observability.** A batcher standing down and a wedged one previously looked identical. New `op_batcher_publish_gate_decision` gauge (`publishing` / `awaiting_enforcement` / `not_active_batcher` / `boundary_unavailable` / `active_check_failed`) — `publishing` with a flat `batch_tx_submitted` is the wedge. The per-tick warnings now go through `degradedLog`, which matters because a TEE hot standby is the normal post-fork state under the new default. `admin_flushBatcher` still cannot override the gate (that would make a stood-down batcher double-publish or revert), but it now says so instead of silently dropping the request.

A TEE batcher with `EspressoTime` unset can never publish, since the boundary is never reached. That was visible only at `Debug`; it is now a startup warning.

## Tests

- `TestShouldSkipPublish_EnforcementBoundary` — every boundary scenario for both roles. Pre-enforcement cases run against `noContractL1Client`, which fails the test on any contract read, proving in-window decisions are contract-independent.
- `TestPublishAuthInvariant_RoleTimeFlag` — composes the publish gate with the auth-dispatch gate across role x tip region x flag, asserting that exactly one role publishes and its batch lands. The single excluded cell (grace window with the flag set) is asserted as a stall, recording the dependency on the deploy default. Reverting either gate fix fails it.
- `TestIsBatchAuthEnforcedAtTip_Memoization` — the memo's observable effects: one tip fetch in steady state, a tip going backwards staying enforced, and the fail-closed change once latched.

Contract-side, `BatchAuthenticator.t.sol` already pins the revert the excluded cell depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217525737014017
