### PR TITLE
op-batcher: cover the safety-critical espresso batcher logic with tests

### DIFF
--- a/op-batcher/batcher/espresso_active_test.go
+++ b/op-batcher/batcher/espresso_active_test.go
@@ -1,0 +1,415 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/espresso/bindings"
+	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+var (
+	testAuthAddr          = common.HexToAddress("0x00000000000000000000000000000000000000a0")
+	testSysCfgAddr        = common.HexToAddress("0x00000000000000000000000000000000000000b0")
+	testSenderAddr        = common.HexToAddress("0x00000000000000000000000000000000000000c0")
+	testOtherAddr         = common.HexToAddress("0x00000000000000000000000000000000000000d0")
+	errContractCallFailed = errors.New("contract call failed")
+)
+
+// contractCallHandler produces the raw return data (or error) for one contract
+// method invocation.
+type contractCallHandler func() ([]byte, error)
+
+// mockContractL1Client is an L1Client whose CallContract dispatches on the
+// 4-byte method selector of the incoming call. Selectors are unique across the
+// BatchAuthenticator and SystemConfig ABIs, so one dispatch table serves both
+// contracts. Calls with no registered handler fail loudly: the tests below also
+// use that to prove a method was NOT consulted on a given path.
+type mockContractL1Client struct {
+	bind.ContractBackend
+	code     []byte
+	codeErr  error
+	tipTime  uint64
+	tipErr   error
+	handlers map[string]contractCallHandler // hex selector -> handler
+}
+
+func (m *mockContractL1Client) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	return m.code, m.codeErr
+}
+
+func (m *mockContractL1Client) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	sel := hexutil.Encode(call.Data[:4])
+	handler, ok := m.handlers[sel]
+	if !ok {
+		return nil, fmt.Errorf("unexpected contract call with selector %s", sel)
+	}
+	return handler()
+}
+
+func (m *mockContractL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	if m.tipErr != nil {
+		return nil, m.tipErr
+	}
+	return &types.Header{Number: big.NewInt(0), Time: m.tipTime}, nil
+}
+
+func (m *mockContractL1Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
+
+func batchAuthenticatorABI(t *testing.T) *abi.ABI {
+	a, err := bindings.BatchAuthenticatorMetaData.GetAbi()
+	require.NoError(t, err)
+	return a
+}
+
+func systemConfigABI(t *testing.T) *abi.ABI {
+	a, err := bindings.SystemConfigMetaData.GetAbi()
+	require.NoError(t, err)
+	return a
+}
+
+func methodSelector(t *testing.T, a *abi.ABI, method string) string {
+	m, ok := a.Methods[method]
+	require.True(t, ok, "ABI has no method %q", method)
+	return hexutil.Encode(m.ID)
+}
+
+// returns registers a handler that packs vals as the method's return values.
+func returns(t *testing.T, a *abi.ABI, method string, vals ...any) contractCallHandler {
+	m := a.Methods[method]
+	return func() ([]byte, error) {
+		out, err := m.Outputs.Pack(vals...)
+		require.NoError(t, err)
+		return out, nil
+	}
+}
+
+func fails() contractCallHandler {
+	return func() ([]byte, error) { return nil, errContractCallFailed }
+}
+
+// addressAsBytes32 left-pads an address into the low 20 bytes of a bytes32,
+// mirroring how SystemConfig stores batcherHash.
+func addressAsBytes32(addr common.Address) [32]byte {
+	var out [32]byte
+	copy(out[12:], addr[:])
+	return out
+}
+
+func newActiveGateSubmitter(t *testing.T, espressoEnabled bool, client *mockContractL1Client) *BatchSubmitter {
+	l := &BatchSubmitter{}
+	l.Log = testlog.Logger(t, log.LevelDebug)
+	l.Metr = metrics.NoopMetrics
+	l.RollupConfig = &rollup.Config{
+		BatchAuthenticatorAddress: testAuthAddr,
+	}
+	l.Config.NetworkTimeout = time.Second
+	l.Config.Espresso.Enabled = espressoEnabled
+	l.Txmgr = testutils.NewFakeTxMgr(l.Log, testSenderAddr, eth.ChainIDFromUInt64(1))
+	l.L1Client = client
+	return l
+}
+
+// TestIsBatcherActive locks the two gates of the active-batcher switch: the
+// mode gate (the contract's activeIsEspresso flag must match this node's role)
+// and the identity gate (the configured sender key must be the authorized
+// batcher for that mode). This switch decides whether a batcher publishes at
+// all during a handoff, and an inverted mode check compiles and passes CI, so
+// every quadrant of (activeIsEspresso x Espresso.Enabled) is pinned explicitly.
+func TestIsBatcherActive(t *testing.T) {
+	authABI := batchAuthenticatorABI(t)
+	sysABI := systemConfigABI(t)
+
+	selActive := methodSelector(t, authABI, "activeIsEspresso")
+	selEspressoBatcher := methodSelector(t, authABI, "espressoBatcher")
+	selSystemConfig := methodSelector(t, authABI, "systemConfig")
+	selBatcherHash := methodSelector(t, sysABI, "batcherHash")
+
+	tests := []struct {
+		name            string
+		espressoEnabled bool
+		handlers        map[string]contractCallHandler
+		want            bool
+		wantErr         bool
+	}{
+		{
+			name:            "espresso batcher active and authorized",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive:          returns(t, authABI, "activeIsEspresso", true),
+				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testSenderAddr),
+			},
+			want: true,
+		},
+		{
+			name:            "espresso batcher active but key not authorized",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive:          returns(t, authABI, "activeIsEspresso", true),
+				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testOtherAddr),
+			},
+			want: false,
+		},
+		{
+			// No espressoBatcher handler: the identity of the inactive mode
+			// must not even be consulted once the mode gate fails.
+			name:            "espresso batcher while fallback mode is active",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive: returns(t, authABI, "activeIsEspresso", false),
+			},
+			want: false,
+		},
+		{
+			// The counterpart quadrant: an inverted mode check would return
+			// true here and make the fallback batcher publish during an
+			// Espresso handoff.
+			name:            "fallback batcher while espresso mode is active",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive: returns(t, authABI, "activeIsEspresso", true),
+			},
+			want: false,
+		},
+		{
+			name:            "fallback batcher active and authorized via batcherHash",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
+				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testSenderAddr)),
+			},
+			want: true,
+		},
+		{
+			name:            "fallback batcher active but key not authorized",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
+				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testOtherAddr)),
+			},
+			want: false,
+		},
+		{
+			// batcherHash stores the batcher address in its low 20 bytes; a
+			// future versioned batcherHash may set high bytes. The gate must
+			// slice the low 20 bytes rather than compare the whole word.
+			name:            "batcherHash high bytes do not obscure the low-20-byte address",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
+				selBatcherHash: func() ([]byte, error) {
+					versioned := addressAsBytes32(testSenderAddr)
+					for i := 0; i < 12; i++ {
+						versioned[i] = 0xff
+					}
+					return sysABI.Methods["batcherHash"].Outputs.Pack(versioned)
+				},
+			},
+			want: true,
+		},
+		{
+			name:            "activeIsEspresso read failure is an error",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive: fails(),
+			},
+			wantErr: true,
+		},
+		{
+			name:            "espressoBatcher read failure is an error",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive:          returns(t, authABI, "activeIsEspresso", true),
+				selEspressoBatcher: fails(),
+			},
+			wantErr: true,
+		},
+		{
+			name:            "systemConfig read failure is an error",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: fails(),
+			},
+			wantErr: true,
+		},
+		{
+			name:            "batcherHash read failure is an error",
+			espressoEnabled: false,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
+				selBatcherHash:  fails(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &mockContractL1Client{
+				code:     []byte{0x01},
+				handlers: test.handlers,
+			}
+			l := newActiveGateSubmitter(t, test.espressoEnabled, client)
+
+			got, err := l.isBatcherActive(context.Background())
+			if test.wantErr {
+				require.Error(t, err)
+				require.False(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+
+	t.Run("no contract code at the authenticator address is an error", func(t *testing.T) {
+		client := &mockContractL1Client{code: nil}
+		l := newActiveGateSubmitter(t, true, client)
+		got, err := l.isBatcherActive(context.Background())
+		require.ErrorContains(t, err, "no contract code")
+		require.False(t, got)
+	})
+
+	t.Run("CodeAt failure is an error", func(t *testing.T) {
+		client := &mockContractL1Client{codeErr: errContractCallFailed}
+		l := newActiveGateSubmitter(t, true, client)
+		got, err := l.isBatcherActive(context.Background())
+		require.Error(t, err)
+		require.False(t, got)
+	})
+}
+
+// TestShouldSkipPublishForActiveSeq locks the publish gate wired into
+// publishStateToL1: the Espresso batcher always honors the on-chain active
+// flag, the fallback batcher honors it only once fallback auth is required
+// (post EspressoTime), and every gate-evaluation failure fails closed by
+// skipping the tick.
+func TestShouldSkipPublishForActiveSeq(t *testing.T) {
+	const espressoTime = 1000
+	authABI := batchAuthenticatorABI(t)
+	sysABI := systemConfigABI(t)
+
+	selActive := methodSelector(t, authABI, "activeIsEspresso")
+	selEspressoBatcher := methodSelector(t, authABI, "espressoBatcher")
+	selSystemConfig := methodSelector(t, authABI, "systemConfig")
+	selBatcherHash := methodSelector(t, sysABI, "batcherHash")
+
+	tests := []struct {
+		name            string
+		espressoEnabled bool
+		tipTime         uint64
+		tipErr          error
+		handlers        map[string]contractCallHandler
+		wantSkip        bool
+	}{
+		{
+			name:            "active espresso batcher publishes",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive:          returns(t, authABI, "activeIsEspresso", true),
+				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testSenderAddr),
+			},
+			wantSkip: false,
+		},
+		{
+			name:            "espresso batcher skips while fallback mode is active",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive: returns(t, authABI, "activeIsEspresso", false),
+			},
+			wantSkip: true,
+		},
+		{
+			name:            "espresso batcher fails closed on gate error",
+			espressoEnabled: true,
+			handlers: map[string]contractCallHandler{
+				selActive: fails(),
+			},
+			wantSkip: true,
+		},
+		{
+			// No handlers at all: consulting the contract would fail and flip
+			// the result to skip, so wantSkip=false also proves the pre-fork
+			// fallback batcher never touches the BatchAuthenticator.
+			name:            "pre-fork fallback batcher publishes without consulting the contract",
+			espressoEnabled: false,
+			tipTime:         espressoTime - 1,
+			handlers:        nil,
+			wantSkip:        false,
+		},
+		{
+			name:            "post-fork fallback batcher publishes while active and authorized",
+			espressoEnabled: false,
+			tipTime:         espressoTime,
+			handlers: map[string]contractCallHandler{
+				selActive:       returns(t, authABI, "activeIsEspresso", false),
+				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
+				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testSenderAddr)),
+			},
+			wantSkip: false,
+		},
+		{
+			name:            "post-fork fallback batcher skips while espresso mode is active",
+			espressoEnabled: false,
+			tipTime:         espressoTime,
+			handlers: map[string]contractCallHandler{
+				selActive: returns(t, authABI, "activeIsEspresso", true),
+			},
+			wantSkip: true,
+		},
+		{
+			name:            "fallback batcher fails closed on fallback-auth gate error",
+			espressoEnabled: false,
+			tipErr:          errContractCallFailed,
+			wantSkip:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &mockContractL1Client{
+				code:     []byte{0x01},
+				tipTime:  test.tipTime,
+				tipErr:   test.tipErr,
+				handlers: test.handlers,
+			}
+			l := newActiveGateSubmitter(t, test.espressoEnabled, client)
+			l.RollupConfig.EspressoTime = u64(espressoTime)
+
+			require.Equal(t, test.wantSkip, l.shouldSkipPublishForActiveSeq(context.Background()))
+		})
+	}
+
+	t.Run("no authenticator configured never skips", func(t *testing.T) {
+		// A nil L1 client proves neither gate is evaluated: any RPC use would panic.
+		l := newActiveGateSubmitter(t, true, nil)
+		l.L1Client = nil
+		l.RollupConfig.BatchAuthenticatorAddress = common.Address{}
+
+		require.False(t, l.shouldSkipPublishForActiveSeq(context.Background()))
+	})
+}

