### PR TITLE
op-batcher: use one BatchAuthenticator reader, bound and code-checked once at startup

### DIFF
--- a/op-batcher/batcher/batch_authenticator.go
+++ b/op-batcher/batcher/batch_authenticator.go
@@ -1,0 +1,154 @@
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-service/bindings/batchauthenticator"
+	"github.com/ethereum-optimism/optimism/op-service/bindings/systemconfig"
+)
+
+// batchAuthenticatorReader is the batcher's single read-only view of the
+// BatchAuthenticator contract, bound once at construction and shared by
+// registerBatcher, resolveTEEVerifierAddress and isBatcherActive.
+//
+// The SystemConfig binding comes from RollupConfig.L1SystemConfigAddress
+// rather than from BatchAuthenticator.systemConfig(), which the batcher would
+// otherwise re-read on every publish tick to reach the same address.
+//
+// The deployment probe is lazy and latching: it runs on each call until it
+// first observes code, then never again. Lazy so a batcher started before the
+// contract is deployed keeps skipping publishes per tick rather than failing
+// to start; latching keeps the probe off the steady-state publish path, which
+// leaves the gate at two eth_calls per tick in either mode.
+//
+// A zero BatchAuthenticator address is a nil reader, not a reader bound to the
+// zero address.
+type batchAuthenticatorReader struct {
+	addr         common.Address
+	auth         *batchauthenticator.BatchAuthenticatorCaller
+	systemConfig *systemconfig.SystemConfigCaller
+	backend      bind.ContractCaller
+	timeout      time.Duration
+
+	mu       sync.Mutex
+	haveCode bool
+}
+
+// newBatchAuthenticatorReader binds a reader to addr, resolving the fallback
+// batcher through the SystemConfig at systemConfigAddr.
+func newBatchAuthenticatorReader(addr, systemConfigAddr common.Address, backend bind.ContractCaller, timeout time.Duration) (*batchAuthenticatorReader, error) {
+	auth, err := batchauthenticator.NewBatchAuthenticatorCaller(addr, backend)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind BatchAuthenticator at %s: %w", addr, err)
+	}
+	systemConfig, err := systemconfig.NewSystemConfigCaller(systemConfigAddr, backend)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind SystemConfig at %s: %w", systemConfigAddr, err)
+	}
+	return &batchAuthenticatorReader{
+		addr:         addr,
+		auth:         auth,
+		systemConfig: systemConfig,
+		backend:      backend,
+		timeout:      timeout,
+	}, nil
+}
+
+// Address returns the BatchAuthenticator address this reader is bound to.
+func (r *batchAuthenticatorReader) Address() common.Address {
+	return r.addr
+}
+
+// ensureDeployed verifies that code exists at the bound address, skipping the
+// check once it has succeeded. Failures are not latched, so a transient RPC
+// error or a not-yet-deployed contract is retried on the next call.
+func (r *batchAuthenticatorReader) ensureDeployed(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.haveCode {
+		return nil
+	}
+	cCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	code, err := r.backend.CodeAt(cCtx, r.addr, nil)
+	if err != nil {
+		return fmt.Errorf("failed to check code at BatchAuthenticator address %s: %w", r.addr, err)
+	}
+	if len(code) == 0 {
+		return fmt.Errorf("no contract code at BatchAuthenticator address %s", r.addr)
+	}
+	r.haveCode = true
+	return nil
+}
+
+// callOpts bounds a single contract read by the network timeout. The caller
+// must invoke the returned cancel func.
+func (r *batchAuthenticatorReader) callOpts(ctx context.Context) (*bind.CallOpts, context.CancelFunc) {
+	cCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	return &bind.CallOpts{Context: cCtx}, cancel
+}
+
+// ActiveIsEspresso reports the contract's activeIsEspresso flag: true when the
+// Espresso (TEE) batcher is active, false when the fallback batcher is.
+func (r *batchAuthenticatorReader) ActiveIsEspresso(ctx context.Context) (bool, error) {
+	if err := r.ensureDeployed(ctx); err != nil {
+		return false, err
+	}
+	opts, cancel := r.callOpts(ctx)
+	defer cancel()
+	active, err := r.auth.ActiveIsEspresso(opts)
+	if err != nil {
+		return false, fmt.Errorf("failed to check activeIsEspresso: %w", err)
+	}
+	return active, nil
+}
+
+// EspressoBatcher returns the address authorized to authenticate batches while
+// activeIsEspresso is true.
+func (r *batchAuthenticatorReader) EspressoBatcher(ctx context.Context) (common.Address, error) {
+	if err := r.ensureDeployed(ctx); err != nil {
+		return common.Address{}, err
+	}
+	opts, cancel := r.callOpts(ctx)
+	defer cancel()
+	addr, err := r.auth.EspressoBatcher(opts)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to read espressoBatcher: %w", err)
+	}
+	return addr, nil
+}
+
+// FallbackBatcher returns the address authorized to authenticate batches while
+// activeIsEspresso is false, read from the SystemConfig's batcherHash.
+func (r *batchAuthenticatorReader) FallbackBatcher(ctx context.Context) (common.Address, error) {
+	opts, cancel := r.callOpts(ctx)
+	defer cancel()
+	batcherHash, err := r.systemConfig.BatcherHash(opts)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to read batcherHash: %w", err)
+	}
+	// batcherHash stores the batcher address in its low 20 bytes,
+	// which is why we use bytes to address
+	return common.BytesToAddress(batcherHash[:]), nil
+}
+
+// EspressoTEEVerifier returns the contract's configured EspressoTEEVerifier
+// address. Read once at startup.
+func (r *batchAuthenticatorReader) EspressoTEEVerifier(ctx context.Context) (common.Address, error) {
+	if err := r.ensureDeployed(ctx); err != nil {
+		return common.Address{}, err
+	}
+	opts, cancel := r.callOpts(ctx)
+	defer cancel()
+	addr, err := r.auth.EspressoTEEVerifier(opts)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to query EspressoTEEVerifier address: %w", err)
+	}
+	return addr, nil
+}

