### PR TITLE
op-batcher: bound every Espresso network call and drop the streamer on stop

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -321,6 +321,14 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 
 	if l.espressoStreamer != nil {
 		l.espressoStreamer.Stop()
+		// Drop the stopped streamer. The next StartBatchSubmitting runs clearState
+		// before constructing a fresh one, and a leftover streamer would activate
+		// the espressoReanchorTarget gate: against a resyncing op-node that gate
+		// retries every 5s with no deadline while the start holds l.mutex — which
+		// the stop that could cancel it also needs. Nil means "nothing to
+		// re-anchor", which is true: setupEspressoStreamer anchors the fresh
+		// streamer itself.
+		l.espressoStreamer = nil
 	}
 
 	l.Log.Info("Batch Submitter stopped")

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -319,17 +319,7 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	l.wg.Wait()
 	l.cancelKillCtx()
 
-	if l.espressoStreamer != nil {
-		l.espressoStreamer.Stop()
-		// Drop the stopped streamer. The next StartBatchSubmitting runs clearState
-		// before constructing a fresh one, and a leftover streamer would activate
-		// the espressoReanchorTarget gate: against a resyncing op-node that gate
-		// retries every 5s with no deadline while the start holds l.mutex — which
-		// the stop that could cancel it also needs. Nil means "nothing to
-		// re-anchor", which is true: setupEspressoStreamer anchors the fresh
-		// streamer itself.
-		l.espressoStreamer = nil
-	}
+	l.teardownEspressoStreamer()
 
 	l.Log.Info("Batch Submitter stopped")
 	return nil

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -120,7 +120,7 @@ type espressoTransactionSubmitter struct {
 	verifyReceiptJobQueue      chan espressoVerifyReceiptJob
 	verifyReceiptRespQueue     chan espressoVerifyReceiptJobResponse
 	verifyReceiptWorkerQueue   chan chan espressoVerifyReceiptJobAttempt
-	espresso                   espressoClient.EspressoClient
+	espresso                   EspressoSubmitClient
 	latestBlockHeight          atomic.Uint64 // shared HotShot block height, updated by trackBlockHeight
 	verifyReceiptMaxBlocks     uint64
 	verifyReceiptSafetyTimeout time.Duration
@@ -134,7 +134,7 @@ type espressoTransactionSubmitter struct {
 // creating the EspressoTransactionSubmitter.
 type EspressoTransactionSubmitterConfig struct {
 	Ctx                                context.Context
-	EspressoClient                     espressoClient.EspressoClient
+	EspressoClient                     EspressoSubmitClient
 	Wg                                 *sync.WaitGroup
 	SubmitJobQueueCapacity             int
 	SubmitResponseQueueCapacity        int
@@ -160,7 +160,7 @@ func WithContext(ctx context.Context) EspressoTransactionSubmitterOption {
 
 // WithEspressoClient is an option that can be used to set the Espresso client
 // for the EspressoTransactionSubmitterConfig.
-func WithEspressoClient(client espressoClient.EspressoClient) EspressoTransactionSubmitterOption {
+func WithEspressoClient(client EspressoSubmitClient) EspressoTransactionSubmitterOption {
 	return func(config *EspressoTransactionSubmitterConfig) {
 		config.EspressoClient = client
 	}
@@ -631,7 +631,7 @@ func (s *espressoTransactionSubmitter) scheduleVerifyReceiptsJobs() {
 func espressoSubmitTransactionWorker(
 	ctx context.Context,
 	wg *sync.WaitGroup,
-	cli espressoClient.EspressoClient,
+	cli EspressoSubmitClient,
 	workerQueue chan<- chan espressoTransactionJobAttempt,
 ) {
 	ctx, cancel := context.WithCancel(ctx)
@@ -688,7 +688,7 @@ func espressoSubmitTransactionWorker(
 func espressoVerifyTransactionWorker(
 	ctx context.Context,
 	wg *sync.WaitGroup,
-	cli espressoClient.EspressoClient,
+	cli EspressoSubmitClient,
 	workerQueue chan<- chan espressoVerifyReceiptJobAttempt,
 	latestHeight *atomic.Uint64,
 	retryDelay time.Duration,
@@ -915,7 +915,15 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 					break
 				}
 
-				batch := l.espressoStreamer.Peek(ctx)
+				// Peek retries undecided batches' validity checks, which read L1
+				// (a contract call and a header fetch, both uncached on a miss)
+				// with no deadline of their own. Unbounded, a hung L1 RPC would
+				// silently stall frame publication for good, so it gets the same
+				// per-call bound as every other raw RPC; on expiry the batch
+				// stays undecided and is retried next tick.
+				peekCtx, peekCancel := l.networkTimeoutCtx(ctx)
+				batch := l.espressoStreamer.Peek(peekCtx)
+				peekCancel()
 				if batch == nil {
 					break
 				}

--- a/op-batcher/batcher/espresso_client.go
+++ b/op-batcher/batcher/espresso_client.go
@@ -1,0 +1,51 @@
+package batcher
+
+import (
+	"context"
+	"time"
+
+	espressoCommon "github.com/EspressoSystems/espresso-network/sdks/go/types"
+)
+
+// EspressoSubmitClient is the slice of the Espresso SDK client consumed by the
+// transaction submitter and its workers. Narrowed from the SDK's full
+// EspressoClient so the per-call deadline wrapper below only has to cover
+// methods that are actually called (the full interface includes streaming
+// endpoints, which a per-call deadline would break).
+type EspressoSubmitClient interface {
+	SubmitTransaction(ctx context.Context, tx espressoCommon.Transaction) (*espressoCommon.TaggedBase64, error)
+	FetchTransactionByHash(ctx context.Context, hash *espressoCommon.TaggedBase64) (espressoCommon.TransactionQueryData, error)
+	FetchLatestBlockHeight(ctx context.Context) (uint64, error)
+}
+
+// boundedEspressoClient enforces a per-call deadline on every Espresso SDK
+// call. The SDK issues plain HTTP requests with no client-side timeout, and the
+// submit/verify workers otherwise call it with their long-lived loop contexts —
+// a black-holed connection would hold a worker forever, and with every worker
+// wedged, submission stays stopped even after the endpoint recovers.
+type boundedEspressoClient struct {
+	inner   EspressoSubmitClient
+	timeout time.Duration
+}
+
+func newBoundedEspressoClient(inner EspressoSubmitClient, timeout time.Duration) *boundedEspressoClient {
+	return &boundedEspressoClient{inner: inner, timeout: timeout}
+}
+
+func (c *boundedEspressoClient) SubmitTransaction(ctx context.Context, tx espressoCommon.Transaction) (*espressoCommon.TaggedBase64, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	return c.inner.SubmitTransaction(ctx, tx)
+}
+
+func (c *boundedEspressoClient) FetchTransactionByHash(ctx context.Context, hash *espressoCommon.TaggedBase64) (espressoCommon.TransactionQueryData, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	return c.inner.FetchTransactionByHash(ctx, hash)
+}
+
+func (c *boundedEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	return c.inner.FetchLatestBlockHeight(ctx)
+}

--- a/op-batcher/batcher/espresso_client_test.go
+++ b/op-batcher/batcher/espresso_client_test.go
@@ -1,0 +1,61 @@
+package batcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	espressoCommon "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingEspressoClient hangs every call until its context is cancelled,
+// modeling the SDK's timeout-less HTTP client on a black-holed connection.
+type blockingEspressoClient struct{}
+
+func (blockingEspressoClient) SubmitTransaction(ctx context.Context, tx espressoCommon.Transaction) (*espressoCommon.TaggedBase64, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingEspressoClient) FetchTransactionByHash(ctx context.Context, hash *espressoCommon.TaggedBase64) (espressoCommon.TransactionQueryData, error) {
+	<-ctx.Done()
+	return espressoCommon.TransactionQueryData{}, ctx.Err()
+}
+
+func (blockingEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+// TestBoundedEspressoClientAppliesDeadline pins that every method of the
+// wrapper the submit/verify workers call through carries a per-call deadline:
+// a hung endpoint must yield a prompt DeadlineExceeded instead of consuming a
+// worker forever.
+func TestBoundedEspressoClientAppliesDeadline(t *testing.T) {
+	c := newBoundedEspressoClient(blockingEspressoClient{}, 10*time.Millisecond)
+
+	calls := map[string]func(context.Context) error{
+		"SubmitTransaction": func(ctx context.Context) error {
+			_, err := c.SubmitTransaction(ctx, espressoCommon.Transaction{})
+			return err
+		},
+		"FetchTransactionByHash": func(ctx context.Context) error {
+			_, err := c.FetchTransactionByHash(ctx, nil)
+			return err
+		},
+		"FetchLatestBlockHeight": func(ctx context.Context) error {
+			_, err := c.FetchLatestBlockHeight(ctx)
+			return err
+		},
+	}
+
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			// The parent context has no deadline, like the workers' loop
+			// contexts; only the wrapper can unblock the call.
+			err := call(context.Background())
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+	}
+}

--- a/op-batcher/batcher/espresso_client_test.go
+++ b/op-batcher/batcher/espresso_client_test.go
@@ -28,34 +28,18 @@ func (blockingEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint6
 	return 0, ctx.Err()
 }
 
-// TestBoundedEspressoClientAppliesDeadline pins that every method of the
-// wrapper the submit/verify workers call through carries a per-call deadline:
-// a hung endpoint must yield a prompt DeadlineExceeded instead of consuming a
-// worker forever.
+// TestBoundedEspressoClientAppliesDeadline pins that every wrapped method
+// carries a per-call deadline even when the caller's context has none (as the
+// workers' long-lived loop contexts do not).
 func TestBoundedEspressoClientAppliesDeadline(t *testing.T) {
 	c := newBoundedEspressoClient(blockingEspressoClient{}, 10*time.Millisecond)
 
-	calls := map[string]func(context.Context) error{
-		"SubmitTransaction": func(ctx context.Context) error {
-			_, err := c.SubmitTransaction(ctx, espressoCommon.Transaction{})
-			return err
-		},
-		"FetchTransactionByHash": func(ctx context.Context) error {
-			_, err := c.FetchTransactionByHash(ctx, nil)
-			return err
-		},
-		"FetchLatestBlockHeight": func(ctx context.Context) error {
-			_, err := c.FetchLatestBlockHeight(ctx)
-			return err
-		},
-	}
+	_, err := c.SubmitTransaction(context.Background(), espressoCommon.Transaction{})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	for name, call := range calls {
-		t.Run(name, func(t *testing.T) {
-			// The parent context has no deadline, like the workers' loop
-			// contexts; only the wrapper can unblock the call.
-			err := call(context.Background())
-			require.ErrorIs(t, err, context.DeadlineExceeded)
-		})
-	}
+	_, err = c.FetchTransactionByHash(context.Background(), nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, err = c.FetchLatestBlockHeight(context.Background())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -82,8 +82,10 @@ func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 // timeout. Every raw RPC read on the Espresso startup path must go through it:
 // StartBatchSubmitting holds the start mutex, and StopBatchSubmitting needs that
 // mutex before it can cancel anything, so an unbounded call on a stalled endpoint
-// would wedge the batcher beyond even a graceful shutdown. Calls with their own
-// timeout regime (the attestation service client, Txmgr.Send) are exempt.
+// would wedge the batcher beyond even a graceful shutdown. The batch-loading
+// loop's streamer reads (Peek) take the same bound, and the Espresso SDK calls
+// get it via boundedEspressoClient. Calls with their own timeout regime (the
+// attestation service client, Txmgr.Send) are exempt.
 func (l *BatchSubmitter) networkTimeoutCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, l.Config.NetworkTimeout)
 }
@@ -236,6 +238,9 @@ func (l *BatchSubmitter) rollbackFailedStart() {
 	l.cancelKillCtx()
 	if l.espressoStreamer != nil {
 		l.espressoStreamer.Stop()
+		// Same as StopBatchSubmitting: a leftover streamer would put the next
+		// start's clearState behind the re-anchor gate with no deadline.
+		l.espressoStreamer = nil
 	}
 	l.running = false
 }
@@ -269,7 +274,9 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 	l.espressoSubmitter = NewEspressoTransactionSubmitter(
 		WithContext(l.shutdownCtx),
 		WithWaitGroup(l.wg),
-		WithEspressoClient(l.Espresso.Client),
+		// The SDK client has no client-side timeout, so it is wrapped with the
+		// per-call network-timeout bound; see boundedEspressoClient.
+		WithEspressoClient(newBoundedEspressoClient(l.Espresso.Client, l.Config.NetworkTimeout)),
 		WithVerifyReceiptMaxBlocks(l.Config.Espresso.VerifyReceiptMaxBlocks),
 		WithVerifyReceiptSafetyTimeout(l.Config.Espresso.VerifyReceiptSafetyTimeout),
 		WithVerifyReceiptRetryDelay(l.Config.Espresso.VerifyReceiptRetryDelay),
@@ -329,7 +336,11 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 // LocalSafeL2: the caller must retry the whole clear rather than perform it
 // partially. Reports a nil target (and ok=true) when there is nothing to
 // re-anchor: --espresso.enabled unset, or the startup path, where clearState
-// runs before the streamer is constructed.
+// runs before the streamer is constructed. Every start takes that path — first
+// starts trivially, restarts because StopBatchSubmitting and rollbackFailedStart
+// nil the previous run's streamer. That nil-ing is what keeps this gate off the
+// start path: it retries without a deadline, which is only safe from the
+// loading loop, whose context a stop can cancel without needing l.mutex.
 func (l *BatchSubmitter) espressoReanchorTarget(ctx context.Context) (target *eth.L2BlockRef, ok bool) {
 	if !l.Config.Espresso.Enabled || l.espressoStreamer == nil {
 		return nil, true

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -82,10 +82,8 @@ func (a *batcherL2Adapter) HeaderHashByNumber(ctx context.Context, number *big.I
 // timeout. Every raw RPC read on the Espresso startup path must go through it:
 // StartBatchSubmitting holds the start mutex, and StopBatchSubmitting needs that
 // mutex before it can cancel anything, so an unbounded call on a stalled endpoint
-// would wedge the batcher beyond even a graceful shutdown. The batch-loading
-// loop's streamer reads (Peek) take the same bound, and the Espresso SDK calls
-// get it via boundedEspressoClient. Calls with their own timeout regime (the
-// attestation service client, Txmgr.Send) are exempt.
+// would wedge the batcher beyond even a graceful shutdown. Calls with their own
+// timeout regime (the attestation service client, Txmgr.Send) are exempt.
 func (l *BatchSubmitter) networkTimeoutCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, l.Config.NetworkTimeout)
 }
@@ -236,13 +234,23 @@ func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockR
 func (l *BatchSubmitter) rollbackFailedStart() {
 	l.cancelShutdownCtx()
 	l.cancelKillCtx()
-	if l.espressoStreamer != nil {
-		l.espressoStreamer.Stop()
-		// Same as StopBatchSubmitting: a leftover streamer would put the next
-		// start's clearState behind the re-anchor gate with no deadline.
-		l.espressoStreamer = nil
-	}
+	l.teardownEspressoStreamer()
 	l.running = false
+}
+
+// teardownEspressoStreamer stops and drops the streamer, if any. Every teardown
+// path (StopBatchSubmitting, rollbackFailedStart) must come through here: a dead
+// run's streamer must never survive into the next start, or that start's
+// clearState would run the espressoReanchorTarget gate against it — a retry
+// loop with no deadline, running under the start mutex that the stop able to
+// cancel it would itself need — to re-anchor an object the start is about to
+// replace anyway (setupEspressoStreamer anchors the fresh streamer itself).
+func (l *BatchSubmitter) teardownEspressoStreamer() {
+	if l.espressoStreamer == nil {
+		return
+	}
+	l.espressoStreamer.Stop()
+	l.espressoStreamer = nil
 }
 
 // startEspressoLoops registers the batcher with the BatchAuthenticator
@@ -274,8 +282,6 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 	l.espressoSubmitter = NewEspressoTransactionSubmitter(
 		WithContext(l.shutdownCtx),
 		WithWaitGroup(l.wg),
-		// The SDK client has no client-side timeout, so it is wrapped with the
-		// per-call network-timeout bound; see boundedEspressoClient.
 		WithEspressoClient(newBoundedEspressoClient(l.Espresso.Client, l.Config.NetworkTimeout)),
 		WithVerifyReceiptMaxBlocks(l.Config.Espresso.VerifyReceiptMaxBlocks),
 		WithVerifyReceiptSafetyTimeout(l.Config.Espresso.VerifyReceiptSafetyTimeout),
@@ -336,11 +342,8 @@ func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool
 // LocalSafeL2: the caller must retry the whole clear rather than perform it
 // partially. Reports a nil target (and ok=true) when there is nothing to
 // re-anchor: --espresso.enabled unset, or the startup path, where clearState
-// runs before the streamer is constructed. Every start takes that path — first
-// starts trivially, restarts because StopBatchSubmitting and rollbackFailedStart
-// nil the previous run's streamer. That nil-ing is what keeps this gate off the
-// start path: it retries without a deadline, which is only safe from the
-// loading loop, whose context a stop can cancel without needing l.mutex.
+// runs before the streamer is constructed. Every start takes that path — see
+// teardownEspressoStreamer for why no earlier run's streamer can be left over.
 func (l *BatchSubmitter) espressoReanchorTarget(ctx context.Context) (target *eth.L2BlockRef, ok bool) {
 	if !l.Config.Espresso.Enabled || l.espressoStreamer == nil {
 		return nil, true

--- a/op-batcher/batcher/espresso_driver_test.go
+++ b/op-batcher/batcher/espresso_driver_test.go
@@ -1,0 +1,51 @@
+package batcher
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// startedSubmitter returns a BatchSubmitter in the state StartBatchSubmitting
+// leaves it in right after taking ownership (running, fresh contexts, empty
+// waitgroup) with a streamer attached. A zero-value Streamer is safe here:
+// Stop() on it is a no-op (nil cancel), and these tests only exercise
+// teardown, never the streamer itself.
+func startedSubmitter(t *testing.T) *BatchSubmitter {
+	l := &BatchSubmitter{}
+	l.Log = testlog.Logger(t, log.LevelDebug)
+	l.running = true
+	l.shutdownCtx, l.cancelShutdownCtx = context.WithCancel(context.Background())
+	l.killCtx, l.cancelKillCtx = context.WithCancel(context.Background())
+	l.wg = &sync.WaitGroup{}
+	l.espressoStreamer = &espressoStreamers.Streamer{}
+	return l
+}
+
+// TestStopBatchSubmittingDropsStreamer pins that a stop/start cycle cannot put
+// the next start's clearState behind the streamer re-anchor gate: that gate
+// retries with no deadline while StartBatchSubmitting holds l.mutex — the very
+// mutex the stop that could cancel it would need — so the stopped run's
+// streamer must not survive into the next start.
+func TestStopBatchSubmittingDropsStreamer(t *testing.T) {
+	l := startedSubmitter(t)
+	require.NoError(t, l.StopBatchSubmitting(context.Background()))
+	require.Nil(t, l.espressoStreamer)
+	require.False(t, l.running)
+}
+
+// TestRollbackFailedStartDropsStreamer pins the same invariant for the failed
+// start path: a start that constructed a streamer and then failed must not
+// leave it behind for the next attempt's clearState to re-anchor against.
+func TestRollbackFailedStartDropsStreamer(t *testing.T) {
+	l := startedSubmitter(t)
+	l.rollbackFailedStart()
+	require.Nil(t, l.espressoStreamer)
+	require.False(t, l.running)
+}

--- a/op-batcher/batcher/espresso_driver_test.go
+++ b/op-batcher/batcher/espresso_driver_test.go
@@ -28,11 +28,8 @@ func startedSubmitter(t *testing.T) *BatchSubmitter {
 	return l
 }
 
-// TestStopBatchSubmittingDropsStreamer pins that a stop/start cycle cannot put
-// the next start's clearState behind the streamer re-anchor gate: that gate
-// retries with no deadline while StartBatchSubmitting holds l.mutex — the very
-// mutex the stop that could cancel it would need — so the stopped run's
-// streamer must not survive into the next start.
+// TestStopBatchSubmittingDropsStreamer pins that a stopped run's streamer does
+// not survive into the next start; see teardownEspressoStreamer for why.
 func TestStopBatchSubmittingDropsStreamer(t *testing.T) {
 	l := startedSubmitter(t)
 	require.NoError(t, l.StopBatchSubmitting(context.Background()))
@@ -40,9 +37,8 @@ func TestStopBatchSubmittingDropsStreamer(t *testing.T) {
 	require.False(t, l.running)
 }
 
-// TestRollbackFailedStartDropsStreamer pins the same invariant for the failed
-// start path: a start that constructed a streamer and then failed must not
-// leave it behind for the next attempt's clearState to re-anchor against.
+// TestRollbackFailedStartDropsStreamer pins the same invariant for a start
+// that constructed a streamer and then failed.
 func TestRollbackFailedStartDropsStreamer(t *testing.T) {
 	l := startedSubmitter(t)
 	l.rollbackFailedStart()

--- a/op-batcher/batcher/espresso_helpers_test.go
+++ b/op-batcher/batcher/espresso_helpers_test.go
@@ -7,90 +7,51 @@ import (
 	"errors"
 	"sync"
 
-	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 	"github.com/EspressoSystems/espresso-network/sdks/go/types"
 	common "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 )
 
 // ErrNotImplemented is a sentinel error used to indicate that a method
 // was not implemented.
 var ErrNotImplemented = errors.New("not implemented")
 
-// AlwaysFailingEspressoClient is a mock implementation of the EspressoClient
-// interface that always returns an error for every method call. This is
-// useful for testing error handling in the batcher without relying on a
-// real Espresso client.
+// The fakes below implement batcher.EspressoSubmitClient — the narrow slice of
+// the SDK the transaction submitter consumes — rather than the SDK's full
+// EspressoClient, so SDK interface growth cannot break them.
+
+// AlwaysFailingEspressoClient returns an error from every method call. This is
+// useful for testing error handling in the batcher without relying on a real
+// Espresso client.
 type AlwaysFailingEspressoClient struct{}
 
-// Compile time check to ensure adherence to EspressoClient interface
-var _ espressoClient.EspressoClient = (*AlwaysFailingEspressoClient)(nil)
+var _ batcher.EspressoSubmitClient = (*AlwaysFailingEspressoClient)(nil)
 
 func (*AlwaysFailingEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
 	return 0, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchHeaderByHeight(ctx context.Context, height uint64) (types.HeaderImpl, error) {
-	return types.HeaderImpl{}, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchRawHeaderByHeight(ctx context.Context, height uint64) (json.RawMessage, error) {
-	return json.RawMessage{}, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchHeadersByRange(ctx context.Context, from uint64, until uint64) ([]types.HeaderImpl, error) {
-	return []types.HeaderImpl{}, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchTransactionsInBlock(ctx context.Context, blockHeight uint64, namespace uint64) (espressoClient.TransactionsInBlock, error) {
-	return espressoClient.TransactionsInBlock{}, ErrNotImplemented
 }
 
 func (*AlwaysFailingEspressoClient) FetchTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.TransactionQueryData, error) {
 	return types.TransactionQueryData{}, ErrNotImplemented
 }
 
-func (*AlwaysFailingEspressoClient) FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error) {
-	return types.VidCommon{}, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchExplorerTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.ExplorerTransactionQueryData, error) {
-	return types.ExplorerTransactionQueryData{}, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) StreamPayloads(ctx context.Context, height uint64) (espressoClient.Stream[types.PayloadQueryData], error) {
-	return nil, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) StreamTransactions(ctx context.Context, height uint64) (espressoClient.Stream[types.TransactionQueryData], error) {
-	return nil, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) StreamTransactionsInNamespace(ctx context.Context, height uint64, namespace uint64) (espressoClient.Stream[types.TransactionQueryData], error) {
-	return nil, ErrNotImplemented
-}
-
-func (*AlwaysFailingEspressoClient) FetchNamespaceTransactionsInRange(ctx context.Context, fromHeight uint64, toHeight uint64, namespace uint64) ([]types.NamespaceTransactionsRangeData, error) {
-	return []types.NamespaceTransactionsRangeData{}, ErrNotImplemented
-}
-
 func (*AlwaysFailingEspressoClient) SubmitTransaction(ctx context.Context, tx common.Transaction) (*common.TaggedBase64, error) {
 	return nil, ErrNotImplemented
 }
 
-// EspressoClientSwappableImplementation is as implementation of EspressoClient
-// that is just a proxy.
+// EspressoClientSwappableImplementation is just a proxy to an inner client.
 //
 // This allows it to be created and swapped easily as needed for testing.
 type EspressoClientSwappableImplementation struct {
 	sync.RWMutex
-	espClient espressoClient.EspressoClient
+	espClient batcher.EspressoSubmitClient
 }
 
-// Compile time check to ensure adherence to EspressoClient interface
-var _ espressoClient.EspressoClient = (*EspressoClientSwappableImplementation)(nil)
+var _ batcher.EspressoSubmitClient = (*EspressoClientSwappableImplementation)(nil)
 
-func (c *EspressoClientSwappableImplementation) SetEspressoClient(client espressoClient.EspressoClient) {
+func (c *EspressoClientSwappableImplementation) SetEspressoClient(client batcher.EspressoSubmitClient) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -104,81 +65,11 @@ func (c *EspressoClientSwappableImplementation) FetchLatestBlockHeight(ctx conte
 	return c.espClient.FetchLatestBlockHeight(ctx)
 }
 
-func (c *EspressoClientSwappableImplementation) FetchHeaderByHeight(ctx context.Context, height uint64) (types.HeaderImpl, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchHeaderByHeight(ctx, height)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchRawHeaderByHeight(ctx context.Context, height uint64) (json.RawMessage, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchRawHeaderByHeight(ctx, height)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchHeadersByRange(ctx context.Context, from uint64, until uint64) ([]types.HeaderImpl, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchHeadersByRange(ctx, from, until)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchTransactionsInBlock(ctx context.Context, blockHeight uint64, namespace uint64) (espressoClient.TransactionsInBlock, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchTransactionsInBlock(ctx, blockHeight, namespace)
-}
-
 func (c *EspressoClientSwappableImplementation) FetchTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.TransactionQueryData, error) {
 	c.RLock()
 	defer c.RUnlock()
 
 	return c.espClient.FetchTransactionByHash(ctx, hash)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchVidCommonByHeight(ctx, blockHeight)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchExplorerTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.ExplorerTransactionQueryData, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchExplorerTransactionByHash(ctx, hash)
-}
-
-func (c *EspressoClientSwappableImplementation) StreamPayloads(ctx context.Context, height uint64) (espressoClient.Stream[types.PayloadQueryData], error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.StreamPayloads(ctx, height)
-}
-
-func (c *EspressoClientSwappableImplementation) StreamTransactions(ctx context.Context, height uint64) (espressoClient.Stream[types.TransactionQueryData], error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.StreamTransactions(ctx, height)
-}
-
-func (c *EspressoClientSwappableImplementation) StreamTransactionsInNamespace(ctx context.Context, height uint64, namespace uint64) (espressoClient.Stream[types.TransactionQueryData], error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.StreamTransactionsInNamespace(ctx, height, namespace)
-}
-
-func (c *EspressoClientSwappableImplementation) FetchNamespaceTransactionsInRange(ctx context.Context, fromHeight uint64, toHeight uint64, namespace uint64) ([]types.NamespaceTransactionsRangeData, error) {
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.espClient.FetchNamespaceTransactionsInRange(ctx, fromHeight, toHeight, namespace)
 }
 
 func (c *EspressoClientSwappableImplementation) SubmitTransaction(ctx context.Context, tx common.Transaction) (*common.TaggedBase64, error) {
@@ -188,17 +79,16 @@ func (c *EspressoClientSwappableImplementation) SubmitTransaction(ctx context.Co
 	return c.espClient.SubmitTransaction(ctx, tx)
 }
 
-// FakeSubmissionSucceedingEspressoClient is a mock implementation of the
-// EspressoClient for the explicit purposes of submitting transactions, and
-// seeing their response.
+// FakeSubmissionSucceedingEspressoClient is a mock for the explicit purposes
+// of submitting transactions and seeing their response. Methods it does not
+// implement itself delegate to the embedded client.
 type FakeSubmissionSucceedingEspressoClient struct {
 	sync.RWMutex
-	espressoClient.EspressoClient
+	batcher.EspressoSubmitClient
 	txns map[string]common.Transaction
 }
 
-// Compile time check to ensure adherence to EspressoClient interface
-var _ espressoClient.EspressoClient = (*FakeSubmissionSucceedingEspressoClient)(nil)
+var _ batcher.EspressoSubmitClient = (*FakeSubmissionSucceedingEspressoClient)(nil)
 
 var (
 	ErrNotInitialized      = errors.New("not initialized")

--- a/op-batcher/batcher/espresso_transaction_submitter_test.go
+++ b/op-batcher/batcher/espresso_transaction_submitter_test.go
@@ -111,7 +111,7 @@ func TestEspressoTransactionSubmitterProgress(t *testing.T) {
 	failingClient := new(AlwaysFailingEspressoClient)
 	succeedingClient := new(FakeSubmissionSucceedingEspressoClient)
 	succeedingClient.Init()
-	succeedingClient.EspressoClient = failingClient
+	succeedingClient.EspressoSubmitClient = failingClient
 	espClient := new(EspressoClientSwappableImplementation)
 	espClient.SetEspressoClient(failingClient)
 	submitter := batcher.NewEspressoTransactionSubmitter(


### PR DESCRIPTION
Closes #493. Stacked on #459 (`espresso/batcher`).

## Problem

Three wedge modes, all the same family: a hung network call with no deadline parks a component forever.

1. **Submit/verify workers**: the Espresso SDK issues plain HTTP requests with no client-side timeout, and the workers called it with their long-lived loop contexts. One black-holed connection consumed a worker permanently; with all four wedged, submission stayed stopped even after the endpoint recovered.
2. **Loading loop**: `Peek` retries undecided batches' L1-backed validity checks (a contract call plus a header fetch) on the loop's shutdown context, so a hung L1 RPC silently stalled frame publication with no error logs.
3. **Stop/start**: `l.espressoStreamer` was never nil'ed, so the next `StartBatchSubmitting` ran `clearState` against the stale streamer, whose re-anchor gate retries every 5s with no deadline **while holding the start mutex** — the very mutex the stop that could cancel it needs. Against a resyncing op-node, a later SIGTERM blocked forever (the same start-mutex-hang pattern already fixed for `waitForLocalSafeHead` and registration).

## Fix

Per the issue's suggestion, the SDK timeout is enforced once at a client-wrapper seam rather than per call site:

- The submitter's client dependency is narrowed to the three-method `EspressoSubmitClient` (the SDK's full interface includes streaming endpoints, which a per-call deadline would break), and the driver hands it a `boundedEspressoClient` wrapping every call with `NetworkTimeout`. This covers the block-height tracker too.
- `Peek` gets the same per-call bound as every other raw RPC on this path (via the existing `networkTimeoutCtx`); on expiry the batch stays undecided and is retried next tick, and the streamer's own warn logs now surface instead of silence.
- `StopBatchSubmitting` and `rollbackFailedStart` drop the stopped streamer, so every start reaches `clearState` streamer-free and the no-deadline re-anchor gate only ever runs from the loading loop, whose context a stop can cancel without taking the mutex.

## Tests

- `TestBoundedEspressoClientAppliesDeadline`: a blocking fake (models the timeout-less SDK on a black-holed connection) called with a deadline-free parent context — each of the three wrapped methods must return `DeadlineExceeded` promptly.
- `TestStopBatchSubmittingDropsStreamer` / `TestRollbackFailedStartDropsStreamer`: both teardown paths must leave `espressoStreamer` nil (a zero-value `Streamer` is `Stop()`-safe, which makes the lifecycle directly unit-testable).
- The `Peek` bound is a context wrap with no seam a unit test can observe; it rides on the streamer's existing undecided-retry semantics.

`go vet` and the full `op-batcher/batcher` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217525737014025