--- a/op-batcher/batcher/espresso_active_test.go
+++ b/op-batcher/batcher/espresso_active_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -33,22 +32,54 @@ var (
 	errContractCallFailed = errors.New("contract call failed")
 )
 
-// contractCallHandler produces the raw return data (or error) for one contract
-// method invocation.
-type contractCallHandler func() ([]byte, error)
+// The two contract ABIs the active-batcher gate reads from, parsed once.
+var (
+	authABI   = mustGetABI(bindings.BatchAuthenticatorMetaData)
+	sysCfgABI = mustGetABI(bindings.SystemConfigMetaData)
+)
+
+func mustGetABI(md *bind.MetaData) *abi.ABI {
+	parsed, err := md.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+// gateMethodBySelector resolves the calldata's 4-byte selector to a method of
+// one of the two gate ABIs.
+func gateMethodBySelector(data []byte) (abi.Method, error) {
+	if m, err := authABI.MethodById(data[:4]); err == nil {
+		return *m, nil
+	}
+	if m, err := sysCfgABI.MethodById(data[:4]); err == nil {
+		return *m, nil
+	}
+	return abi.Method{}, fmt.Errorf("unknown method selector %#x", data[:4])
+}
+
+// contractCallHandler produces the raw return data (or error) for one
+// invocation of the given contract method.
+type contractCallHandler func(method abi.Method) ([]byte, error)
+
+// contractHandlers routes contract calls per contract address, then per method
+// name.
+type contractHandlers map[common.Address]map[string]contractCallHandler
 
 // mockContractL1Client is an L1Client whose CallContract dispatches on the
-// 4-byte method selector of the incoming call. Selectors are unique across the
-// BatchAuthenticator and SystemConfig ABIs, so one dispatch table serves both
-// contracts. Calls with no registered handler fail loudly: the tests below also
-// use that to prove a method was NOT consulted on a given path.
+// target contract address and the method named by the calldata selector.
+// Keying on the address matters: the two ABIs share several selectors (owner,
+// version, ...), and it makes the tests prove a value was read from the right
+// contract, not merely that the method was called somewhere. Calls with no
+// registered handler fail loudly: the tests below also use that to prove a
+// method was NOT consulted on a given path.
 type mockContractL1Client struct {
 	bind.ContractBackend
 	code     []byte
 	codeErr  error
 	tipTime  uint64
 	tipErr   error
-	handlers map[string]contractCallHandler // hex selector -> handler
+	handlers contractHandlers
 }
 
 func (m *mockContractL1Client) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
@@ -56,12 +87,18 @@ func (m *mockContractL1Client) CodeAt(ctx context.Context, contract common.Addre
 }
 
 func (m *mockContractL1Client) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	sel := hexutil.Encode(call.Data[:4])
-	handler, ok := m.handlers[sel]
-	if !ok {
-		return nil, fmt.Errorf("unexpected contract call with selector %s", sel)
+	if call.To == nil {
+		return nil, errors.New("unexpected contract-creation call")
 	}
-	return handler()
+	method, err := gateMethodBySelector(call.Data)
+	if err != nil {
+		return nil, err
+	}
+	handler, ok := m.handlers[*call.To][method.Name]
+	if !ok {
+		return nil, fmt.Errorf("unexpected call to method %s on contract %s", method.Name, call.To)
+	}
+	return handler(method)
 }
 
 func (m *mockContractL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
@@ -75,44 +112,16 @@ func (m *mockContractL1Client) NonceAt(ctx context.Context, account common.Addre
 	return 0, nil
 }
 
-func batchAuthenticatorABI(t *testing.T) *abi.ABI {
-	a, err := bindings.BatchAuthenticatorMetaData.GetAbi()
-	require.NoError(t, err)
-	return a
-}
-
-func systemConfigABI(t *testing.T) *abi.ABI {
-	a, err := bindings.SystemConfigMetaData.GetAbi()
-	require.NoError(t, err)
-	return a
-}
-
-func methodSelector(t *testing.T, a *abi.ABI, method string) string {
-	m, ok := a.Methods[method]
-	require.True(t, ok, "ABI has no method %q", method)
-	return hexutil.Encode(m.ID)
-}
-
-// returns registers a handler that packs vals as the method's return values.
-func returns(t *testing.T, a *abi.ABI, method string, vals ...any) contractCallHandler {
-	m := a.Methods[method]
-	return func() ([]byte, error) {
-		out, err := m.Outputs.Pack(vals...)
-		require.NoError(t, err)
-		return out, nil
+// returns builds a handler that packs vals as the called method's return
+// values.
+func returns(vals ...any) contractCallHandler {
+	return func(method abi.Method) ([]byte, error) {
+		return method.Outputs.Pack(vals...)
 	}
 }
 
 func fails() contractCallHandler {
-	return func() ([]byte, error) { return nil, errContractCallFailed }
-}
-
-// addressAsBytes32 left-pads an address into the low 20 bytes of a bytes32,
-// mirroring how SystemConfig stores batcherHash.
-func addressAsBytes32(addr common.Address) [32]byte {
-	var out [32]byte
-	copy(out[12:], addr[:])
-	return out
+	return func(abi.Method) ([]byte, error) { return nil, errContractCallFailed }
 }
 
 func newActiveGateSubmitter(t *testing.T, espressoEnabled bool, client *mockContractL1Client) *BatchSubmitter {
@@ -136,36 +145,32 @@ func newActiveGateSubmitter(t *testing.T, espressoEnabled bool, client *mockCont
 // all during a handoff, and an inverted mode check compiles and passes CI, so
 // every quadrant of (activeIsEspresso x Espresso.Enabled) is pinned explicitly.
 func TestIsBatcherActive(t *testing.T) {
-	authABI := batchAuthenticatorABI(t)
-	sysABI := systemConfigABI(t)
-
-	selActive := methodSelector(t, authABI, "activeIsEspresso")
-	selEspressoBatcher := methodSelector(t, authABI, "espressoBatcher")
-	selSystemConfig := methodSelector(t, authABI, "systemConfig")
-	selBatcherHash := methodSelector(t, sysABI, "batcherHash")
-
 	tests := []struct {
 		name            string
 		espressoEnabled bool
-		handlers        map[string]contractCallHandler
+		handlers        contractHandlers
 		want            bool
 		wantErr         bool
 	}{
 		{
 			name:            "espresso batcher active and authorized",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive:          returns(t, authABI, "activeIsEspresso", true),
-				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testSenderAddr),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+					"espressoBatcher":  returns(testSenderAddr),
+				},
 			},
 			want: true,
 		},
 		{
 			name:            "espresso batcher active but key not authorized",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive:          returns(t, authABI, "activeIsEspresso", true),
-				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testOtherAddr),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+					"espressoBatcher":  returns(testOtherAddr),
+				},
 			},
 			want: false,
 		},
@@ -174,8 +179,10 @@ func TestIsBatcherActive(t *testing.T) {
 			// must not even be consulted once the mode gate fails.
 			name:            "espresso batcher while fallback mode is active",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive: returns(t, authABI, "activeIsEspresso", false),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+				},
 			},
 			want: false,
 		},
