### PR TITLE
Add enclave tools / docker building for TEE image to celo repository

### DIFF
--- a/.github/workflows/espresso-enclave-images.yaml
+++ b/.github/workflows/espresso-enclave-images.yaml
@@ -1,0 +1,71 @@
+# Builds and publishes the two images that EspressoSystems/tee-image-builder's
+# nitro-op-poster workflow consumes to produce the TEE batch poster:
+#
+#   ghcr.io/celo-org/optimism/op-batcher-enclave-app  — wrapped into the Nitro EIF
+#   ghcr.io/celo-org/optimism/op-batcher-tee          — enclave-tools is extracted from it
+
+name: Build and Push Espresso Enclave Images
+
+on:
+  push:
+    branches:
+      - "espresso/**"
+  pull_request:
+    branches:
+      - "espresso/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/celo-org/optimism
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: op-batcher-enclave-app
+            target: op-batcher-enclave-app
+          - image: op-batcher-tee
+            target: op-batcher-enclave-target
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ops/docker/op-stack-go/Dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}

--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 

--- a/op-batcher/enclave-entrypoint.bash
+++ b/op-batcher/enclave-entrypoint.bash
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# Entrypoint for op-batcher running in enclaver image.
+
+set -e
+
+echo "=== Enclave Environment Debug Info ==="
+echo "PATH: $PATH"
+echo "Working directory: $(pwd)"
+echo "Proxy: ${http_proxy:-not set}"
+echo "======================================"
+
+# Re-populate the arguments passed through the environment
+if [ -n "$ENCLAVE_BATCHER_ARGS" ]; then
+  eval set -- "$ENCLAVE_BATCHER_ARGS"
+fi
+
+# Store the original arguments from ENCLAVE_BATCHER_ARGS
+original_args=("$@")
+
+# ---------------------------------------------------------------------------
+# Start nc listener in background IMMEDIATELY — before Odyn setup.
+#
+# ---------------------------------------------------------------------------
+NC_PORT=8337
+READY_PORT=8338
+received_args=()
+NC_TMPFILE=$(mktemp)
+echo "nc listener starting on port $NC_PORT (background, 60 second timeout)"
+nc -l -p "$NC_PORT" -w 60 > "$NC_TMPFILE" &
+NC_BG_PID=$!
+# Ensure nc process and tempfile are cleaned up on any exit path.
+trap 'kill "$NC_BG_PID" 2>/dev/null; rm -f "$NC_TMPFILE"' EXIT
+if ! kill -0 "$NC_BG_PID" 2>/dev/null; then
+    echo "[ERROR] nc listener failed to start on port $NC_PORT" >&2
+    exit 1
+fi
+echo "nc listener running (PID $NC_BG_PID)"
+
+# Verify Odyn proxy is available
+if [ -z "$http_proxy" ]; then
+    echo "[ERROR] http_proxy not set" >&2
+    exit 1
+fi
+
+if ! ODYN_PROXY_PORT=$(trurl --url "$http_proxy" --get "{port}"); then
+    echo "[ERROR] Failed to parse http_proxy" >&2
+    exit 1
+fi
+
+echo "[DEBUG] Testing Odyn proxy on port $ODYN_PROXY_PORT..." >&2
+if nc -z 127.0.0.1 $ODYN_PROXY_PORT 2>/dev/null; then
+  echo "✓ Odyn proxy functional on port $ODYN_PROXY_PORT"
+else
+  echo "[ERROR] Odyn proxy unreachable on port $ODYN_PROXY_PORT" >&2
+  exit 1
+fi
+
+# Preserve proxy environment variables for Go's HTTP client
+export HTTPS_PROXY="$http_proxy"
+export HTTP_PROXY="$http_proxy"
+export https_proxy="$http_proxy"
+export NO_PROXY="localhost,127.0.0.1,::1,host"
+export no_proxy="$NO_PROXY"
+
+echo "[DEBUG] Proxy environment configured:"
+echo "  HTTPS_PROXY=$HTTPS_PROXY"
+echo "  NO_PROXY=$NO_PROXY"
+echo "[DEBUG] External URLs will use proxy with correct SNI/Host headers"
+echo ""
+
+# Send "READY" on port $READY_PORT (background).
+echo "Signaling readiness on port $READY_PORT (background)..."
+echo "READY" | nc -l -p "$READY_PORT" -w 30 &
+
+# Helper function to check if URL needs socat proxying
+needs_socat_proxy() {
+    local url="$1"
+    local host
+    host="$(trurl --url "$url" --get "{host}" 2>/dev/null)" || return 1
+
+    if [[ "$host" == "localhost" ]] || [[ "$host" == "127.0.0.1" ]] || [[ "$host" == "::1" ]] || [[ "$host" == "host" ]]; then
+        return 0  # needs socat
+    fi
+    return 1  # is external, use HTTPS_PROXY
+}
+
+# Helper function to wait for socat to open a port
+wait_for_port() {
+    local port="$1"
+
+    for ((i=0; i<100; i++)); do
+        if nc -z 127.0.0.1 "$port" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.3
+    done
+
+    echo "[ERROR] socat did not open port $port in time" >&2
+    return 1
+}
+
+# Helper function to launch socat proxy for internal URLs
+launch_socat() {
+    local original_url="$1"
+    local socat_port="$2"
+
+    local host port scheme path
+    if ! read -r host port scheme path < <(trurl --url "$original_url" --default-port --get "{host} {port} {scheme} {path}"); then
+        echo "[ERROR] Failed to parse URL: $original_url" >&2
+        return 1
+    fi
+
+    # Map localhost to "host" for enclave's parent
+    if [[ "$host" == "localhost" ]] || [[ "$host" == "127.0.0.1" ]] || [[ "$host" == "::1" ]]; then
+        echo "[DEBUG] Rewriting '$host' to 'host'" >&2
+        host="host"
+    fi
+
+    if [[ "$scheme" != "http" ]] && [[ "$scheme" != "https" ]]; then
+        echo "[ERROR] Invalid scheme: '$scheme'. Only http and https are supported." >&2
+        return 1
+    fi
+
+    # Start socat to proxy through Odyn to "host"
+    echo "[DEBUG] Starting socat: 127.0.0.1:${socat_port} -> PROXY:${host}:${port} via Odyn:${ODYN_PROXY_PORT}" >&2
+    socat -t 10 -d TCP4-LISTEN:"${socat_port}",reuseaddr,fork PROXY:127.0.0.1:"$host":"$port",proxyport="${ODYN_PROXY_PORT}" > /dev/null 2>&1 &
+    socat_pid=$!
+    disown "$socat_pid"
+
+    wait_for_port "${socat_port}" || {
+        kill "$socat_pid" 2>/dev/null
+        wait "$socat_pid" 2>/dev/null
+        return 1
+    }
+
+    # Return socat-proxied URL (strip trailing slash to avoid double-slash in paths)
+    local new_url
+    new_url="$(trurl --url "$original_url" --set host="127.0.0.1" --set port="$socat_port")"
+    # Remove trailing slash if present
+    new_url="${new_url%/}"
+    echo "$new_url"
+
+    return 0
+}
+
+# Wait for background nc to finish
+echo "Waiting for batcher arguments (nc PID $NC_BG_PID)..."
+wait "$NC_BG_PID" 2>/dev/null || true
+
+if [ -s "$NC_TMPFILE" ]; then
+    while IFS= read -r -d '' arg; do
+        if [[ -z "$arg" ]]; then
+            break
+        fi
+        received_args+=("$arg")
+    done < "$NC_TMPFILE"
+fi
+rm -f "$NC_TMPFILE"
+
+if [ ${#received_args[@]} -eq 0 ]; then
+    echo "Warning: No arguments received via nc listener within 60 seconds, using original arguments"
+    set -- "${original_args[@]}"
+else
+    echo "Received ${#received_args[@]} arguments via nc, merging with original arguments"
+    set -- "${original_args[@]}" "${received_args[@]}"
+fi
+
+# Batcher flags whose values are URLs
+URL_ARG_RE='^(--altda\.da-server|--espresso\.espresso-attestation-service|--espresso\.urls|--espresso\.l1-url|--l1-eth-rpc|--l2-eth-rpc|--rollup-rpc|--signer\.endpoint)(=|$)'
+# Process all arguments
+filtered_args=()
+url_args=()
+SOCAT_PORT=10001
+
+echo "Processing arguments..."
+while [ $# -gt 0 ]; do
+    # Check if the argument matches the URL pattern
+    if [[ $1 =~ $URL_ARG_RE ]]; then
+        flag=${BASH_REMATCH[1]}
+
+        # Extract value from "--flag=value" or "--flag value"
+        if [[ "$1" == *=* ]]; then
+            value="${1#*=}"
+        else
+            shift || { echo "$flag missing value"; exit 1; }
+            value="$1"
+        fi
+
+        # Handle comma-separated values for any flag
+        if [[ "$value" == *","* ]]; then
+            IFS=',' read -r -a parts <<< "$value"
+            rewritten_parts=()
+            for part in "${parts[@]}"; do
+                if needs_socat_proxy "$part"; then
+                    if ! new_url=$(launch_socat "$part" "$SOCAT_PORT"); then
+                        echo "[ERROR] Failed to launch socat for $flag=$part" >&2
+                        exit 1
+                    fi
+                    echo "[DEBUG] Proxying internal URL via socat: $part -> $new_url" >&2
+                    rewritten_parts+=("$new_url")
+                    SOCAT_PORT=$((SOCAT_PORT + 1))
+                else
+                    echo "[DEBUG] Keeping external URL unchanged (will use HTTPS_PROXY): $part" >&2
+                    rewritten_parts+=("$part")
+                fi
+            done
+            # Join with commas
+            joined=$(IFS=,; echo "${rewritten_parts[*]}")
+            url_args+=("${flag}=${joined}")
+        else
+            if needs_socat_proxy "$value"; then
+                if ! new_url=$(launch_socat "$value" "$SOCAT_PORT"); then
+                    echo "[ERROR] Failed to launch socat for $flag=$value" >&2
+                    exit 1
+                fi
+                echo "[DEBUG] Proxying internal URL via socat: $value -> $new_url" >&2
+                url_args+=("$flag" "$new_url")
+                SOCAT_PORT=$((SOCAT_PORT + 1))
+            else
+                echo "[DEBUG] Keeping external URL unchanged (will use HTTPS_PROXY): $value" >&2
+                url_args+=("$flag" "$value")
+            fi
+        fi
+    else
+        filtered_args+=("$1")
+    fi
+    shift
+done
+
+# Combine all arguments
+all_args=("${filtered_args[@]}" "${url_args[@]}")
+
+echo ""
+echo "=== Final op-batcher arguments ==="
+echo "Total arguments: ${#all_args[@]}"
+next_is_secret=false
+for i in "${!all_args[@]}"; do
+    arg="${all_args[$i]}"
+    if $next_is_secret; then
+        echo "  [$i]: [REDACTED]" >&2
+        next_is_secret=false
+    elif [[ "$arg" =~ ^--(private-key|mnemonic)= ]]; then
+        flag="${arg%%=*}"
+        echo "  [$i]: ${flag}=[REDACTED]" >&2
+    elif [[ "$arg" == "--private-key" || "$arg" == "--mnemonic" ]]; then
+        echo "  [$i]: $arg" >&2
+        next_is_secret=true
+    else
+        echo "  [$i]: $arg" >&2
+    fi
+done
+echo "===================================" >&2
+echo ""
+
+echo "[DEBUG] Launching op-batcher..." >&2
+exec op-batcher "${all_args[@]}"

--- a/op-batcher/enclave-tools/cmd/main.go
+++ b/op-batcher/enclave-tools/cmd/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	enclave_tools "github.com/ethereum-optimism/optimism/op-batcher/enclave-tools"
+)
+
+func main() {
+	app := &cli.App{
+		Name:        "enclave-tools",
+		Usage:       "Build enclave EIF images",
+		Description: "Builds AWS Nitro EIF (Enclave Image Format) images for the Optimism op-batcher.",
+		Version:     "1.0.0",
+		Commands: []*cli.Command{
+			buildEifCommand(),
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildEifCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "build-eif",
+		Usage: "Build EIF image from a pre-built app Docker image",
+		Description: `Build an EIF (Enclave Image Format) image by wrapping a pre-built
+op-batcher-enclave-app Docker image with Enclaver. Prints PCR measurements
+to stdout in KEY=VALUE format (PCR0, PCR1, PCR2) for CI capture.
+
+Example:
+  enclave-tools build-eif \
+    --app-image ghcr.io/celo-org/optimism/op-batcher-enclave-app:TAG \
+    --eif-tag op-batcher-eif:TAG`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "app-image",
+				Usage:    "Pre-built app Docker image to wrap (e.g. ghcr.io/org/op-batcher-enclave-app:tag)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "eif-tag",
+				Usage: "Docker tag for the resulting EIF image",
+				Value: "op-batcher-eif:latest",
+			},
+			&cli.UintFlag{
+				Name:  "cpu-count",
+				Usage: "Number of vCPUs to allocate to the enclave (affects PCR0)",
+				Value: 2,
+			},
+			&cli.UintFlag{
+				Name:  "memory-mb",
+				Usage: "Memory in MiB to allocate to the enclave (affects PCR0)",
+				Value: 4096,
+			},
+		},
+		Action: buildEifAction,
+	}
+}
+
+func buildEifAction(c *cli.Context) error {
+	appImage := c.String("app-image")
+	eifTag := c.String("eif-tag")
+	cpuCount := c.Uint("cpu-count")
+	memoryMb := c.Uint("memory-mb")
+
+	ctx := context.Background()
+	slog.Info("Building EIF from pre-built app image...", "app-image", appImage, "eif-tag", eifTag, "cpu-count", cpuCount, "memory-mb", memoryMb)
+
+	measurements, err := enclave_tools.BuildEifFromImage(ctx, appImage, eifTag, cpuCount, memoryMb)
+	if err != nil {
+		return fmt.Errorf("failed to build EIF: %w", err)
+	}
+
+	slog.Info("EIF build completed",
+		"PCR0", measurements.PCR0,
+		"PCR1", measurements.PCR1,
+		"PCR2", measurements.PCR2)
+	// Print measurements to stdout in KEY=VALUE format for CI capture
+	fmt.Printf("PCR0=%s\nPCR1=%s\nPCR2=%s\n", measurements.PCR0, measurements.PCR1, measurements.PCR2)
+	return nil
+}

--- a/op-batcher/enclave-tools/enclaver.go
+++ b/op-batcher/enclave-tools/enclaver.go
@@ -1,0 +1,130 @@
+package enclave_tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// ArgDeliveryPort is the vsock port for batcher arg delivery. Must match NC_PORT in enclave-entrypoint.bash.
+	ArgDeliveryPort uint16 = 8337
+	// ReadinessPort is the vsock port for the readiness handshake. Must match READY_PORT in enclave-entrypoint.bash.
+	ReadinessPort uint16 = 8338
+)
+
+type EnclaveMeasurements struct {
+	PCR0 string `json:"PCR0"`
+	PCR1 string `json:"PCR1"`
+	PCR2 string `json:"PCR2"`
+}
+
+type EnclaverManifestSources struct {
+	App string `yaml:"app"`
+}
+
+type EnclaverManifestDefaults struct {
+	CpuCount uint `yaml:"cpu_count"`
+	MemoryMb uint `yaml:"memory_mb"`
+}
+
+type EnclaverManifestEgress struct {
+	Allow     []string `yaml:"allow"`
+	Deny      []string `yaml:"deny"`
+	ProxyPort uint16   `yaml:"proxy_port,omitempty"`
+}
+
+type EnclaverManifestIngress struct {
+	ListenPort uint16 `yaml:"listen_port"`
+}
+
+type EnclaverManifest struct {
+	Version  string                    `yaml:"version"`
+	Name     string                    `yaml:"name"`
+	Target   string                    `yaml:"target"`
+	Sources  *EnclaverManifestSources  `yaml:"sources,omitempty"`
+	Defaults *EnclaverManifestDefaults `yaml:"defaults,omitempty"`
+	Egress   *EnclaverManifestEgress   `yaml:"egress,omitempty"`
+	Ingress  []EnclaverManifestIngress `yaml:"ingress"`
+}
+
+func DefaultManifest(name string, target string, source string, cpuCount uint, memoryMb uint) EnclaverManifest {
+	return EnclaverManifest{
+		Version: "v1",
+		Name:    name,
+		Target:  target,
+		Sources: &EnclaverManifestSources{
+			App: source,
+		},
+		Defaults: &EnclaverManifestDefaults{
+			CpuCount: cpuCount,
+			MemoryMb: memoryMb,
+		},
+		Egress: &EnclaverManifestEgress{
+			ProxyPort: 10000,
+			Allow:     []string{"0.0.0.0/0", "**", "::/0"},
+		},
+		Ingress: []EnclaverManifestIngress{
+			{ListenPort: ArgDeliveryPort}, // batcher arg delivery
+			{ListenPort: ReadinessPort},   // readiness handshake
+		},
+	}
+}
+
+// BuildEifFromImage builds an EIF image by wrapping a pre-built app Docker image with Enclaver.
+func BuildEifFromImage(ctx context.Context, appImage string, eifTag string, cpuCount uint, memoryMb uint) (EnclaveMeasurements, error) {
+	return buildEnclave(ctx, DefaultManifest("op-batcher", eifTag, appImage, cpuCount, memoryMb))
+}
+
+type enclaverBuildOutput struct {
+	Measurements EnclaveMeasurements `json:"Measurements"`
+}
+
+// buildEnclave builds an enclaver EIF image using the provided manifest. If build is successful,
+// it returns the image's Measurements.
+func buildEnclave(ctx context.Context, manifest EnclaverManifest) (EnclaveMeasurements, error) {
+	tempfile, err := os.CreateTemp("", "enclaver-manifest")
+	if err != nil {
+		return EnclaveMeasurements{}, err
+	}
+	defer os.Remove(tempfile.Name())
+
+	if err := yaml.NewEncoder(tempfile).Encode(manifest); err != nil {
+		return EnclaveMeasurements{}, err
+	}
+
+	var stdout bytes.Buffer
+	cmd := exec.CommandContext(
+		ctx,
+		"enclaver",
+		"build",
+		"--file",
+		tempfile.Name(),
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return EnclaveMeasurements{}, err
+	}
+
+	// Find measurements in the output
+	re := regexp.MustCompile(`\{[\s\S]*"Measurements"[\s\S]*\}`)
+	jsonMatch := re.Find(stdout.Bytes())
+	if jsonMatch == nil {
+		return EnclaveMeasurements{}, fmt.Errorf("could not find measurements JSON in output")
+	}
+
+	var output enclaverBuildOutput
+	if err := json.Unmarshal(jsonMatch, &output); err != nil {
+		return EnclaveMeasurements{}, fmt.Errorf("failed to parse measurements JSON: %w", err)
+	}
+
+	return output.Measurements, nil
+}