--- a/op-batcher/batcher/batch_authenticator_test.go
+++ b/op-batcher/batcher/batch_authenticator_test.go
@@ -1,0 +1,242 @@
+package batcher
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/bindings/batchauthenticator"
+	"github.com/ethereum-optimism/optimism/op-service/bindings/systemconfig"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+var (
+	testAuthAddr         = common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	testSystemConfigAddr = common.HexToAddress("0x00000000000000000000000000000000000000cc")
+)
+
+// mockAuthBackend is a minimal bind.ContractCaller standing in for the L1
+// client, serving both the BatchAuthenticator and the SystemConfig.
+type mockAuthBackend struct {
+	authABI         *abi.ABI
+	systemConfigABI *abi.ABI
+
+	// code is returned by CodeAt. Empty means "not deployed yet".
+	code []byte
+	// codeErr, when set, fails CodeAt instead of returning code.
+	codeErr error
+
+	activeIsEspresso bool
+	espressoBatcher  common.Address
+	fallbackBatcher  common.Address
+	teeVerifier      common.Address
+
+	codeAtCalls int
+	callCalls   int
+	// lastCallHadDeadline records whether the context reaching CallContract
+	// carried a deadline, i.e. whether the reader applied NetworkTimeout.
+	lastCallHadDeadline bool
+}
+
+func newMockAuthBackend(t *testing.T) *mockAuthBackend {
+	t.Helper()
+	authABI, err := batchauthenticator.BatchAuthenticatorMetaData.GetAbi()
+	require.NoError(t, err)
+	systemConfigABI, err := systemconfig.SystemConfigMetaData.GetAbi()
+	require.NoError(t, err)
+	return &mockAuthBackend{
+		authABI:         authABI,
+		systemConfigABI: systemConfigABI,
+		code:            []byte{0x60, 0x00},
+	}
+}
+
+func (m *mockAuthBackend) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	m.codeAtCalls++
+	if m.codeErr != nil {
+		return nil, m.codeErr
+	}
+	return m.code, nil
+}
+
+func (m *mockAuthBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	m.callCalls++
+	_, m.lastCallHadDeadline = ctx.Deadline()
+	if len(call.Data) < 4 {
+		return nil, errors.New("short calldata")
+	}
+	selector := string(call.Data[:4])
+	switch {
+	case selector == string(m.authABI.Methods["activeIsEspresso"].ID):
+		return m.authABI.Methods["activeIsEspresso"].Outputs.Pack(m.activeIsEspresso)
+	case selector == string(m.authABI.Methods["espressoBatcher"].ID):
+		return m.authABI.Methods["espressoBatcher"].Outputs.Pack(m.espressoBatcher)
+	case selector == string(m.authABI.Methods["espressoTEEVerifier"].ID):
+		return m.authABI.Methods["espressoTEEVerifier"].Outputs.Pack(m.teeVerifier)
+	case selector == string(m.systemConfigABI.Methods["batcherHash"].ID):
+		var batcherHash [32]byte
+		copy(batcherHash[12:], m.fallbackBatcher.Bytes())
+		return m.systemConfigABI.Methods["batcherHash"].Outputs.Pack(batcherHash)
+	default:
+		return nil, errors.New("unexpected method call")
+	}
+}
+
+func newTestReader(t *testing.T, backend *mockAuthBackend) *batchAuthenticatorReader {
+	t.Helper()
+	r, err := newBatchAuthenticatorReader(testAuthAddr, testSystemConfigAddr, backend, time.Second)
+	require.NoError(t, err)
+	return r
+}
+
+// TestBatchAuthenticatorReader_ProbeLatches is the core claim of the shared
+// reader: the deployment probe is paid once, not once per publish tick. It also
+// checks that the reader applies the network timeout itself, so no call site
+// can forget it.
+func TestBatchAuthenticatorReader_ProbeLatches(t *testing.T) {
+	backend := newMockAuthBackend(t)
+	backend.activeIsEspresso = true
+	r := newTestReader(t, backend)
+
+	for i := 0; i < 5; i++ {
+		active, err := r.ActiveIsEspresso(context.Background())
+		require.NoError(t, err)
+		require.True(t, active)
+	}
+
+	require.Equal(t, 1, backend.codeAtCalls, "deployment probe should be paid once, not per read")
+	require.Equal(t, 5, backend.callCalls, "each read is still one eth_call")
+	require.True(t, backend.lastCallHadDeadline, "reader must bound reads by NetworkTimeout")
+}
+
+// TestBatchAuthenticatorReader_ProbeFailureIsNotLatched covers the reason the
+// probe stays lazy: a batcher may legitimately start before the
+// BatchAuthenticator is deployed. Such a batcher must keep retrying and recover
+// once the contract appears, rather than caching the failure for the life of
+// the process.
+func TestBatchAuthenticatorReader_ProbeFailureIsNotLatched(t *testing.T) {
+	backend := newMockAuthBackend(t)
+	backend.code = nil // not deployed yet
+	r := newTestReader(t, backend)
+
+	_, err := r.ActiveIsEspresso(context.Background())
+	require.ErrorContains(t, err, "no contract code at BatchAuthenticator address")
+	require.Zero(t, backend.callCalls, "should not read from an undeployed address")
+
+	backend.codeErr = errors.New("rpc boom")
+	_, err = r.ActiveIsEspresso(context.Background())
+	require.ErrorContains(t, err, "rpc boom")
+
+	// Contract shows up; the reader recovers without needing a restart.
+	backend.codeErr = nil
+	backend.code = []byte{0x60, 0x00}
+	backend.activeIsEspresso = true
+	active, err := r.ActiveIsEspresso(context.Background())
+	require.NoError(t, err)
+	require.True(t, active)
+
+	require.Equal(t, 3, backend.codeAtCalls)
+	require.Equal(t, 1, backend.callCalls)
+}
+
+// TestBatchAuthenticatorReader_EspressoTEEVerifier covers what the reader adds
+// over the generated binding: it refuses to read from an undeployed address,
+// and it bounds the call with NetworkTimeout. The resolved address feeds the
+// EIP-712 VerifyingContract domain field, so a silently zeroed result would
+// sign against the wrong verifier.
+func TestBatchAuthenticatorReader_EspressoTEEVerifier(t *testing.T) {
+	backend := newMockAuthBackend(t)
+	backend.teeVerifier = common.HexToAddress("0x00000000000000000000000000000000000000bb")
+	backend.code = nil // not deployed yet
+	r := newTestReader(t, backend)
+
+	_, err := r.EspressoTEEVerifier(context.Background())
+	require.ErrorContains(t, err, "no contract code at BatchAuthenticator address")
+	require.Zero(t, backend.callCalls, "should not read from an undeployed address")
+
+	backend.code = []byte{0x60, 0x00}
+	got, err := r.EspressoTEEVerifier(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, backend.teeVerifier, got)
+	require.True(t, backend.lastCallHadDeadline, "reader must bound reads by NetworkTimeout")
+}
+
+// TestBatchAuthenticatorReader_FallbackBatcher locks in that the fallback
+// batcher address comes from the SystemConfig bound at construction, rather
+// than from a per-tick BatchAuthenticator.systemConfig() lookup. Reaching for
+// the latter would surface here as an "unexpected method call".
+func TestBatchAuthenticatorReader_FallbackBatcher(t *testing.T) {
+	backend := newMockAuthBackend(t)
+	backend.fallbackBatcher = common.HexToAddress("0x00000000000000000000000000000000000000dd")
+	r := newTestReader(t, backend)
+
+	got, err := r.FallbackBatcher(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, backend.fallbackBatcher, got)
+	require.Equal(t, 1, backend.callCalls, "fallback batcher should cost a single batcherHash read")
+}
+
+// TestIsBatcherActive covers the publish gate's two checks - mode, then
+// identity - and pins the per-tick cost at two eth_calls in either mode.
+func TestIsBatcherActive(t *testing.T) {
+	espressoAddr := common.HexToAddress("0x00000000000000000000000000000000000000e1")
+	fallbackAddr := common.HexToAddress("0x00000000000000000000000000000000000000e2")
+	otherAddr := common.HexToAddress("0x00000000000000000000000000000000000000e3")
+
+	tests := []struct {
+		name             string
+		activeIsEspresso bool
+		espressoEnabled  bool
+		from             common.Address
+		want             bool
+		wantCalls        int
+	}{
+		{"espresso batcher, espresso active, authorized", true, true, espressoAddr, true, 2},
+		{"fallback batcher, fallback active, authorized", false, false, fallbackAddr, true, 2},
+		{"espresso batcher, espresso active, wrong key", true, true, otherAddr, false, 2},
+		{"fallback batcher, fallback active, wrong key", false, false, otherAddr, false, 2},
+		// Mode mismatch short-circuits before the identity read.
+		{"espresso batcher while fallback active", false, true, espressoAddr, false, 1},
+		{"fallback batcher while espresso active", true, false, fallbackAddr, false, 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backend := newMockAuthBackend(t)
+			backend.activeIsEspresso = test.activeIsEspresso
+			backend.espressoBatcher = espressoAddr
+			backend.fallbackBatcher = fallbackAddr
+
+			l := &BatchSubmitter{}
+			l.Log = testlog.Logger(t, log.LevelDebug)
+			l.Txmgr = &testutils.FakeTxMgr{FromAddr: test.from}
+			l.Config.Espresso.Enabled = test.espressoEnabled
+			l.batchAuth = newTestReader(t, backend)
+
+			got, err := l.isBatcherActive(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+			require.Equal(t, test.wantCalls, backend.callCalls)
+		})
+	}
+}
+
+// TestIsBatcherActive_NoAuthenticator guards the nil reader case: without a
+// configured BatchAuthenticator the gate must report an error rather than
+// silently treating this batcher as active.
+func TestIsBatcherActive_NoAuthenticator(t *testing.T) {
+	l := &BatchSubmitter{}
+	l.Log = testlog.Logger(t, log.LevelDebug)
+
+	_, err := l.isBatcherActive(context.Background())
+	require.ErrorContains(t, err, "no BatchAuthenticator configured")
+}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -164,6 +164,12 @@ type BatchSubmitter struct {
 
 	teeVerifierAddress common.Address
 
+	// batchAuth is the read-only binding to the BatchAuthenticator contract,
+	// shared by registerBatcher, resolveTEEVerifierAddress and the
+	// isBatcherActive gate. Nil when RollupConfig has a zero
+	// BatchAuthenticatorAddress.
+	batchAuth *batchAuthenticatorReader
+
 	// degradedLog throttles repeated warnings from tick-driven loops so the
 	// log debouncer doesn't see the same message every poll interval.
 	degradedLog *oplog.RepeatStateLogger
@@ -185,6 +191,17 @@ func NewBatchSubmitter(setup DriverSetup) *BatchSubmitter {
 	err := batcher.SetThrottleController(setup.Config.ThrottleParams.ControllerType, setup.Config.ThrottleParams.PIDConfig)
 	if err != nil {
 		panic(err)
+	}
+
+	// Bind the BatchAuthenticator reader once, here, rather than per call site.
+	// This does no network I/O - only ABI parsing, which can fail solely on a
+	// malformed generated binding, so a failure here is a build-time defect.
+	if addr := setup.RollupConfig.BatchAuthenticatorAddress; addr != (common.Address{}) {
+		reader, err := newBatchAuthenticatorReader(addr, setup.RollupConfig.L1SystemConfigAddress, setup.L1Client, setup.Config.NetworkTimeout)
+		if err != nil {
+			panic(err)
+		}
+		batcher.batchAuth = reader
 	}
 
 	return batcher

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -19,8 +19,6 @@ import (
 	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
 	espressoCommon "github.com/EspressoSystems/espresso-network/sdks/go/types"
 	"github.com/EspressoSystems/espresso-streamers/op/derivation"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1231,19 +1229,13 @@ func (l *BatchSubmitter) fetchBlock(ctx context.Context, blockNumber uint64) (*t
 // resolveTEEVerifierAddress queries the BatchAuthenticator contract to get the
 // EspressoTEEVerifier address.
 func (l *BatchSubmitter) resolveTEEVerifierAddress(ctx context.Context) error {
-	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
+	if l.batchAuth == nil {
 		// If batcher authenticator address is nil, we will keep teeVerifierAddress to nil as well
 		return nil
 	}
-	auth, err := batchauthenticator.NewBatchAuthenticatorCaller(l.RollupConfig.BatchAuthenticatorAddress, l.L1Client)
+	addr, err := l.batchAuth.EspressoTEEVerifier(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create BatchAuthenticator caller: %w", err)
-	}
-	callCtx, cancel := l.networkTimeoutCtx(ctx)
-	defer cancel()
-	addr, err := auth.EspressoTEEVerifier(&bind.CallOpts{Context: callCtx})
-	if err != nil {
-		return fmt.Errorf("failed to query EspressoTEEVerifier address: %w", err)
+		return err
 	}
 	l.teeVerifierAddress = addr
 	l.Log.Info("Resolved TEE verifier address", "address", addr.Hex())
@@ -1261,15 +1253,12 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 		return nil
 	}
 
-	l.Log.Info("Batch authenticator address", "value", l.RollupConfig.BatchAuthenticatorAddress)
-	codeCtx, cancel := l.networkTimeoutCtx(ctx)
-	code, err := l.L1Client.CodeAt(codeCtx, l.RollupConfig.BatchAuthenticatorAddress, nil)
-	cancel()
-	if err != nil {
-		return fmt.Errorf("failed to check code at contract address: %w", err)
+	if l.batchAuth == nil {
+		return errors.New("cannot register batcher: no BatchAuthenticator address configured")
 	}
-	if len(code) == 0 {
-		return fmt.Errorf("no contract deployed at this address %w", err)
+	l.Log.Info("Batch authenticator address", "value", l.batchAuth.Address())
+	if err := l.batchAuth.ensureDeployed(ctx); err != nil {
+		return err
 	}
 
 	abi, err := batchauthenticator.BatchAuthenticatorMetaData.GetAbi()

--- a/op-batcher/batcher/espresso_active.go
+++ b/op-batcher/batcher/espresso_active.go
@@ -2,13 +2,9 @@ package batcher
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/ethereum-optimism/optimism/op-service/bindings/batchauthenticator"
-	"github.com/ethereum-optimism/optimism/op-service/bindings/systemconfig"
 )
 
 // isBatcherActive checks if the current batcher is the active one by querying
@@ -22,38 +18,21 @@ import (
 //  2. Identity: once the mode matches, the configured sender key (Txmgr.From) must
 //     be the authorized batcher for that mode, otherwise every authenticateBatchInfo
 //     call reverts (Unauthorized{Espresso,Fallback}Batcher) and the batcher loops.
+//
+// This runs on every publish tick and costs two eth_calls in either mode.
 func (l *BatchSubmitter) isBatcherActive(ctx context.Context) (bool, error) {
-	// Check if contract code exists at the address
-	codeCtx, codeCancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
-	defer codeCancel()
-	code, err := l.L1Client.CodeAt(codeCtx, l.RollupConfig.BatchAuthenticatorAddress, nil)
-	if err != nil {
-		return false, fmt.Errorf("failed to check code at BatchAuthenticator address: %w", err)
-	}
-	if len(code) == 0 {
-		return false, fmt.Errorf("no contract code at BatchAuthenticator address %s", l.RollupConfig.BatchAuthenticatorAddress.Hex())
+	if l.batchAuth == nil {
+		return false, errors.New("no BatchAuthenticator configured")
 	}
 
-	batchAuthenticator, err := batchauthenticator.NewBatchAuthenticator(l.RollupConfig.BatchAuthenticatorAddress, l.L1Client)
+	activeIsEspresso, err := l.batchAuth.ActiveIsEspresso(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to create BatchAuthenticator binding: %w", err)
-	}
-
-	cCtx, cancel := context.WithTimeout(ctx, l.Config.NetworkTimeout)
-	defer cancel()
-
-	callOpts := &bind.CallOpts{Context: cCtx}
-
-	activeIsEspresso, err := batchAuthenticator.ActiveIsEspresso(callOpts)
-	if err != nil {
-		return false, fmt.Errorf("failed to check activeIsEspresso: %w", err)
+		return false, err
 	}
 
 	batcherAddr := l.Txmgr.From()
 
-	modeActive := (activeIsEspresso && l.Config.Espresso.Enabled) ||
-		(!activeIsEspresso && !l.Config.Espresso.Enabled)
-	if !modeActive {
+	if activeIsEspresso != l.Config.Espresso.Enabled {
 		l.Log.Warn("Batcher is not the active batcher, skipping publish",
 			"batcherAddr", batcherAddr,
 			"activeIsEspresso", activeIsEspresso,
@@ -66,15 +45,12 @@ func (l *BatchSubmitter) isBatcherActive(ctx context.Context) (bool, error) {
 	// otherwise every publish reverts (Unauthorized*Batcher) in a loop.
 	var expected common.Address
 	if activeIsEspresso {
-		expected, err = batchAuthenticator.EspressoBatcher(callOpts)
-		if err != nil {
-			return false, fmt.Errorf("failed to read espressoBatcher: %w", err)
-		}
+		expected, err = l.batchAuth.EspressoBatcher(ctx)
 	} else {
-		expected, err = l.fallbackBatcherAddr(batchAuthenticator, callOpts)
-		if err != nil {
-			return false, err
-		}
+		expected, err = l.batchAuth.FallbackBatcher(ctx)
+	}
+	if err != nil {
+		return false, err
 	}
 
 	if batcherAddr != expected {
@@ -87,23 +63,4 @@ func (l *BatchSubmitter) isBatcherActive(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
-}
-
-// fallbackBatcherAddr returns the address the BatchAuthenticator's fallback batcher
-func (l *BatchSubmitter) fallbackBatcherAddr(batchAuthenticator *batchauthenticator.BatchAuthenticator, opts *bind.CallOpts) (common.Address, error) {
-	systemConfigAddr, err := batchAuthenticator.SystemConfig(opts)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to read systemConfig address: %w", err)
-	}
-	systemConfig, err := systemconfig.NewSystemConfigCaller(systemConfigAddr, l.L1Client)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to create SystemConfig binding: %w", err)
-	}
-	batcherHash, err := systemConfig.BatcherHash(opts)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to read batcherHash: %w", err)
-	}
-	// batcherHash stores the batcher address in its low 20 bytes,
-	// which is why we use bytes to address
-	return common.BytesToAddress(batcherHash[:]), nil
 }

--- a/op-batcher/batcher/espresso_driver.go
+++ b/op-batcher/batcher/espresso_driver.go
@@ -294,7 +294,7 @@ func (l *BatchSubmitter) startEspressoLoops(receiptsCh chan txmgr.TxReceipt[txRe
 // Fails closed: if either gate cannot be evaluated, publishing is skipped for
 // this tick and retried on the next.
 func (l *BatchSubmitter) shouldSkipPublishForActiveSeq(ctx context.Context) bool {
-	if l.RollupConfig.BatchAuthenticatorAddress == (common.Address{}) {
+	if l.batchAuth == nil {
 		return false
 	}
 	consultActiveFlag := l.Config.Espresso.Enabled


### PR DESCRIPTION
Closes https://github.com/celo-org/optimism/issues/503.

This PR:
* Follows up on https://github.com/celo-org/optimism/pull/459#issuecomment-5291539823 to add batchAuthenticatorReader and tests.

Key places to review:
* op-batcher/batcher/batch_authenticator.go
* op-batcher/batcher/batch_authenticator_test.go

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217525743187730