@@ -185,28 +192,38 @@ func TestIsBatcherActive(t *testing.T) {
 			// Espresso handoff.
 			name:            "fallback batcher while espresso mode is active",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive: returns(t, authABI, "activeIsEspresso", true),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+				},
 			},
 			want: false,
 		},
 		{
 			name:            "fallback batcher active and authorized via batcherHash",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
-				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testSenderAddr)),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     returns(testSysCfgAddr),
+				},
+				testSysCfgAddr: {
+					"batcherHash": returns(eth.AddressAsLeftPaddedHash(testSenderAddr)),
+				},
 			},
 			want: true,
 		},
 		{
 			name:            "fallback batcher active but key not authorized",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
-				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testOtherAddr)),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     returns(testSysCfgAddr),
+				},
+				testSysCfgAddr: {
+					"batcherHash": returns(eth.AddressAsLeftPaddedHash(testOtherAddr)),
+				},
 			},
 			want: false,
 		},
@@ -216,15 +233,19 @@ func TestIsBatcherActive(t *testing.T) {
 			// slice the low 20 bytes rather than compare the whole word.
 			name:            "batcherHash high bytes do not obscure the low-20-byte address",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
-				selBatcherHash: func() ([]byte, error) {
-					versioned := addressAsBytes32(testSenderAddr)
-					for i := 0; i < 12; i++ {
-						versioned[i] = 0xff
-					}
-					return sysABI.Methods["batcherHash"].Outputs.Pack(versioned)
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     returns(testSysCfgAddr),
+				},
+				testSysCfgAddr: {
+					"batcherHash": func(method abi.Method) ([]byte, error) {
+						versioned := eth.AddressAsLeftPaddedHash(testSenderAddr)
+						for i := 0; i < 12; i++ {
+							versioned[i] = 0xff
+						}
+						return method.Outputs.Pack(versioned)
+					},
 				},
 			},
 			want: true,
@@ -232,36 +253,46 @@ func TestIsBatcherActive(t *testing.T) {
 		{
 			name:            "activeIsEspresso read failure is an error",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive: fails(),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": fails(),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name:            "espressoBatcher read failure is an error",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive:          returns(t, authABI, "activeIsEspresso", true),
-				selEspressoBatcher: fails(),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+					"espressoBatcher":  fails(),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name:            "systemConfig read failure is an error",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: fails(),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     fails(),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name:            "batcherHash read failure is an error",
 			espressoEnabled: false,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
-				selBatcherHash:  fails(),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     returns(testSysCfgAddr),
+				},
+				testSysCfgAddr: {
+					"batcherHash": fails(),
+				},
 			},
 			wantErr: true,
 		},
@@ -310,44 +341,43 @@ func TestIsBatcherActive(t *testing.T) {
 // skipping the tick.
 func TestShouldSkipPublishForActiveSeq(t *testing.T) {
 	const espressoTime = 1000
-	authABI := batchAuthenticatorABI(t)
-	sysABI := systemConfigABI(t)
-
-	selActive := methodSelector(t, authABI, "activeIsEspresso")
-	selEspressoBatcher := methodSelector(t, authABI, "espressoBatcher")
-	selSystemConfig := methodSelector(t, authABI, "systemConfig")
-	selBatcherHash := methodSelector(t, sysABI, "batcherHash")
 
 	tests := []struct {
 		name            string
 		espressoEnabled bool
 		tipTime         uint64
 		tipErr          error
-		handlers        map[string]contractCallHandler
+		handlers        contractHandlers
 		wantSkip        bool
 	}{
 		{
 			name:            "active espresso batcher publishes",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive:          returns(t, authABI, "activeIsEspresso", true),
-				selEspressoBatcher: returns(t, authABI, "espressoBatcher", testSenderAddr),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+					"espressoBatcher":  returns(testSenderAddr),
+				},
 			},
 			wantSkip: false,
 		},
 		{
 			name:            "espresso batcher skips while fallback mode is active",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive: returns(t, authABI, "activeIsEspresso", false),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+				},
 			},
 			wantSkip: true,
 		},
 		{
 			name:            "espresso batcher fails closed on gate error",
 			espressoEnabled: true,
-			handlers: map[string]contractCallHandler{
-				selActive: fails(),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": fails(),
+				},
 			},
 			wantSkip: true,
 		},
@@ -365,10 +395,14 @@ func TestShouldSkipPublishForActiveSeq(t *testing.T) {
 			name:            "post-fork fallback batcher publishes while active and authorized",
 			espressoEnabled: false,
 			tipTime:         espressoTime,
-			handlers: map[string]contractCallHandler{
-				selActive:       returns(t, authABI, "activeIsEspresso", false),
-				selSystemConfig: returns(t, authABI, "systemConfig", testSysCfgAddr),
-				selBatcherHash:  returns(t, sysABI, "batcherHash", addressAsBytes32(testSenderAddr)),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(false),
+					"systemConfig":     returns(testSysCfgAddr),
+				},
+				testSysCfgAddr: {
+					"batcherHash": returns(eth.AddressAsLeftPaddedHash(testSenderAddr)),
+				},
 			},
 			wantSkip: false,
 		},