--- a/op-batcher/justfile
+++ b/op-batcher/justfile
@@ -8,13 +8,17 @@ _LDFLAGSSTRING := "'" + trim(
     "") + "'"
 
 BINARY := "./bin/op-batcher"
+ENCLAVE_TOOLS_BINARY := "./bin/enclave-tools"
 
 # Build op-batcher binary
 op-batcher: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
 
+# Build enclave-tools binary: builds, registers and runs the op-batcher Nitro enclave EIF
+enclave-tools: (go_build ENCLAVE_TOOLS_BINARY "./enclave-tools/cmd")
+
 # Clean build artifacts
 clean:
-    rm -f {{BINARY}}
+    rm -f {{BINARY}} {{ENCLAVE_TOOLS_BINARY}}
 
 # Run tests
 test: (go_test "./...")

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -12,6 +12,9 @@ ARG TARGET_BASE_IMAGE=alpine:3.20
 # The ubuntu target base image is used for the op-challenger build with kona.
 ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:24.04
 
+# Base for the Espresso Nitro enclave targets.
+ARG ENCLAVE_BASE_IMAGE=alpine:3.22
+
 # builder_foundry does not need to be built on $BUILDPLATFORM, as foundry produces static binaries.
 FROM alpine:3.21 AS builder_foundry
 