@@ -376,8 +410,10 @@ func TestShouldSkipPublishForActiveSeq(t *testing.T) {
 			name:            "post-fork fallback batcher skips while espresso mode is active",
 			espressoEnabled: false,
 			tipTime:         espressoTime,
-			handlers: map[string]contractCallHandler{
-				selActive: returns(t, authABI, "activeIsEspresso", true),
+			handlers: contractHandlers{
+				testAuthAddr: {
+					"activeIsEspresso": returns(true),
+				},
 			},
 			wantSkip: true,
 		},
@@ -405,9 +441,9 @@ func TestShouldSkipPublishForActiveSeq(t *testing.T) {
 	}
 
 	t.Run("no authenticator configured never skips", func(t *testing.T) {
-		// A nil L1 client proves neither gate is evaluated: any RPC use would panic.
+		// The typed-nil client panics on any RPC use, proving neither gate is
+		// evaluated.
 		l := newActiveGateSubmitter(t, true, nil)
-		l.L1Client = nil
 		l.RollupConfig.BatchAuthenticatorAddress = common.Address{}
 
 		require.False(t, l.shouldSkipPublishForActiveSeq(context.Background()))

--- a/op-batcher/batcher/espresso_block_loader_test.go
+++ b/op-batcher/batcher/espresso_block_loader_test.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -389,8 +388,9 @@ func TestEnqueueBlocksReorgDetection(t *testing.T) {
 // handshake between the batch queueing loop (requester) and the batch loading
 // loop (performer). The handshake exists so the queueing loop never runs
 // clearState itself — doing so raced the loading loop on the channel manager
-// and streamer (the earlier data-race fix); this is its regression test and
-// must keep running under -race.
+// and streamer. TestEnqueueBlocksReorgDetection locks the requester side of
+// that fix (a reorg requests the clear, never performs it); this locks the
+// performer side.
 func TestClearStateHandshake(t *testing.T) {
 	populatedStatus := &eth.SyncStatus{
 		HeadL1:      eth.L1BlockRef{Number: 50, Hash: common.Hash{0xa1}},
@@ -414,54 +414,23 @@ func TestClearStateHandshake(t *testing.T) {
 		require.False(t, bs.clearStateRequested.Load())
 	})
 
-	t.Run("concurrent requesters and one performer race cleanly", func(t *testing.T) {
+	t.Run("concurrent requests coalesce into one clear", func(t *testing.T) {
 		bs, ep := setup(t, nil)
-		ep.rollupClient.Mock.On("SyncStatus").Return(populatedStatus, nil)
+		ep.rollupClient.ExpectSyncStatus(populatedStatus, nil)
 
-		const requesters = 4
-		const requestsEach = 64
-
-		var performed atomic.Int64
-		stop := make(chan struct{})
-		var performerWg sync.WaitGroup
-		performerWg.Add(1)
-		go func() {
-			defer performerWg.Done()
-			for {
-				if bs.performClearState(t.Context()) {
-					performed.Add(1)
-				}
-				select {
-				case <-stop:
-					return
-				default:
-				}
-			}
-		}()
-
-		var requesterWg sync.WaitGroup
-		for i := 0; i < requesters; i++ {
-			requesterWg.Add(1)
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
 			go func() {
-				defer requesterWg.Done()
-				for j := 0; j < requestsEach; j++ {
+				defer wg.Done()
+				for j := 0; j < 64; j++ {
 					bs.requestClearState()
 				}
 			}()
 		}
-		requesterWg.Wait()
-		close(stop)
-		performerWg.Wait()
+		wg.Wait()
 
-		// The performer may have exited between the last request and its
-		// final check; one drain settles it.
-		if bs.performClearState(t.Context()) {
-			performed.Add(1)
-		}
-
-		require.False(t, bs.clearStateRequested.Load(), "no request may be left dangling")
-		require.GreaterOrEqual(t, performed.Load(), int64(1))
-		require.LessOrEqual(t, performed.Load(), int64(requesters*requestsEach),
-			"the CAS must never perform more clears than were requested")
+		require.True(t, bs.performClearState(t.Context()), "the pending request must be performed")
+		require.False(t, bs.performClearState(t.Context()), "all requests coalesce into a single clear")
 	})
 }

--- a/op-batcher/batcher/espresso_block_loader_test.go
+++ b/op-batcher/batcher/espresso_block_loader_test.go
@@ -1,17 +1,25 @@
 package batcher
 
 import (
+	"context"
 	"errors"
+	"math/big"
+	"math/rand"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	derivetest "github.com/ethereum-optimism/optimism/op-node/rollup/derive/test"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -172,5 +180,288 @@ func TestEspressoReanchorTarget(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, target)
 		require.Equal(t, localSafe, *target)
+	})
+}
+
+// numberedRef builds an L2BlockRef whose hash encodes its number, so hash
+// comparisons in the loader are meaningful without building real blocks.
+func numberedRef(n uint64) eth.L2BlockRef {
+	return eth.L2BlockRef{Number: n, Hash: common.Hash{byte(n)}}
+}
+
+// numberedRefs builds the contiguous ref chain [from, to].
+func numberedRefs(from, to uint64) []eth.L2BlockRef {
+	refs := make([]eth.L2BlockRef, 0, to-from+1)
+	for n := from; n <= to; n++ {
+		refs = append(refs, numberedRef(n))
+	}
+	return refs
+}
+
+// TestNextBlockRangeBranches locks the reset/reorg/prune branches of
+// nextBlockRange. The safe-chain-reorg hash check is the sole defense against
+// re-queueing orphaned blocks to Espresso, and every reset branch feeds
+// loader.reset() -> requestClearState, so a silently wrong action here either
+// resubmits derived history or drops blocks.
+func TestNextBlockRangeBranches(t *testing.T) {
+	newStatus := func(localSafe eth.L2BlockRef, unsafeNum uint64) *eth.SyncStatus {
+		return &eth.SyncStatus{
+			HeadL1:      eth.L1BlockRef{Number: 50, Hash: common.Hash{0xa1}},
+			CurrentL1:   eth.L1BlockRef{Number: 20, Hash: common.Hash{0xa2}},
+			LocalSafeL2: localSafe,
+			UnsafeL2:    numberedRef(unsafeNum),
+		}
+	}
+
+	t.Run("queue caught up with the unsafe head retries", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 109)
+		r, action := loader.nextBlockRange(newStatus(numberedRef(104), 109))
+		require.Equal(t, EnqueueBlockAction(ActionRetry), action)
+		require.Equal(t, inclusiveBlockRange{}, r)
+		require.Equal(t, numberedRefs(105, 109), loader.queuedBlocks)
+	})
+
+	t.Run("reversed CurrentL1 retries and keeps the old baseline", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		prev := newStatus(numberedRef(104), 109)
+		prev.CurrentL1.Number = 30 // ahead of the new status' CurrentL1 (20)
+		loader.prevSyncStatus = prev
+		r, action := loader.nextBlockRange(newStatus(numberedRef(104), 109))
+		require.Equal(t, EnqueueBlockAction(ActionRetry), action)
+		require.Equal(t, inclusiveBlockRange{}, r)
+		require.Same(t, prev, loader.prevSyncStatus,
+			"a reversed status must not become the comparison baseline")
+	})
+
+	t.Run("derivation ahead of the whole queue resets", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 106)
+		_, action := loader.nextBlockRange(newStatus(numberedRef(107), 110))
+		require.Equal(t, EnqueueBlockAction(ActionReset), action)
+	})
+
+	t.Run("safe head below the oldest queued block resets", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 108)
+		_, action := loader.nextBlockRange(newStatus(numberedRef(103), 110))
+		require.Equal(t, EnqueueBlockAction(ActionReset), action)
+	})
+
+	t.Run("gapped queue with the safe head above its span resets", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		// A queue with a hole (106 missing, e.g. after a partial enqueue
+		// failure) makes the count-based check the only guard.
+		loader.queuedBlocks = []eth.L2BlockRef{numberedRef(105), numberedRef(107)}
+		_, action := loader.nextBlockRange(newStatus(numberedRef(107), 110))
+		require.Equal(t, EnqueueBlockAction(ActionReset), action)
+	})
+
+	t.Run("safe-chain reorg is detected by hash mismatch", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 108)
+		// Same height we queued at 106, different (canonical) hash: our
+		// queued chain was orphaned and must not keep feeding Espresso.
+		reorgedSafe := eth.L2BlockRef{Number: 106, Hash: common.Hash{0xde, 0xad}}
+		_, action := loader.nextBlockRange(newStatus(reorgedSafe, 110))
+		require.Equal(t, EnqueueBlockAction(ActionReset), action)
+	})
+
+	t.Run("matching safe hash prunes derived blocks and enqueues the rest", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 108)
+		r, action := loader.nextBlockRange(newStatus(numberedRef(106), 110))
+		require.Equal(t, EnqueueBlockAction(ActionEnqueue), action)
+		require.Equal(t, inclusiveBlockRange{109, 110}, r)
+		require.Equal(t, numberedRefs(106, 108), loader.queuedBlocks,
+			"blocks strictly below the safe head are derived and must be dropped")
+	})
+
+	t.Run("safe head just below the queue enqueues without pruning", func(t *testing.T) {
+		loader := newTestBlockLoader(t)
+		loader.queuedBlocks = numberedRefs(105, 108)
+		// Hash deliberately unrelated to the queue: with zero blocks to
+		// enqueue-check there is nothing of ours at the safe height yet, so
+		// no hash comparison (and no prune) may fire.
+		safe := eth.L2BlockRef{Number: 104, Hash: common.Hash{0xbe, 0xef}}
+		r, action := loader.nextBlockRange(newStatus(safe, 110))
+		require.Equal(t, EnqueueBlockAction(ActionEnqueue), action)
+		require.Equal(t, inclusiveBlockRange{109, 110}, r)
+		require.Equal(t, numberedRefs(105, 108), loader.queuedBlocks)
+	})
+}
+
+// nopEspressoClient satisfies the EspressoClient interface for wiring up an
+// espressoTransactionSubmitter whose workers are never spawned; any actual use
+// of the client would panic on the embedded nil interface.
+type nopEspressoClient struct {
+	espressoClient.EspressoClient
+}
+
+// fakeChainSigner returns a constant signature; EnqueueBlocks only needs
+// signing to succeed, not to verify.
+type fakeChainSigner struct{}
+
+func (fakeChainSigner) SignTransaction(ctx context.Context, addr common.Address, tx *types.Transaction) (*types.Transaction, error) {
+	return tx, nil
+}
+
+func (fakeChainSigner) Sign(ctx context.Context, hash []byte) ([]byte, error) {
+	return make([]byte, 65), nil
+}
+
+// newEnqueueTestSubmitter builds a BatchSubmitter that can run EnqueueBlocks
+// end to end: fetch a block from the (mock) sequencer, convert it, sign it,
+// and hand it to the espresso transaction submitter's job queue.
+func newEnqueueTestSubmitter(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
+	bs, ep := setup(t, nil)
+	bs.Espresso.ChainSigner = fakeChainSigner{}
+	bs.espressoSubmitter = NewEspressoTransactionSubmitter(
+		WithContext(t.Context()),
+		WithEspressoClient(nopEspressoClient{}),
+	)
+	return bs, ep
+}
+
+// TestEnqueueBlocksReorgDetection locks EnqueueBlocks' parent-hash check — the
+// loader-side reorg defense — and the reset it triggers: the reset must be
+// requested via the clearState handshake, never performed inline on the
+// queueing loop (the data race the handshake was introduced to fix).
+func TestEnqueueBlocksReorgDetection(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+
+	t.Run("a reorged block resets the loader and requests a state clear", func(t *testing.T) {
+		bs, ep := newEnqueueTestSubmitter(t)
+		loader := &BlockLoader{batcher: bs}
+		loader.queuedBlocks = []eth.L2BlockRef{{Number: 105, Hash: common.Hash{0xee}}}
+		loader.prevSyncStatus = &eth.SyncStatus{}
+
+		block := derivetest.RandomL2BlockWithChainId(rng, 1, defaultTestRollupConfig.L2ChainID)
+		require.NotEqual(t, loader.queuedBlocks[0].Hash, block.ParentHash(),
+			"sanity: the fetched block must not extend the queued tip")
+		ep.ethClient.ExpectBlockByNumber(new(big.Int).SetUint64(106), block, nil)
+
+		loader.EnqueueBlocks(t.Context(), inclusiveBlockRange{106, 106})
+
+		require.Nil(t, loader.queuedBlocks, "reorg must drop the queued chain")
+		require.Nil(t, loader.prevSyncStatus, "reorg must drop the sync-status baseline")
+		require.True(t, bs.clearStateRequested.Load(),
+			"reorg must request a state clear from the loading loop")
+		require.Empty(t, bs.espressoSubmitter.submitJobQueue,
+			"the reorged block must not reach Espresso")
+	})
+
+	t.Run("a block extending the queue is signed, queued to espresso, and appended", func(t *testing.T) {
+		bs, ep := newEnqueueTestSubmitter(t)
+		block := derivetest.RandomL2BlockWithChainId(rng, 1, defaultTestRollupConfig.L2ChainID)
+		loader := &BlockLoader{batcher: bs}
+		loader.queuedBlocks = []eth.L2BlockRef{{Number: block.NumberU64() - 1, Hash: block.ParentHash()}}
+		ep.ethClient.ExpectBlockByNumber(new(big.Int).SetUint64(106), block, nil)
+
+		loader.EnqueueBlocks(t.Context(), inclusiveBlockRange{106, 106})
+
+		require.Len(t, loader.queuedBlocks, 2)
+		appended := loader.queuedBlocks[1]
+		require.Equal(t, block.Hash(), appended.Hash)
+		require.Equal(t, block.NumberU64(), appended.Number)
+		require.False(t, bs.clearStateRequested.Load())
+		require.Len(t, bs.espressoSubmitter.submitJobQueue, 1,
+			"exactly one espresso submission job for the one new block")
+	})
+
+	t.Run("a fetch failure stops the scan without resetting", func(t *testing.T) {
+		bs, ep := newEnqueueTestSubmitter(t)
+		loader := &BlockLoader{batcher: bs}
+		loader.queuedBlocks = []eth.L2BlockRef{{Number: 105, Hash: common.Hash{0xee}}}
+		ep.ethClient.ExpectBlockByNumber(new(big.Int).SetUint64(106), (*types.Block)(nil), errors.New("rpc down"))
+
+		// The range spans two blocks; the mock would reject a fetch of 107,
+		// so completing without a mock failure also proves the scan stopped.
+		loader.EnqueueBlocks(t.Context(), inclusiveBlockRange{106, 107})
+
+		require.Equal(t, []eth.L2BlockRef{{Number: 105, Hash: common.Hash{0xee}}}, loader.queuedBlocks,
+			"a transient fetch failure must keep the queue for the next tick")
+		require.False(t, bs.clearStateRequested.Load())
+	})
+}
+
+// TestClearStateHandshake locks the requestClearState/performClearState CAS
+// handshake between the batch queueing loop (requester) and the batch loading
+// loop (performer). The handshake exists so the queueing loop never runs
+// clearState itself — doing so raced the loading loop on the channel manager
+// and streamer (the earlier data-race fix); this is its regression test and
+// must keep running under -race.
+func TestClearStateHandshake(t *testing.T) {
+	populatedStatus := &eth.SyncStatus{
+		HeadL1:      eth.L1BlockRef{Number: 50, Hash: common.Hash{0xa1}},
+		LocalSafeL2: eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 40}},
+	}
+
+	t.Run("perform without a request is a no-op", func(t *testing.T) {
+		bs, _ := setup(t, nil)
+		// No SyncStatus expectation is registered: if performClearState ran
+		// clearState anyway, the mock would reject the unexpected call.
+		require.False(t, bs.performClearState(t.Context()))
+	})
+
+	t.Run("a request is performed exactly once", func(t *testing.T) {
+		bs, ep := setup(t, nil)
+		ep.rollupClient.ExpectSyncStatus(populatedStatus, nil)
+
+		bs.requestClearState()
+		require.True(t, bs.performClearState(t.Context()), "the requested clear must be performed")
+		require.False(t, bs.performClearState(t.Context()), "the request must be consumed by the CAS")
+		require.False(t, bs.clearStateRequested.Load())
+	})
+
+	t.Run("concurrent requesters and one performer race cleanly", func(t *testing.T) {
+		bs, ep := setup(t, nil)
+		ep.rollupClient.Mock.On("SyncStatus").Return(populatedStatus, nil)
+
+		const requesters = 4
+		const requestsEach = 64
+
+		var performed atomic.Int64
+		stop := make(chan struct{})
+		var performerWg sync.WaitGroup
+		performerWg.Add(1)
+		go func() {
+			defer performerWg.Done()
+			for {
+				if bs.performClearState(t.Context()) {
+					performed.Add(1)
+				}
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+
+		var requesterWg sync.WaitGroup
+		for i := 0; i < requesters; i++ {
+			requesterWg.Add(1)
+			go func() {
+				defer requesterWg.Done()
+				for j := 0; j < requestsEach; j++ {
+					bs.requestClearState()
+				}
+			}()
+		}
+		requesterWg.Wait()
+		close(stop)
+		performerWg.Wait()
+
+		// The performer may have exited between the last request and its
+		// final check; one drain settles it.
+		if bs.performClearState(t.Context()) {
+			performed.Add(1)
+		}
+
+		require.False(t, bs.clearStateRequested.Load(), "no request may be left dangling")
+		require.GreaterOrEqual(t, performed.Load(), int64(1))
+		require.LessOrEqual(t, performed.Load(), int64(requesters*requestsEach),
+			"the CAS must never perform more clears than were requested")
 	})
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -193,10 +193,17 @@ const (
 // explicitly - nothing derives a handoff height from the rollup config, since
 // espresso_time is a timestamp and its L2 block height is not statically known.
 func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockRef, error) {
-	ctx, cancel := context.WithTimeout(ctx, espressoAnchorTimeout)
+	return l.waitForLocalSafeHeadWithTiming(ctx, espressoAnchorTimeout, espressoAnchorRetryInterval)
+}
+
+// waitForLocalSafeHeadWithTiming is waitForLocalSafeHead with the timeout and
+// retry interval injected so tests can exercise the retry and give-up paths
+// without waiting out the real one-minute anchor timeout.
+func (l *BatchSubmitter) waitForLocalSafeHeadWithTiming(ctx context.Context, timeout, retryInterval time.Duration) (eth.L2BlockRef, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(espressoAnchorRetryInterval)
+	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 
 	caffeinationL2 := l.Config.Espresso.CaffeinationHeightL2
@@ -219,7 +226,7 @@ func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockR
 		case <-ctx.Done():
 			return eth.L2BlockRef{}, fmt.Errorf(
 				"no local-safe L2 head at or past the caffeination point (%d) to anchor the Espresso streamer within %s (safe to retry once activation has been derived from L1): %w",
-				caffeinationL2, espressoAnchorTimeout, ctx.Err())
+				caffeinationL2, timeout, ctx.Err())
 		}
 	}
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -112,7 +112,7 @@ func (l *BatchSubmitter) setupEspressoStreamer(ctx context.Context) error {
 		return nil
 	}
 
-	anchor, err := l.waitForLocalSafeHead(ctx)
+	anchor, err := l.waitForLocalSafeHead(ctx, espressoAnchorTimeout, espressoAnchorRetryInterval)
 	if err != nil {
 		return err
 	}
@@ -192,14 +192,10 @@ const (
 // is the derived tip), but a handoff from the fallback batcher must set the flag
 // explicitly - nothing derives a handoff height from the rollup config, since
 // espresso_time is a timestamp and its L2 block height is not statically known.
-func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context) (eth.L2BlockRef, error) {
-	return l.waitForLocalSafeHeadWithTiming(ctx, espressoAnchorTimeout, espressoAnchorRetryInterval)
-}
-
-// waitForLocalSafeHeadWithTiming is waitForLocalSafeHead with the timeout and
-// retry interval injected so tests can exercise the retry and give-up paths
-// without waiting out the real one-minute anchor timeout.
-func (l *BatchSubmitter) waitForLocalSafeHeadWithTiming(ctx context.Context, timeout, retryInterval time.Duration) (eth.L2BlockRef, error) {
+// The timeout and retry interval are parameters (espressoAnchorTimeout and
+// espressoAnchorRetryInterval in production) so tests can exercise the retry
+// and give-up paths without waiting out the real one-minute anchor timeout.
+func (l *BatchSubmitter) waitForLocalSafeHead(ctx context.Context, timeout, retryInterval time.Duration) (eth.L2BlockRef, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/op-batcher/batcher/espresso_driver_test.go
+++ b/op-batcher/batcher/espresso_driver_test.go
@@ -1,0 +1,153 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	espressoStreamers "github.com/EspressoSystems/espresso-streamers/op"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+const testCaffeinationL2 = uint64(500)
+
+func newAnchorTestSubmitter(t *testing.T, caffeinationL2 uint64) (*BatchSubmitter, *mockL2EndpointProvider) {
+	ep := newEndpointProvider()
+	l := &BatchSubmitter{
+		DriverSetup: DriverSetup{
+			Log: testlog.Logger(t, log.LevelDebug),
+			Config: BatcherConfig{
+				NetworkTimeout: time.Second,
+				Espresso: EspressoBatcherConfig{
+					CaffeinationHeightL2: caffeinationL2,
+				},
+			},
+			EndpointProvider: ep,
+		},
+	}
+	return l, ep
+}
+
+// anchorStatus returns a sync status whose HeadL1 is populated (getSyncStatus
+// backs off internally on an empty HeadL1) and whose LocalSafeL2 sits at the
+// given height.
+func anchorStatus(localSafe uint64) *eth.SyncStatus {
+	status := &eth.SyncStatus{
+		HeadL1: eth.L1BlockRef{Number: 50, Hash: common.Hash{0xa1}},
+	}
+	if localSafe > 0 {
+		status.LocalSafeL2 = eth.L2BlockRef{Number: localSafe, Hash: common.Hash{byte(localSafe)}}
+	}
+	return status
+}
+
+// TestWaitForLocalSafeHead locks the streamer's anchor gate: the Espresso
+// batcher must refuse to run until the caffeination point is local-safe (the
+// fallback batcher's pre-activation channels have derived), must retry through
+// transient sync-status trouble, and must give up with a retryable error
+// rather than anchoring below the caffeination point.
+func TestWaitForLocalSafeHead(t *testing.T) {
+	t.Run("anchors once the caffeination point is local-safe", func(t *testing.T) {
+		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
+
+		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, testCaffeinationL2, anchor.Number)
+	})
+
+	t.Run("anchors past the caffeination point", func(t *testing.T) {
+		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2+7), nil)
+
+		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, testCaffeinationL2+7, anchor.Number)
+	})
+
+	t.Run("gives up while the caffeination point stays underived", func(t *testing.T) {
+		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
+		ep.rollupClient.Mock.On("SyncStatus").Return(anchorStatus(testCaffeinationL2-1), nil)
+
+		_, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 50*time.Millisecond, 5*time.Millisecond)
+		require.ErrorContains(t, err, "caffeination point (500)",
+			"the give-up error must name the height the operator is waiting on")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("retries through a transient sync-status failure", func(t *testing.T) {
+		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
+		ep.rollupClient.ExpectSyncStatus(nil, errors.New("transient RPC failure"))
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
+
+		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 5*time.Second, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, testCaffeinationL2, anchor.Number)
+	})
+
+	t.Run("retries past an empty local-safe head", func(t *testing.T) {
+		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(0), nil) // populated status, zero LocalSafeL2
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
+
+		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 5*time.Second, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, testCaffeinationL2, anchor.Number)
+	})
+
+	t.Run("zero caffeination height anchors on any populated local-safe head", func(t *testing.T) {
+		// --espresso.origin-height-l2 unset: no floor beyond a populated
+		// head. Steady-state restarts rely on this; handoffs must set the flag.
+		l, ep := newAnchorTestSubmitter(t, 0)
+		ep.rollupClient.ExpectSyncStatus(anchorStatus(1), nil)
+
+		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), anchor.Number)
+	})
+}
+
+// TestRollbackFailedStart locks the startup rollback: a failed Espresso setup
+// must undo everything StartBatchSubmitting set up — clear the running flag so
+// a later start attempt is not rejected with "batcher is already running", and
+// cancel both contexts so nothing keeps running behind the failed start.
+func TestRollbackFailedStart(t *testing.T) {
+	tests := []struct {
+		name     string
+		streamer *espressoStreamers.Streamer
+	}{
+		{
+			// Setup can fail before setupEspressoStreamer constructs one.
+			name:     "without a streamer",
+			streamer: nil,
+		},
+		{
+			// A constructed-but-never-started streamer makes Stop a no-op.
+			name:     "with a constructed streamer",
+			streamer: &espressoStreamers.Streamer{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			l := &BatchSubmitter{}
+			l.Log = testlog.Logger(t, log.LevelDebug)
+			l.shutdownCtx, l.cancelShutdownCtx = context.WithCancel(context.Background())
+			l.killCtx, l.cancelKillCtx = context.WithCancel(context.Background())
+			l.running = true
+			l.espressoStreamer = test.streamer
+
+			l.rollbackFailedStart()
+
+			require.False(t, l.running, "a failed start must not wedge later start attempts")
+			require.ErrorIs(t, l.shutdownCtx.Err(), context.Canceled)
+			require.ErrorIs(t, l.killCtx.Err(), context.Canceled)
+		})
+	}
+}