@@ -141,6 +144,10 @@ FROM --platform=$BUILDPLATFORM builder AS op-batcher-builder
 ARG OP_BATCHER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   cd op-batcher && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_BATCHER_VERSION" just op-batcher
+
+FROM --platform=$BUILDPLATFORM builder AS enclave-tools-builder
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+  cd op-batcher && GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE just enclave-tools
 
 FROM --platform=$BUILDPLATFORM builder AS op-proposer-builder
 ARG OP_PROPOSER_VERSION=v0.0.0
@@ -300,6 +307,23 @@ CMD ["op-dispute-mon"]
 FROM $TARGET_BASE_IMAGE AS op-batcher-target
 COPY --from=op-batcher-builder /app/op-batcher/bin/op-batcher /usr/local/bin/
 CMD ["op-batcher"]
+
+# Runs inside the AWS Nitro enclave.
+FROM $ENCLAVE_BASE_IMAGE AS op-batcher-enclave-app
+RUN apk add --no-cache libgcc bash socat trurl
+COPY --from=op-batcher-builder /app/op-batcher/bin/op-batcher /usr/local/bin/
+COPY op-batcher/enclave-entrypoint.bash /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+# Runs outside the enclave (published as op-batcher-tee).
+FROM $ENCLAVE_BASE_IMAGE AS op-batcher-enclave-target
+ARG ENCLAVER_VERSION=v0.6.1
+RUN apk add --no-cache libgcc docker curl
+RUN curl -L "https://github.com/enclaver-io/enclaver/releases/download/${ENCLAVER_VERSION}/enclaver-linux-x86_64-${ENCLAVER_VERSION}.tar.gz" \
+  | tar xz --strip-components=1 -C /usr/local/bin "enclaver-linux-x86_64-${ENCLAVER_VERSION}/enclaver"
+COPY --from=enclave-tools-builder /app/op-batcher/bin/enclave-tools /usr/local/bin/
+CMD ["enclave-tools"]
 
 FROM $TARGET_BASE_IMAGE AS op-proposer-target
 COPY --from=op-proposer-builder /app/op-proposer/bin/op-proposer /usr/local/bin/


### PR DESCRIPTION
Based on https://github.com/celo-org/optimism/pull/459.

* Adds `op-batcher-enclave-app` and `op-batcher-enclave-target`as targets in `ops/docker/op-stack-go/Dockerfile`.
* Adds `op-batcher/enclave-tools` and a `just enclave-tools` recipe.
* Builds and publishes both images to `ghcr.io/celo-org/optimism` on pushes and PRs to `espresso/**`.
* Drops `--espresso.batch-authenticator-addr` and `--espresso.rollup-l1-url` from the ported scripts.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217064592136259