--- a/op-batcher/batcher/espresso_driver_test.go
+++ b/op-batcher/batcher/espresso_driver_test.go
@@ -57,7 +57,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
 
-		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		anchor, err := l.waitForLocalSafeHead(t.Context(), time.Second, time.Millisecond)
 		require.NoError(t, err)
 		require.Equal(t, testCaffeinationL2, anchor.Number)
 	})
@@ -66,7 +66,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2+7), nil)
 
-		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		anchor, err := l.waitForLocalSafeHead(t.Context(), time.Second, time.Millisecond)
 		require.NoError(t, err)
 		require.Equal(t, testCaffeinationL2+7, anchor.Number)
 	})
@@ -75,7 +75,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		l, ep := newAnchorTestSubmitter(t, testCaffeinationL2)
 		ep.rollupClient.Mock.On("SyncStatus").Return(anchorStatus(testCaffeinationL2-1), nil)
 
-		_, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 50*time.Millisecond, 5*time.Millisecond)
+		_, err := l.waitForLocalSafeHead(t.Context(), 50*time.Millisecond, 5*time.Millisecond)
 		require.ErrorContains(t, err, "caffeination point (500)",
 			"the give-up error must name the height the operator is waiting on")
 		require.ErrorIs(t, err, context.DeadlineExceeded)
@@ -86,7 +86,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		ep.rollupClient.ExpectSyncStatus(nil, errors.New("transient RPC failure"))
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
 
-		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 5*time.Second, time.Millisecond)
+		anchor, err := l.waitForLocalSafeHead(t.Context(), 5*time.Second, time.Millisecond)
 		require.NoError(t, err)
 		require.Equal(t, testCaffeinationL2, anchor.Number)
 	})
@@ -96,7 +96,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(0), nil) // populated status, zero LocalSafeL2
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(testCaffeinationL2), nil)
 
-		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), 5*time.Second, time.Millisecond)
+		anchor, err := l.waitForLocalSafeHead(t.Context(), 5*time.Second, time.Millisecond)
 		require.NoError(t, err)
 		require.Equal(t, testCaffeinationL2, anchor.Number)
 	})
@@ -107,7 +107,7 @@ func TestWaitForLocalSafeHead(t *testing.T) {
 		l, ep := newAnchorTestSubmitter(t, 0)
 		ep.rollupClient.ExpectSyncStatus(anchorStatus(1), nil)
 
-		anchor, err := l.waitForLocalSafeHeadWithTiming(t.Context(), time.Second, time.Millisecond)
+		anchor, err := l.waitForLocalSafeHead(t.Context(), time.Second, time.Millisecond)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), anchor.Number)
 	})

--- a/op-batcher/batcher/espresso_verify_receipt_test.go
+++ b/op-batcher/batcher/espresso_verify_receipt_test.go
@@ -1,0 +1,185 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
+	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
+	espressoTypes "github.com/EspressoSystems/espresso-network/sdks/go/types"
+	espressoTypesCommon "github.com/EspressoSystems/espresso-network/sdks/go/types/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvaluateVerification locks the receipt-verification decision table, in
+// particular the two re-submission timeouts: the HotShot block-count timeout
+// (with its zero-startHeight guard for a tracker that has not produced a
+// height yet) and the wall-clock safety backstop for a stale or broken
+// tracker. A wrong verdict here either drops a batch (skipping a retryable
+// job) or re-submits forever.
+func TestEvaluateVerification(t *testing.T) {
+	const maxBlocks = 10
+	const safetyTimeout = time.Hour
+
+	ephemeralErr := fmt.Errorf("%w: receipt not found", espressoClient.ErrEphemeral)
+	permanentErr := fmt.Errorf("%w: malformed transaction", espressoClient.ErrPermanent)
+
+	tests := []struct {
+		name          string
+		err           error
+		startHeight   uint64
+		currentHeight uint64
+		startedAgo    time.Duration
+		want          JobEvaluation
+	}{
+		{
+			name: "success is handled",
+			want: Handle,
+		},
+		{
+			name: "permanent error is skipped",
+			err:  permanentErr,
+			// Both timeouts exceeded: a permanent error must win over retry.
+			startHeight:   100,
+			currentHeight: 100 + maxBlocks,
+			startedAgo:    2 * safetyTimeout,
+			want:          Skip,
+		},
+		{
+			name:          "ephemeral error within both budgets retries verification",
+			err:           ephemeralErr,
+			startHeight:   100,
+			currentHeight: 100 + maxBlocks - 1,
+			want:          RetryVerification,
+		},
+		{
+			name:          "exactly maxBlocks elapsed re-submits",
+			err:           ephemeralErr,
+			startHeight:   100,
+			currentHeight: 100 + maxBlocks,
+			want:          RetrySubmission,
+		},
+		{
+			name:          "far past maxBlocks re-submits",
+			err:           ephemeralErr,
+			startHeight:   100,
+			currentHeight: 100 + 100*maxBlocks,
+			want:          RetrySubmission,
+		},
+		{
+			// The tracker had not stored a height when the job started, so
+			// block counting is meaningless: the guard must fall through to
+			// verification retry, not treat height 0 as "maxBlocks passed".
+			name:          "zero startHeight never triggers the block-count timeout",
+			err:           ephemeralErr,
+			startHeight:   0,
+			currentHeight: 1 << 40,
+			want:          RetryVerification,
+		},
+		{
+			// Tracker stale or broken (currentHeight stuck at startHeight):
+			// the wall clock is the backstop.
+			name:          "wall-clock safety timeout re-submits",
+			err:           ephemeralErr,
+			startHeight:   100,
+			currentHeight: 100,
+			startedAgo:    safetyTimeout + time.Minute,
+			want:          RetrySubmission,
+		},
+		{
+			name:          "unclassified error is retried like an ephemeral one",
+			err:           errors.New("connection reset"),
+			startHeight:   100,
+			currentHeight: 100 + maxBlocks - 1,
+			want:          RetryVerification,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &espressoTransactionSubmitter{
+				verifyReceiptMaxBlocks:     maxBlocks,
+				verifyReceiptSafetyTimeout: safetyTimeout,
+			}
+			resp := espressoVerifyReceiptJobResponse{
+				job: espressoVerifyReceiptJob{
+					startHeight: test.startHeight,
+					startTime:   time.Now().Add(-test.startedAgo),
+				},
+				err:           test.err,
+				currentHeight: test.currentHeight,
+			}
+			require.Equal(t, test.want, s.evaluateVerification(resp))
+		})
+	}
+}
+
+// stuckReceiptEspressoClient accepts submissions and serves an advancing
+// HotShot block height, but never finds a submitted transaction: the shape of
+// an Espresso node that swallowed a transaction. The embedded nil interface
+// panics on any other method, proving no other client call is involved.
+type stuckReceiptEspressoClient struct {
+	espressoClient.EspressoClient
+	height      atomic.Uint64
+	heightStep  uint64
+	fetches     atomic.Int64
+	submissions atomic.Int64
+}
+
+func (c *stuckReceiptEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
+	c.fetches.Add(1)
+	return c.height.Add(c.heightStep), nil
+}
+
+func (c *stuckReceiptEspressoClient) SubmitTransaction(ctx context.Context, tx espressoTypesCommon.Transaction) (*espressoTypesCommon.TaggedBase64, error) {
+	c.submissions.Add(1)
+	return tagged_base64.New("TX", tx.Payload)
+}
+
+func (c *stuckReceiptEspressoClient) FetchTransactionByHash(ctx context.Context, hash *espressoTypes.TaggedBase64) (espressoTypes.TransactionQueryData, error) {
+	return espressoTypes.TransactionQueryData{}, fmt.Errorf("%w: transaction not yet in a block", espressoClient.ErrEphemeral)
+}
+
+// TestVerifyReceiptBlockCountTimeoutResubmits runs the whole submitter
+// pipeline against a client whose transactions never become queryable while
+// HotShot keeps producing blocks, and requires the transaction to be
+// re-submitted. This is the end-to-end path of the block-count timeout: the
+// tracker feeding latestBlockHeight, the worker snapshotting startHeight on
+// the first attempt, and evaluateVerification routing the job back to the
+// submission queue.
+func TestVerifyReceiptBlockCountTimeoutResubmits(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	client := &stuckReceiptEspressoClient{heightStep: 10}
+	client.height.Store(100)
+
+	submitter := NewEspressoTransactionSubmitter(
+		WithContext(ctx),
+		WithEspressoClient(client),
+		WithVerifyReceiptMaxBlocks(5),
+		// Keep the wall-clock backstop out of play so only the block-count
+		// path can trigger the re-submission this test requires.
+		WithVerifyReceiptSafetyTimeout(time.Hour),
+		WithVerifyReceiptRetryDelay(time.Millisecond),
+	)
+	submitter.SpawnWorkers(1, 1)
+	submitter.Start()
+
+	// Wait until the tracker has completed a fetch-and-store round (the
+	// second fetch proves the first store), so the verify job's startHeight
+	// snapshot is nonzero — a zero snapshot disables the block-count timeout
+	// by design.
+	require.Eventually(t, func() bool { return client.fetches.Load() >= 2 }, 10*time.Second, time.Millisecond,
+		"the block height tracker never polled the client")
+
+	txn := &espressoTypesCommon.Transaction{Namespace: 1, Payload: make([]byte, 8)}
+	require.NoError(t, submitter.SubmitTransaction(txn))
+
+	require.Eventually(t, func() bool { return client.submissions.Load() >= 2 }, 30*time.Second, time.Millisecond,
+		"the verification timeout never re-submitted the stuck transaction")
+}

--- a/op-batcher/batcher/espresso_verify_receipt_test.go
+++ b/op-batcher/batcher/espresso_verify_receipt_test.go
@@ -124,15 +124,15 @@ func TestEvaluateVerification(t *testing.T) {
 // panics on any other method, proving no other client call is involved.
 type stuckReceiptEspressoClient struct {
 	espressoClient.EspressoClient
-	height      atomic.Uint64
-	heightStep  uint64
 	fetches     atomic.Int64
 	submissions atomic.Int64
 }
 
+// FetchLatestBlockHeight advances HotShot by 10 blocks per poll from a base of
+// 100, so a single step already exceeds the 5-block verify budget the test
+// configures.
 func (c *stuckReceiptEspressoClient) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
-	c.fetches.Add(1)
-	return c.height.Add(c.heightStep), nil
+	return 100 + 10*uint64(c.fetches.Add(1)), nil
 }
 
 func (c *stuckReceiptEspressoClient) SubmitTransaction(ctx context.Context, tx espressoTypesCommon.Transaction) (*espressoTypesCommon.TaggedBase64, error) {
@@ -152,14 +152,10 @@ func (c *stuckReceiptEspressoClient) FetchTransactionByHash(ctx context.Context,
 // the first attempt, and evaluateVerification routing the job back to the
 // submission queue.
 func TestVerifyReceiptBlockCountTimeoutResubmits(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	client := &stuckReceiptEspressoClient{heightStep: 10}
-	client.height.Store(100)
+	client := &stuckReceiptEspressoClient{}
 
 	submitter := NewEspressoTransactionSubmitter(
-		WithContext(ctx),
+		WithContext(t.Context()),
 		WithEspressoClient(client),
 		WithVerifyReceiptMaxBlocks(5),
 		// Keep the wall-clock backstop out of play so only the block-count


### PR DESCRIPTION
Closes #496. Stacked on #459 (`espresso/batcher`), which is where all of the code under test lives.

## What is covered

**Active-batcher gate** (`espresso_active.go`, `shouldSkipPublishForActiveSeq`)
- Every quadrant of the `isBatcherActive` mode check (`activeIsEspresso` × `Espresso.Enabled`) — an inverted mode check compiles and passes CI, so each quadrant is pinned explicitly.
- The identity gate for both modes, including the `batcherHash` low-20-byte slicing (with a nonzero-high-bytes case so a future versioned batcherHash can't break address extraction).
- Every `shouldSkipPublishForActiveSeq` path: the fail-closed error paths, and proof that the pre-fork fallback batcher never consults the BatchAuthenticator (the mock rejects unregistered calls, and a consult would flip the result).
- The contract mock dispatches per (contract address, method), so the tests also prove `batcherHash` is read from the contract `systemConfig()` returned — not merely that the method was called somewhere.

**`nextBlockRange` reset/reorg/prune branches** (`espresso.go`)
- The safe-chain-reorg hash check — the sole defense against re-queueing orphaned blocks to Espresso — plus the caught-up, reversed-CurrentL1, derivation-ahead, safe-below-queue, gapped-queue, prune, and no-prune-boundary branches.

**`EnqueueBlocks` reorg detection + clearState CAS handshake** (`espresso.go`)
- A reorged block must drop the queued chain and *request* a clear via the handshake, never perform it inline on the queueing loop — that inline clear was the earlier data race, and the requested-not-performed assertions are its regression test. The handshake's perform-once/coalescing semantics are locked separately.
- The happy path runs end to end (fetch → parent-hash check → convert → sign → espresso job queue) using `derivetest` blocks and a fake `ChainSigner`, and the transient-fetch-failure path keeps the queue for the next tick.

**`evaluateVerification`** (`espresso.go`)
- The full decision table: permanent-skip, ephemeral-retry, the HotShot block-count timeout (including its boundary and the zero-`startHeight` guard for a tracker with no height yet), the wall-clock safety backstop, and unclassified errors treated as retryable.
- An end-to-end test with a client whose `FetchLatestBlockHeight` *works* — both existing mocks failed it, so `startHeight` stayed 0 and the re-submission path had never executed. The test drives a stuck transaction through the tracker, the worker's `startHeight` snapshot, and back onto the submission queue.

**`rollbackFailedStart` / `waitForLocalSafeHead`** (`espresso_driver.go`)
- `rollbackFailedStart` clears the running flag and cancels both contexts, with and without a constructed streamer.
- `waitForLocalSafeHead` covers the caffeination gate: anchoring at/past the point, retrying through transient sync-status failures and empty local-safe heads, the give-up error naming the height, and the zero-height (flag unset) semantics.

## Production change

One, minimal: `waitForLocalSafeHead` hardcoded its one-minute anchor timeout and one-second retry interval, so its retry/give-up paths were untestable as written (as noted in the issue). The timeout and retry interval are now parameters, passed as the same constants at the single production call site — behavior unchanged, and the tests exercise exactly the function production runs.

## Testing

- `go test ./op-batcher/... -count=1` — all green.
- New tests run under `-race` (repeated runs on the timing-sensitive ones for flake-checking).
- `gofmt` / `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217522740944201